### PR TITLE
Add tests for Zipfile

### DIFF
--- a/tests/unit/BloggerApiTest.php
+++ b/tests/unit/BloggerApiTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/bloggerapi.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpctag.php';
+
+class BloggerApiTest extends TestCase
+{
+    public function testConstructorSetsTagMap(): void
+    {
+        $params = [];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+
+        $api = new BloggerApi($params, $response, $module);
+
+        $this->assertSame('postid', $api->_getXoopsTagMap('storyid'));
+        $this->assertSame('dateCreated', $api->_getXoopsTagMap('published'));
+        $this->assertSame('userid', $api->_getXoopsTagMap('uid'));
+    }
+
+    public function testNewPostAddsAuthFaultWhenUserInvalid(): void
+    {
+        $params = [null, 'blog', 'user', 'badpass'];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new BloggerApiDouble($params, $response, $module);
+        $api->checkUserResult = false;
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $response->_tags[0]);
+        $this->assertSame(104, $response->_tags[0]->_code);
+    }
+
+    public function testNewPostReportsMissingRequiredFields(): void
+    {
+        $params = [null, 'blog', 'user', 'pass', '<title></title>'];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new BloggerApiDouble($params, $response, $module);
+        $api->postFields = ['title' => ['required' => true]];
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(109, $fault->_code);
+        $this->assertStringContainsString('<title>', $fault->_extra);
+    }
+
+    public function testNewPostForwardsToXoopsApiWithMappedParams(): void
+    {
+        $params = [
+            'app',
+            'blog123',
+            'writer',
+            'secret',
+            '<title>Hello</title><hometext>Body</hometext>',
+            true,
+        ];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new BloggerApiDouble($params, $response, $module);
+        $api->postFields = [
+            'title' => ['required' => true],
+            'hometext' => ['required' => false],
+        ];
+        $api->xoopsApi = new BloggerApiXoopsApiStub($params, $response, $module);
+        $api->user = new stdClass();
+        $api->isadmin = true;
+
+        $api->newPost();
+
+        $expectedParams = [
+            'blog123',
+            'writer',
+            'secret',
+            [
+                'title' => 'Hello',
+                'hometext' => 'Body',
+                'xoops_text' => '<title>Hello</title><hometext>Body</hometext>',
+            ],
+            true,
+        ];
+        $this->assertSame($expectedParams, $api->capturedParams);
+        $this->assertSame([$api->user, true], $api->xoopsApi->userSet);
+        $this->assertTrue($api->xoopsApi->newPostCalled);
+    }
+
+    private function createDummyModule(): object
+    {
+        return new class {
+            public function getVar($name)
+            {
+                return $name;
+            }
+        };
+    }
+}
+
+class BloggerApiDouble extends BloggerApi
+{
+    public $postFields = [];
+    public $xoopsApi;
+    public $capturedParams;
+    public $checkUserResult = true;
+
+    public function _checkUser($username, $password)
+    {
+        return $this->checkUserResult;
+    }
+
+    public function &_getPostFields($post_id = null, $blog_id = null)
+    {
+        return $this->postFields;
+    }
+
+    public function _getXoopsApi(&$params)
+    {
+        $this->capturedParams = $params;
+
+        return $this->xoopsApi;
+    }
+}
+
+class BloggerApiXoopsApiStub extends XoopsXmlRpcApi
+{
+    public $userSet;
+    public $newPostCalled = false;
+
+    public function __construct(&$params, &$response, &$module)
+    {
+        parent::__construct($params, $response, $module);
+    }
+
+    public function _setUser(&$user, $isadmin = false)
+    {
+        $this->userSet = [$user, $isadmin];
+    }
+
+    public function newPost(): void
+    {
+        $this->newPostCalled = true;
+    }
+}

--- a/tests/unit/FormTextAreaTest.php
+++ b/tests/unit/FormTextAreaTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopseditor/textarea/textarea.php';
+
+class FormTextAreaTest extends TestCase
+{
+    public function testInheritsXoopsEditorAndAppliesConfig(): void
+    {
+        $editor = new FormTextArea('Caption', 'name', 'value', 8, 12, ['extra' => 'setting']);
+
+        $this->assertInstanceOf(XoopsEditor::class, $editor);
+        $this->assertSame(8, $editor->_rows);
+        $this->assertSame(12, $editor->_cols);
+        $this->assertTrue($editor->isEnabled);
+        $this->assertSame('setting', $editor->configs['extra']);
+    }
+}

--- a/tests/unit/KernelAndClassLoadingTest.php
+++ b/tests/unit/KernelAndClassLoadingTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+/**
+ * Ensure all kernel and class PHP files declare loadable classes, interfaces, or traits.
+ */
+class KernelAndClassLoadingTest extends TestCase
+{
+    /**
+     * @dataProvider classFileProvider
+     */
+    public function testClassFilesLoadAndDeclareSymbols(string $file, array $declarations): void
+    {
+        require_once $file;
+
+        $allSymbols = array_merge($declarations['classes'], $declarations['interfaces'], $declarations['traits']);
+        $this->assertNotEmpty(
+            $allSymbols,
+            sprintf('File %s should declare at least one class, interface, or trait', $file)
+        );
+    }
+
+    /**
+     * @dataProvider declaredSymbolProvider
+     */
+    public function testDeclaredSymbolIsLoadable(string $file, string $symbolType, string $symbolName): void
+    {
+        require_once $file;
+
+        if ($symbolType === 'class') {
+            $this->assertTrue(
+                class_exists($symbolName, false),
+                sprintf('Expected class %s to be defined after including %s', $symbolName, $file)
+            );
+        } elseif ($symbolType === 'interface') {
+            $this->assertTrue(
+                interface_exists($symbolName, false),
+                sprintf('Expected interface %s to be defined after including %s', $symbolName, $file)
+            );
+        } else {
+            $this->assertTrue(
+                trait_exists($symbolName, false),
+                sprintf('Expected trait %s to be defined after including %s', $symbolName, $file)
+            );
+        }
+    }
+
+    public static function classFileProvider(): array
+    {
+        $files = self::listPhpFiles([
+            XOOPS_ROOT_PATH . '/kernel',
+            XOOPS_ROOT_PATH . '/class',
+        ]);
+
+        $cases = [];
+        foreach ($files as $file) {
+            $declarations = self::collectDeclarations($file);
+            if (!empty($declarations['classes']) || !empty($declarations['interfaces']) || !empty($declarations['traits'])) {
+                $cases[] = [$file, $declarations];
+            }
+        }
+
+        return $cases;
+    }
+
+    public static function declaredSymbolProvider(): array
+    {
+        $files = self::listPhpFiles([
+            XOOPS_ROOT_PATH . '/kernel',
+            XOOPS_ROOT_PATH . '/class',
+        ]);
+
+        $cases = [];
+        foreach ($files as $file) {
+            $declarations = self::collectDeclarations($file);
+            foreach ($declarations['classes'] as $className) {
+                $cases[] = [$file, 'class', $className];
+            }
+            foreach ($declarations['interfaces'] as $interfaceName) {
+                $cases[] = [$file, 'interface', $interfaceName];
+            }
+            foreach ($declarations['traits'] as $traitName) {
+                $cases[] = [$file, 'trait', $traitName];
+            }
+        }
+
+        return $cases;
+    }
+
+    private static function listPhpFiles(array $directories): array
+    {
+        $files = [];
+        foreach ($directories as $directory) {
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $fileInfo) {
+                if ($fileInfo->isFile() && strtolower($fileInfo->getExtension()) === 'php') {
+                    $files[] = $fileInfo->getRealPath();
+                }
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return array{classes: array<int, string>, interfaces: array<int, string>, traits: array<int, string>}
+     */
+    private static function collectDeclarations(string $file): array
+    {
+        $contents = file_get_contents($file);
+        if ($contents === false) {
+            return ['classes' => [], 'interfaces' => [], 'traits' => []];
+        }
+
+        $tokens = token_get_all($contents);
+        $namespace = '';
+        $classes = [];
+        $interfaces = [];
+        $traits = [];
+
+        $tokenCount = count($tokens);
+        for ($index = 0; $index < $tokenCount; ++$index) {
+            $token = $tokens[$index];
+            if (is_array($token) && $token[0] === T_NAMESPACE) {
+                $namespace = self::parseNamespace($tokens, $index);
+                continue;
+            }
+
+            if (!is_array($token)) {
+                continue;
+            }
+
+            [$id, $text] = $token;
+            if (in_array($id, [T_CLASS, T_INTERFACE, T_TRAIT], true) === false) {
+                continue;
+            }
+
+            // Skip anonymous classes.
+            $previous = self::previousSignificantToken($tokens, $index);
+            if ($previous !== null && is_array($previous) && $previous[0] === T_NEW) {
+                continue;
+            }
+
+            $nameToken = self::nextSignificantToken($tokens, $index);
+            if (!is_array($nameToken)) {
+                continue;
+            }
+
+            [$nameId, $name] = $nameToken;
+            if ($nameId !== T_STRING) {
+                continue;
+            }
+
+            $fqn = $namespace !== '' ? $namespace . '\\' . $name : $name;
+
+            if ($id === T_CLASS) {
+                $classes[] = $fqn;
+            } elseif ($id === T_INTERFACE) {
+                $interfaces[] = $fqn;
+            } elseif ($id === T_TRAIT) {
+                $traits[] = $fqn;
+            }
+        }
+
+        return ['classes' => $classes, 'interfaces' => $interfaces, 'traits' => $traits];
+    }
+
+    private static function parseNamespace(array $tokens, int $index): string
+    {
+        $namespace = '';
+        $tokenCount = count($tokens);
+        for ($i = $index + 1; $i < $tokenCount; ++$i) {
+            $token = $tokens[$i];
+            if ($token === '{' || $token === ';') {
+                break;
+            }
+
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if (in_array($token[0], [T_STRING, T_NS_SEPARATOR], true)) {
+                $namespace .= $token[1];
+            }
+        }
+
+        return trim($namespace, '\\');
+    }
+
+    private static function previousSignificantToken(array $tokens, int $index)
+    {
+        for ($i = $index - 1; $i >= 0; --$i) {
+            if (!is_array($tokens[$i])) {
+                continue;
+            }
+
+            if (in_array($tokens[$i][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $tokens[$i];
+        }
+
+        return null;
+    }
+
+    private static function nextSignificantToken(array $tokens, int $index)
+    {
+        $count = count($tokens);
+        for ($i = $index + 1; $i < $count; ++$i) {
+            if (!is_array($tokens[$i])) {
+                continue;
+            }
+
+            if (in_array($tokens[$i][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $tokens[$i];
+        }
+
+        return null;
+    }
+}

--- a/tests/unit/MetaWeblogApiTest.php
+++ b/tests/unit/MetaWeblogApiTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/metaweblogapi.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpctag.php';
+
+class MetaWeblogApiTest extends TestCase
+{
+    public function testConstructorSetsTagMap(): void
+    {
+        $params = [];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+
+        $api = new MetaWeblogApi($params, $response, $module);
+
+        $this->assertSame('postid', $api->_getXoopsTagMap('storyid'));
+        $this->assertSame('dateCreated', $api->_getXoopsTagMap('published'));
+        $this->assertSame('userid', $api->_getXoopsTagMap('uid'));
+    }
+
+    public function testNewPostAddsAuthFaultWhenUserInvalid(): void
+    {
+        $params = ['blog', 'user', 'badpass', []];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new MetaWeblogApiDouble($params, $response, $module);
+        $api->checkUserResult = false;
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(104, $fault->_code);
+    }
+
+    public function testNewPostReportsMissingRequiredFields(): void
+    {
+        $params = ['blog', 'user', 'pass', ['description' => '<title></title>']];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new MetaWeblogApiDouble($params, $response, $module);
+        $api->postFields = ['title' => ['required' => true]];
+        $api->tagValues['title'] = '';
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(109, $fault->_code);
+        $this->assertStringContainsString('<title>', $fault->_extra);
+    }
+
+    public function testNewPostForwardsToXoopsApiWithMappedParams(): void
+    {
+        $params = [
+            'blog123',
+            'writer',
+            'secret',
+            ['description' => '<title>Hello</title><hometext>Body</hometext>'],
+            true,
+        ];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new MetaWeblogApiDouble($params, $response, $module);
+        $api->postFields = [
+            'title' => ['required' => true],
+            'hometext' => ['required' => false],
+        ];
+        $api->tagValues = [
+            'title' => 'Hello',
+            'hometext' => 'Body',
+        ];
+        $api->xoopsApi = new MetaWeblogApiXoopsApiStub($params, $response, $module);
+        $api->user = new stdClass();
+        $api->isadmin = true;
+
+        $api->newPost();
+
+        $expectedParams = [
+            'blog123',
+            'writer',
+            'secret',
+            [
+                'title' => 'Hello',
+                'hometext' => 'Body',
+                'xoops_text' => '<title>Hello</title><hometext>Body</hometext>',
+            ],
+            true,
+        ];
+        $this->assertSame($expectedParams, $api->capturedParams);
+        $this->assertSame([$api->user, true], $api->xoopsApi->userSet);
+        $this->assertTrue($api->xoopsApi->newPostCalled);
+    }
+
+    private function createDummyModule(): object
+    {
+        return new class {
+            public function getVar($name)
+            {
+                return $name;
+            }
+        };
+    }
+}
+
+class MetaWeblogApiDouble extends MetaWeblogApi
+{
+    public $postFields = [];
+    public $tagValues = [];
+    public $xoopsApi;
+    public $capturedParams;
+    public $checkUserResult = true;
+
+    public function _checkUser($username, $password)
+    {
+        return $this->checkUserResult;
+    }
+
+    public function &_getPostFields($post_id = null, $blog_id = null)
+    {
+        return $this->postFields;
+    }
+
+    public function _getTagCdata(&$text, $tag, $remove = true)
+    {
+        return $this->tagValues[$tag] ?? '';
+    }
+
+    public function _getXoopsApi(&$params)
+    {
+        $this->capturedParams = $params;
+
+        return $this->xoopsApi;
+    }
+}
+
+class MetaWeblogApiXoopsApiStub extends XoopsXmlRpcApi
+{
+    public $userSet;
+    public $newPostCalled = false;
+
+    public function __construct(&$params, &$response, &$module)
+    {
+        parent::__construct($params, $response, $module);
+    }
+
+    public function _setUser(&$user, $isadmin = false)
+    {
+        $this->userSet = [$user, $isadmin];
+    }
+
+    public function newPost(): void
+    {
+        $this->newPostCalled = true;
+    }
+}

--- a/tests/unit/MovableTypeApiTest.php
+++ b/tests/unit/MovableTypeApiTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/movabletypeapi.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpctag.php';
+
+class MovableTypeApiTest extends TestCase
+{
+    public function testGetCategoryListAddsAuthFaultWhenUserInvalid(): void
+    {
+        $params = ['blog', 'user', 'badpass'];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new MovableTypeApiDouble($params, $response, $module);
+        $api->checkUserResult = false;
+
+        $api->getCategoryList();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(104, $fault->_code);
+    }
+
+    public function testGetCategoryListReturnsCategories(): void
+    {
+        $params = ['blog', 'user', 'pass'];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new MovableTypeApiDouble($params, $response, $module);
+        $api->categories = [
+            1 => ['title' => 'News'],
+            2 => ['title' => 'Tech'],
+        ];
+        $api->user = new stdClass();
+        $api->isadmin = true;
+
+        $api->getCategoryList();
+
+        $this->assertCount(1, $response->_tags);
+        $arrayTag = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcArray::class, $arrayTag);
+        $this->assertCount(2, $arrayTag->_tags);
+        $firstStruct = $arrayTag->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcStruct::class, $firstStruct);
+        $this->assertSame('categoryId', $firstStruct->_tags[0]['name']);
+        $this->assertSame('1', $firstStruct->_tags[0]['value']->_value);
+        $this->assertSame('categoryName', $firstStruct->_tags[1]['name']);
+        $this->assertSame('News', $firstStruct->_tags[1]['value']->_value);
+    }
+
+    public function testUnsupportedMethodsReturnFault(): void
+    {
+        $params = ['blog', 'user', 'pass'];
+        $response = new XoopsXmlRpcResponse();
+        $module = $this->createDummyModule();
+        $api = new MovableTypeApiDouble($params, $response, $module);
+
+        $api->getPostCategories();
+        $api->setPostCategories();
+        $api->supportedMethods();
+
+        $this->assertCount(3, $response->_tags);
+        foreach ($response->_tags as $fault) {
+            $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+            $this->assertSame(107, $fault->_code);
+        }
+    }
+
+    private function createDummyModule(): object
+    {
+        return new class {
+            public function getVar($name)
+            {
+                return $name;
+            }
+        };
+    }
+}
+
+class MovableTypeApiDouble extends MovableTypeApi
+{
+    public $checkUserResult = true;
+    public $categories = [];
+    public $user;
+    public $isadmin = false;
+    public $xoopsApi;
+
+    public function _checkUser($username, $password)
+    {
+        return $this->checkUserResult;
+    }
+
+    public function _getXoopsApi(&$params)
+    {
+        $this->xoopsApi = new MovableTypeApiXoopsStub($params, $this->response, $this->module, $this->categories);
+
+        return $this->xoopsApi;
+    }
+}
+
+class MovableTypeApiXoopsStub extends XoopsXmlRpcApi
+{
+    public $categories;
+
+    public function __construct(&$params, &$response, &$module, array $categories)
+    {
+        parent::__construct($params, $response, $module);
+        $this->categories = $categories;
+    }
+
+    public function _setUser(&$user, $isadmin = false)
+    {
+        $this->user = $user;
+        $this->isadmin = $isadmin;
+    }
+
+    public function &getCategories($asstruct = false)
+    {
+        return $this->categories;
+    }
+}

--- a/tests/unit/MytsExtensionsTest.php
+++ b/tests/unit/MytsExtensionsTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/module.textsanitizer.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xoopsload.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/iframe/iframe.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/image/image.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/li/li.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/mms/mms.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/mp3/mp3.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/rtsp/rtsp.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/soundcloud/soundcloud.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/syntaxhighlight/syntaxhighlight.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/ul/ul.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/wiki/wiki.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/textsanitizer/wmp/wmp.php';
+
+class MytsExtensionsTest extends TestCase
+{
+    private MyTextSanitizer $myts;
+
+    protected function setUp(): void
+    {
+        $this->myts                 = MyTextSanitizer::getInstance();
+        $this->myts->patterns       = [];
+        $this->myts->replacements   = [];
+        $this->myts->callbackPatterns = [];
+        $this->myts->callbacks        = [];
+        $this->myts->config         = [];
+        $GLOBALS['xoopsConfig']     = ['language' => 'english'];
+        $GLOBALS['xoops']           = new class {
+            public function path($path)
+            {
+                return XOOPS_ROOT_PATH . '/' . ltrim($path, '/');
+            }
+        };
+    }
+
+    public function testIframeLoadAddsPattern(): void
+    {
+        $extension = new MytsIframe($this->myts);
+        $this->assertTrue($extension->load($this->myts));
+
+        $this->assertCount(1, $this->myts->patterns);
+        $this->assertCount(1, $this->myts->replacements);
+        $this->assertStringContainsString('[iframe', $this->myts->patterns[0]);
+        $this->assertStringContainsString('<iframe', $this->myts->replacements[0]);
+    }
+
+    public function testImageLoadWithImagesDisallowed(): void
+    {
+        $this->myts->config = ['allowimage' => false];
+        $extension          = new MytsImage($this->myts);
+
+        $this->assertTrue($extension->load($this->myts));
+        $this->assertCount(6, $this->myts->patterns);
+        $this->assertCount(6, $this->myts->replacements);
+        $this->assertStringContainsString('image.php?id=\\2', $this->myts->replacements[5]);
+    }
+
+    public function testLiAndUlLoadCreateListMarkup(): void
+    {
+        $li  = new MytsLi($this->myts);
+        $ul  = new MytsUl($this->myts);
+
+        $this->assertTrue($li->load($this->myts));
+        $this->assertTrue($ul->load($this->myts));
+
+        $this->assertContains('<li>\\1</li>', $this->myts->replacements);
+        $this->assertContains('<ul>\\1</ul>', $this->myts->replacements);
+    }
+
+    public function testMmsEncodeAndLoad(): void
+    {
+        $extension = new MytsMms($this->myts);
+        [$button, $javascript] = $extension->encode('area');
+
+        $this->assertStringContainsString('xoopsCodeMms', $button);
+        $this->assertStringContainsString('xoopsCodeMms', $javascript);
+
+        $this->assertTrue($extension->load($this->myts));
+        $this->assertNotEmpty($this->myts->patterns);
+        $this->assertStringContainsString('videowindow1', $this->myts->replacements[0]);
+    }
+
+    public function testMp3EncodingLoadingAndDecoding(): void
+    {
+        $extension = new MytsMp3($this->myts);
+        [$button, $javascript] = $extension->encode('mp3area');
+        $this->assertStringContainsString('xoopsCodeMp3', $button);
+        $this->assertStringContainsString('xoopsCodeMp3', $javascript);
+
+        $this->assertTrue($extension->load($this->myts));
+        $this->assertSame('/\[mp3\](.*?)\[\/mp3\]/s', $this->myts->callbackPatterns[0]);
+        $this->assertSame(MytsMp3::class . '::decode', $this->myts->callbacks[0]);
+
+        $html = MytsMp3::decode(['', 'http://example.com/song.mp3']);
+        $this->assertStringContainsString('audio', $html);
+        $this->assertStringContainsString('example.com/song.mp3', $html);
+    }
+
+    public function testRtspEncodeAndLoad(): void
+    {
+        $extension = new MytsRtsp($this->myts);
+        [$button, $javascript] = $extension->encode('rtsparea');
+        $this->assertStringContainsString('xoopsCodeRtsp', $button);
+        $this->assertStringContainsString('xoopsCodeRtsp', $javascript);
+
+        $extension->load($this->myts);
+        $this->assertNotEmpty($this->myts->patterns);
+        $this->assertStringContainsString('rtsp', $this->myts->patterns[0]);
+        $this->assertStringContainsString('clsid:CFCDAA03', $this->myts->replacements[0]);
+    }
+
+    public function testSoundcloudLoadAndCallback(): void
+    {
+        $extension = new MytsSoundcloud($this->myts);
+        $this->assertEmpty($this->myts->callbackPatterns);
+        $extension->load($this->myts);
+
+        $this->assertSame('/\[soundcloud\](http[s]?:\/\/[^\"\'<>]*)(.*)\[\/soundcloud\]/sU', $this->myts->callbackPatterns[0]);
+        $embed = MytsSoundcloud::myCallback([null, 'https://soundcloud.com/user/track', '']);
+        $this->assertStringContainsString('player.soundcloud.com', $embed);
+
+        $this->expectWarning();
+        $this->assertSame('', MytsSoundcloud::myCallback([null, 'https://example.com', '']));
+    }
+
+    public function testSyntaxHighlightReturnsPreWhenDisabled(): void
+    {
+        $extension   = new MytsSyntaxhighlight($this->myts);
+        $configFile  = $this->myts->path_config . '/config.syntaxhighlight.php';
+        $original    = file_exists($configFile) ? file_get_contents($configFile) : null;
+        file_put_contents($configFile, "<?php\nreturn ['highlight' => ''];\n");
+
+        $output = $extension->load($this->myts, 'echo 1;', 'php');
+        $this->assertSame('<pre>echo 1;</pre>', $output);
+
+        if (null !== $original) {
+            file_put_contents($configFile, $original);
+        }
+    }
+
+    public function testUlLoad(): void
+    {
+        $extension = new MytsUl($this->myts);
+        $this->assertTrue($extension->load($this->myts));
+        $this->assertSame('<ul>\\1</ul>', end($this->myts->replacements));
+    }
+
+    public function testWikiCallbacks(): void
+    {
+        $extension = new MytsWiki($this->myts);
+        $extension->load($this->myts);
+
+        $this->assertSame('/\[\[([^\]]*)\]\]/sU', $this->myts->callbackPatterns[0]);
+        $link = MytsWiki::decode('ExampleTerm', 0, 0);
+        $this->assertStringContainsString('ExampleTerm', $link);
+        $this->assertStringContainsString('mediawiki', $link);
+    }
+
+    public function testWmpEncodeAndLoad(): void
+    {
+        $extension = new MytsWmp($this->myts);
+        [$button, $javascript] = $extension->encode('wmparea');
+        $this->assertStringContainsString('xoopsCodeWmp', $button);
+        $this->assertStringContainsString('xoopsCodeWmp', $javascript);
+
+        $extension->load($this->myts);
+        $this->assertNotEmpty($this->myts->patterns);
+        $this->assertStringContainsString('WindowsMediaPlayer', $this->myts->replacements[0]);
+    }
+}

--- a/tests/unit/RpcHandlersTest.php
+++ b/tests/unit/RpcHandlersTest.php
@@ -1,0 +1,284 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/rpc/xmlrpcparser.php';
+
+class RpcHandlersTest extends TestCase
+{
+    private function getParserStub(): object
+    {
+        return new class {
+            public $methodName;
+            public $tempValue;
+            public $tempName = [];
+            public $tempMember = [];
+            public $tempStruct = [];
+            public $tempArray = [];
+            public $params = [];
+            public $currentTag = '';
+            public $parentTag = '';
+            public $workingLevels = [];
+            public $currentLevel = 0;
+
+            public function getCurrentLevel()
+            {
+                return $this->currentLevel;
+            }
+
+            public function getWorkingLevel()
+            {
+                if (empty($this->workingLevels)) {
+                    return $this->currentLevel;
+                }
+
+                return $this->workingLevels[count($this->workingLevels) - 1];
+            }
+
+            public function setWorkingLevel()
+            {
+                $this->workingLevels[] = $this->getCurrentLevel();
+            }
+
+            public function releaseWorkingLevel()
+            {
+                array_pop($this->workingLevels);
+            }
+
+            public function setMethodName($name)
+            {
+                $this->methodName = $name;
+            }
+
+            public function setTempName($name)
+            {
+                $this->tempName[$this->getWorkingLevel()] = $name;
+            }
+
+            public function getTempName()
+            {
+                return $this->tempName[$this->getWorkingLevel()] ?? null;
+            }
+
+            public function setTempValue($value)
+            {
+                if (is_array($value) && is_array($this->tempValue ?? null)) {
+                    $this->tempValue = array_merge($this->tempValue, $value);
+                } elseif (is_string($value) && isset($this->tempValue) && is_string($this->tempValue)) {
+                    $this->tempValue .= $value;
+                } else {
+                    $this->tempValue = $value;
+                }
+            }
+
+            public function getTempValue()
+            {
+                return $this->tempValue;
+            }
+
+            public function resetTempValue()
+            {
+                unset($this->tempValue);
+            }
+
+            public function setTempMember($name, $value)
+            {
+                $this->tempMember[$this->getWorkingLevel()][$name] = $value;
+            }
+
+            public function getTempMember()
+            {
+                return $this->tempMember[$this->getWorkingLevel()] ?? [];
+            }
+
+            public function resetTempMember()
+            {
+                $this->tempMember[$this->getCurrentLevel()] = [];
+            }
+
+            public function setTempStruct($member)
+            {
+                $key = key($member);
+                $this->tempStruct[$this->getWorkingLevel()][$key] = $member[$key];
+            }
+
+            public function getTempStruct()
+            {
+                return $this->tempStruct[$this->getWorkingLevel()] ?? [];
+            }
+
+            public function resetTempStruct()
+            {
+                $this->tempStruct[$this->getCurrentLevel()] = [];
+            }
+
+            public function setTempArray($value)
+            {
+                $this->tempArray[$this->getWorkingLevel()][] = $value;
+            }
+
+            public function getTempArray()
+            {
+                return $this->tempArray[$this->getWorkingLevel()] ?? [];
+            }
+
+            public function resetTempArray()
+            {
+                $this->tempArray[$this->getCurrentLevel()] = [];
+            }
+
+            public function setParam($value)
+            {
+                $this->params[] = $value;
+            }
+
+            public function getParam()
+            {
+                return $this->params;
+            }
+
+            public function getParentTag()
+            {
+                return $this->parentTag;
+            }
+
+            public function getCurrentTag()
+            {
+                return $this->currentTag;
+            }
+        };
+    }
+
+    public function testBasicValueHandlers(): void
+    {
+        $parser = $this->getParserStub();
+
+        $methodHandler = new RpcMethodNameHandler();
+        $this->assertSame('methodName', $methodHandler->getName());
+        $name = 'system.listMethods';
+        $methodHandler->handleCharacterData($parser, $name);
+        $this->assertSame($name, $parser->methodName);
+
+        $intHandler = new RpcIntHandler();
+        $this->assertSame(['int', 'i4'], $intHandler->getName());
+        $intHandler->handleCharacterData($parser, '42');
+        $this->assertSame(42, $parser->getTempValue());
+
+        $doubleHandler = new RpcDoubleHandler();
+        $this->assertSame('double', $doubleHandler->getName());
+        $value = '3.14';
+        $doubleHandler->handleCharacterData($parser, $value);
+        $this->assertSame(3.14, $parser->getTempValue());
+
+        $booleanHandler = new RpcBooleanHandler();
+        $this->assertSame('boolean', $booleanHandler->getName());
+        $boolValue = '0';
+        $booleanHandler->handleCharacterData($parser, $boolValue);
+        $this->assertFalse($parser->getTempValue());
+
+        $stringHandler = new RpcStringHandler();
+        $this->assertSame('string', $stringHandler->getName());
+        $stringHandler->handleCharacterData($parser, 'hello');
+        $this->assertSame('hello', $parser->getTempValue());
+
+        $dateHandler = new RpcDateTimeHandler();
+        $this->assertSame('dateTime.iso8601', $dateHandler->getName());
+        $dateHandler->handleCharacterData($parser, '20240102T03:04:05');
+        $this->assertSame(gmmktime(3, 4, 5, 1, 2, 2024), $parser->getTempValue());
+
+        $base64Handler = new RpcBase64Handler();
+        $this->assertSame('base64', $base64Handler->getName());
+        $base64Handler->handleCharacterData($parser, base64_encode('payload'));
+        $this->assertSame('payload', $parser->getTempValue());
+    }
+
+    public function testNameAndValueHandlerRoutesByParentTag(): void
+    {
+        $parser            = $this->getParserStub();
+        $parser->parentTag = 'member';
+        $parser->setWorkingLevel();
+
+        $nameHandler = new RpcNameHandler();
+        $this->assertSame('name', $nameHandler->getName());
+        $data = 'memberName';
+        $nameHandler->handleCharacterData($parser, $data);
+        $this->assertSame($data, $parser->getTempName());
+
+        $valueHandler = new RpcValueHandler();
+        $this->assertSame('value', $valueHandler->getName());
+        $memberData = 'memberValue';
+        $valueHandler->handleCharacterData($parser, $memberData);
+        $this->assertSame($memberData, $parser->getTempValue());
+
+        $parser->parentTag = 'data';
+        $valueHandler->handleCharacterData($parser, 'arrayValue');
+        $this->assertSame('memberValuearrayValue', $parser->getTempValue());
+    }
+
+    public function testValueHandlerEndElementBranches(): void
+    {
+        $parser                 = $this->getParserStub();
+        $parser->currentTag     = 'member';
+        $parser->parentTag      = 'member';
+        $parser->currentLevel   = 1;
+        $parser->setWorkingLevel();
+        $parser->setTempName('username');
+        $parser->setTempValue('bob');
+
+        $valueHandler = new RpcValueHandler();
+        $valueHandler->handleEndElement($parser);
+        $this->assertSame(['username' => 'bob'], $parser->getTempMember());
+        $this->assertNull($parser->getTempValue());
+
+        $parser->currentTag = 'array';
+        $parser->setTempValue(['first']);
+        $valueHandler->handleEndElement($parser);
+        $this->assertSame([['first']], $parser->tempArray);
+
+        $parser->currentTag = 'value';
+        $parser->setTempValue('final');
+        $valueHandler->handleEndElement($parser);
+        $this->assertSame(['final'], $parser->getParam());
+    }
+
+    public function testMemberHandlerPreparesWorkingLevels(): void
+    {
+        $parser               = $this->getParserStub();
+        $parser->currentLevel = 2;
+
+        $handler = new RpcMemberHandler();
+        $this->assertSame('member', $handler->getName());
+        $handler->handleBeginElement($parser, $attributes = []);
+
+        $this->assertSame(2, $parser->getWorkingLevel());
+        $this->assertSame([], $parser->getTempMember());
+
+        $parser->setTempMember('id', 99);
+        $handler->handleEndElement($parser);
+        $this->assertSame(['id' => 99], $parser->getTempStruct());
+        $this->assertEmpty($parser->workingLevels);
+    }
+
+    public function testArrayAndStructHandlersManageNestedValues(): void
+    {
+        $parser               = $this->getParserStub();
+        $parser->currentLevel = 3;
+
+        $arrayHandler = new RpcArrayHandler();
+        $this->assertSame('array', $arrayHandler->getName());
+        $arrayHandler->handleBeginElement($parser, $attributes = []);
+        $parser->setTempArray('value1');
+        $arrayHandler->handleEndElement($parser);
+        $this->assertSame(['value1'], $parser->getTempValue());
+        $this->assertSame([], $parser->workingLevels);
+
+        $structHandler = new RpcStructHandler();
+        $this->assertSame('struct', $structHandler->getName());
+        $structHandler->handleBeginElement($parser, $attributes = []);
+        $parser->setTempStruct(['name' => 'xoops']);
+        $structHandler->handleEndElement($parser);
+        $this->assertSame(['name' => 'xoops'], $parser->getTempValue());
+        $this->assertSame([], $parser->workingLevels);
+    }
+}

--- a/tests/unit/RssParserTest.php
+++ b/tests/unit/RssParserTest.php
@@ -1,0 +1,244 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/rss/xmlrss2parser.php';
+
+class RssParserTest extends TestCase
+{
+    private function createParser(): object
+    {
+        return new class('') extends XoopsXmlRss2Parser {
+            private $parentTag = null;
+
+            public function setParentTagOverride(string $tag): void
+            {
+                $this->parentTag = $tag;
+            }
+
+            public function getParentTag()
+            {
+                return $this->parentTag;
+            }
+        };
+    }
+
+    public function testChannelImageAndTempStateHelpers(): void
+    {
+        $parser = $this->createParser();
+        $first  = 'one';
+        $second = 'two';
+
+        $parser->setChannelData('title', $first);
+        $parser->setChannelData('title', $second);
+        $this->assertSame('onetwo', $parser->getChannelData('title'));
+        $this->assertIsArray($parser->getChannelData());
+
+        $parser->setImageData('url', $first);
+        $this->assertSame('one', $parser->getImageData('url'));
+        $this->assertFalse($parser->getImageData('missing'));
+
+        $parser->setTempArr('category', $first);
+        $parser->setTempArr('category', $second, ', ');
+        $this->assertSame(['category' => 'one, two'], $parser->getTempArr());
+
+        $parser->resetTempArr();
+        $this->assertSame([], $parser->getTempArr());
+    }
+
+    public function testItemStorage(): void
+    {
+        $parser = $this->createParser();
+        $item   = ['title' => 'Example'];
+
+        $parser->setItems($item);
+        $items = $parser->getItems();
+        $this->assertCount(1, $items);
+        $this->assertSame($item, $items[0]);
+    }
+
+    /**
+     * @dataProvider handlerNameProvider
+     */
+    public function testHandlerNames(XmlTagHandler $handler, string $expected): void
+    {
+        $this->assertSame($expected, $handler->getName());
+    }
+
+    public function handlerNameProvider(): array
+    {
+        return [
+            [new RssChannelHandler(), 'channel'],
+            [new RssTitleHandler(), 'title'],
+            [new RssLinkHandler(), 'link'],
+            [new RssDescriptionHandler(), 'description'],
+            [new RssGeneratorHandler(), 'generator'],
+            [new RssCopyrightHandler(), 'copyright'],
+            [new RssNameHandler(), 'name'],
+            [new RssManagingEditorHandler(), 'managingEditor'],
+            [new RssLanguageHandler(), 'language'],
+            [new RssWebMasterHandler(), 'webMaster'],
+            [new RssDocsHandler(), 'docs'],
+            [new RssTtlHandler(), 'ttl'],
+            [new RssTextInputHandler(), 'textInput'],
+            [new RssLastBuildDateHandler(), 'lastBuildDate'],
+            [new RssImageHandler(), 'image'],
+            [new RssUrlHandler(), 'url'],
+            [new RssWidthHandler(), 'width'],
+            [new RssHeightHandler(), 'height'],
+            [new RssItemHandler(), 'item'],
+            [new RssCategoryHandler(), 'category'],
+            [new RssCommentsHandler(), 'comments'],
+            [new RssPubDateHandler(), 'pubDate'],
+            [new RssGuidHandler(), 'guid'],
+            [new RssAuthorHandler(), 'author'],
+            [new RssSourceHandler(), 'source'],
+        ];
+    }
+
+    /**
+     * @dataProvider channelCharacterHandlersProvider
+     */
+    public function testChannelCharacterHandlers(XmlTagHandler $handler, string $parentTag, string $key): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride($parentTag);
+        $value = 'value';
+
+        $handler->handleCharacterData($parser, $value);
+        $this->assertSame($value, $parser->getChannelData($key));
+    }
+
+    public function channelCharacterHandlersProvider(): array
+    {
+        return [
+            [new RssTitleHandler(), 'channel', 'title'],
+            [new RssLinkHandler(), 'channel', 'link'],
+            [new RssDescriptionHandler(), 'channel', 'description'],
+            [new RssGeneratorHandler(), 'channel', 'generator'],
+            [new RssCopyrightHandler(), 'channel', 'copyright'],
+            [new RssManagingEditorHandler(), 'channel', 'editor'],
+            [new RssLanguageHandler(), 'channel', 'language'],
+            [new RssWebMasterHandler(), 'channel', 'webmaster'],
+            [new RssDocsHandler(), 'channel', 'docs'],
+            [new RssTtlHandler(), 'channel', 'ttl'],
+            [new RssLastBuildDateHandler(), 'channel', 'lastbuilddate'],
+            [new RssCategoryHandler(), 'channel', 'category'],
+            [new RssPubDateHandler(), 'channel', 'pubdate'],
+            [new RssTextInputHandler(), 'channel', 'textinput'],
+        ];
+    }
+
+    /**
+     * @dataProvider imageCharacterHandlersProvider
+     */
+    public function testImageCharacterHandlers(XmlTagHandler $handler, string $key): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride('image');
+        $value = 'content';
+
+        $handler->handleCharacterData($parser, $value);
+        $this->assertSame($value, $parser->getImageData($key));
+    }
+
+    public function imageCharacterHandlersProvider(): array
+    {
+        return [
+            [new RssTitleHandler(), 'title'],
+            [new RssLinkHandler(), 'link'],
+            [new RssDescriptionHandler(), 'description'],
+            [new RssUrlHandler(), 'url'],
+            [new RssWidthHandler(), 'width'],
+            [new RssHeightHandler(), 'height'],
+        ];
+    }
+
+    /**
+     * @dataProvider itemCharacterHandlersProvider
+     */
+    public function testItemCharacterHandlers(XmlTagHandler $handler, string $key): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride('item');
+        $value = 'payload';
+
+        $handler->handleCharacterData($parser, $value);
+        $this->assertSame($value, $parser->getTempArr()[$key]);
+    }
+
+    public function itemCharacterHandlersProvider(): array
+    {
+        return [
+            [new RssTitleHandler(), 'title'],
+            [new RssLinkHandler(), 'link'],
+            [new RssDescriptionHandler(), 'description'],
+            [new RssCategoryHandler(), 'category'],
+            [new RssCommentsHandler(), 'comments'],
+            [new RssPubDateHandler(), 'pubdate'],
+            [new RssGuidHandler(), 'guid'],
+            [new RssAuthorHandler(), 'author'],
+        ];
+    }
+
+    public function testCategoryHandlerAppendsWithDelimiter(): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride('item');
+        $handler = new RssCategoryHandler();
+
+        $first = 'news';
+        $handler->handleCharacterData($parser, $first);
+        $second = 'tech';
+        $handler->handleCharacterData($parser, $second);
+
+        $this->assertSame('news, tech', $parser->getTempArr()['category']);
+    }
+
+    public function testTextInputHandlerTransfersTempArray(): void
+    {
+        $parser = $this->createParser();
+        $handler = new RssTextInputHandler();
+
+        $parser->setTempArr('title', 'old');
+        $handler->handleBeginElement($parser, $attributes = []);
+        $parser->setTempArr('title', 'new');
+        $handler->handleEndElement($parser);
+
+        $this->assertSame(['title' => 'new'], $parser->getChannelData('textinput'));
+    }
+
+    public function testItemHandlerResetsAndStoresItems(): void
+    {
+        $parser = $this->createParser();
+        $handler = new RssItemHandler();
+
+        $parser->setTempArr('title', 'stale');
+        $handler->handleBeginElement($parser, $attributes = []);
+        $this->assertSame([], $parser->getTempArr());
+
+        $parser->setTempArr('title', 'fresh');
+        $handler->handleEndElement($parser);
+
+        $items = $parser->getItems();
+        $this->assertCount(1, $items);
+        $this->assertSame('fresh', $items[0]['title']);
+    }
+
+    public function testSourceHandlerSetsUrlAndTitle(): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride('item');
+        $handler = new RssSourceHandler();
+
+        $attributes = ['url' => 'https://example.com'];
+        $handler->handleBeginElement($parser, $attributes);
+        $title = 'Example Source';
+        $handler->handleCharacterData($parser, $title);
+
+        $temp = $parser->getTempArr();
+        $this->assertSame($attributes['url'], $temp['source_url']);
+        $this->assertSame($title, $temp['source']);
+    }
+}

--- a/tests/unit/SaxParserTest.php
+++ b/tests/unit/SaxParserTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/saxparser.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/xmltaghandler.php';
+
+class RecordingTagHandler extends XmlTagHandler
+{
+    private $name;
+    public $begins = [];
+    public $ends = 0;
+    public $characters = [];
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function handleBeginElement($parser, &$attributes)
+    {
+        $this->begins[] = $attributes;
+    }
+
+    public function handleEndElement($parser)
+    {
+        $this->ends++;
+    }
+
+    public function handleCharacterData($parser, &$data)
+    {
+        $this->characters[] = $data;
+    }
+}
+
+class SaxParserTest extends TestCase
+{
+    public function testConstructorSetsDefaults(): void
+    {
+        $parser = new SaxParser('<root />');
+
+        $this->assertSame(0, $parser->getCurrentLevel());
+        $this->assertFalse($parser->isCaseFolding);
+        $this->assertSame('UTF-8', $parser->targetEncoding);
+        $this->assertSame('UTF-8', xml_parser_get_option($parser->parser, XML_OPTION_TARGET_ENCODING));
+    }
+
+    public function testCaseFoldingAndEncodingOptions(): void
+    {
+        $parser = new SaxParser('<root />');
+
+        $parser->setCaseFolding(true);
+        $this->assertTrue($parser->isCaseFolding);
+        $this->assertSame(1, xml_parser_get_option($parser->parser, XML_OPTION_CASE_FOLDING));
+
+        $parser->useIsoEncoding();
+        $this->assertSame('ISO-8859-1', $parser->targetEncoding);
+        $this->assertSame('ISO-8859-1', xml_parser_get_option($parser->parser, XML_OPTION_TARGET_ENCODING));
+
+        $parser->useAsciiEncoding();
+        $this->assertSame('US-ASCII', $parser->targetEncoding);
+        $this->assertSame('US-ASCII', xml_parser_get_option($parser->parser, XML_OPTION_TARGET_ENCODING));
+    }
+
+    public function testAddTagHandlerRegistersNames(): void
+    {
+        $arrayHandler = new RecordingTagHandler(['FIRST', 'SECOND']);
+        $singleHandler = new RecordingTagHandler('THIRD');
+        $parser = new SaxParser('<root />');
+
+        $parser->addTagHandler($arrayHandler);
+        $parser->addTagHandler($singleHandler);
+
+        $this->assertSame($arrayHandler, $parser->tagHandlers['FIRST']);
+        $this->assertSame($arrayHandler, $parser->tagHandlers['SECOND']);
+        $this->assertSame($singleHandler, $parser->tagHandlers['THIRD']);
+    }
+
+    public function testTagStackAndHandlerRouting(): void
+    {
+        $handler = new RecordingTagHandler('TAG');
+        $parser = new SaxParser('<root />');
+        $parser->addTagHandler($handler);
+
+        $parser->handleBeginElement($parser->parser, 'PARENT', []);
+        $parser->handleBeginElement($parser->parser, 'TAG', ['id' => '1']);
+
+        $this->assertSame('TAG', $parser->getCurrentTag());
+        $this->assertSame('PARENT', $parser->getParentTag());
+        $this->assertSame(2, $parser->getCurrentLevel());
+
+        $parser->handleCharacterData($parser->parser, 'content');
+        $parser->handleEndElement($parser->parser, 'TAG');
+        $parser->handleEndElement($parser->parser, 'PARENT');
+
+        $this->assertSame([['id' => '1']], $handler->begins);
+        $this->assertSame(['content'], $handler->characters);
+        $this->assertSame(1, $handler->ends);
+        $this->assertSame(0, $parser->getCurrentLevel());
+        $this->assertFalse($parser->getParentTag());
+    }
+
+    public function testParseStringInvokesHandlers(): void
+    {
+        $handler = new RecordingTagHandler('ITEM');
+        $parser = new SaxParser('<root><ITEM attr="1">text</ITEM></root>');
+        $parser->addTagHandler($handler);
+
+        $this->assertTrue($parser->parse());
+        $this->assertSame([['ATTR' => '1']], $handler->begins);
+        $this->assertContains('text', $handler->characters);
+        $this->assertSame(1, $handler->ends);
+    }
+
+    public function testParseResourceStream(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, "<root><target attr='v'>body</target></root>");
+        rewind($stream);
+
+        $handler = new RecordingTagHandler('target');
+        $parser = new SaxParser($stream);
+        $parser->addTagHandler($handler);
+
+        $this->assertTrue($parser->parse());
+        $this->assertSame([['attr' => 'v']], $handler->begins);
+        $this->assertSame(['body'], $handler->characters);
+        $this->assertSame(1, $handler->ends);
+    }
+
+    public function testParseStoresErrorsWhenXmlInvalid(): void
+    {
+        $parser = new SaxParser('<root><broken></root>');
+        $this->assertFalse($parser->parse());
+
+        $rawErrors = $parser->getErrors(false);
+        $this->assertNotEmpty($rawErrors);
+        $this->assertStringContainsString('XmlParse error', $rawErrors[0]);
+
+        $htmlErrors = $parser->getErrors();
+        $this->assertStringContainsString('<br>', $htmlErrors);
+    }
+
+    public function testSetErrorsTrimsMessages(): void
+    {
+        $parser = new SaxParser('<root />');
+        $parser->setErrors('  message  ');
+
+        $this->assertSame(['message'], $parser->getErrors(false));
+    }
+}

--- a/tests/unit/SmartyResourceDbTest.php
+++ b/tests/unit/SmartyResourceDbTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/xoops_lib/vendor/smarty/smarty/libs/sysplugins/smarty_resource_custom.php';
+require_once XOOPS_ROOT_PATH . '/class/smarty3_plugins/resource.db.php';
+require_once XOOPS_ROOT_PATH . '/kernel/tplfile.php';
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return $GLOBALS['smarty_resource_db_handlers'][$name] ?? null;
+    }
+}
+
+class SmartyResourceDbTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['smarty_resource_db_handlers'] = [];
+        $GLOBALS['xoopsConfig'] = [
+            'template_set' => 'default',
+            'theme_set'    => 'default',
+        ];
+    }
+
+    public function testFetchLoadsTemplateFromDatabase(): void
+    {
+        $GLOBALS['xoopsConfig']['template_set'] = 'custom';
+
+        $tpl = $this->createMock(XoopsTplFile::class);
+        $tpl->method('getVar')->willReturnMap([
+            ['tpl_source', 'n', '<tpl>'],
+            ['tpl_lastmodified', 'n', 123],
+        ]);
+
+        $handler = new class ($tpl) {
+            public $calls = [];
+            private $tpl;
+
+            public function __construct($tpl)
+            {
+                $this->tpl = $tpl;
+            }
+
+            public function find($tplset, $tpl_module = null, $tpl_refid = null, $tpl_type = null, $tpl_name = null, $orderby = false)
+            {
+                $this->calls[] = [$tplset, $tpl_name];
+                if ($tplset === 'custom') {
+                    return [$this->tpl];
+                }
+
+                return [];
+            }
+        };
+
+        $GLOBALS['smarty_resource_db_handlers']['tplfile'] = $handler;
+
+        $resource = new Smarty_Resource_Db();
+        $source = null;
+        $mtime = null;
+
+        $resource->fetch('db_template.tpl', $source, $mtime);
+
+        $this->assertSame('<tpl>', $source);
+        $this->assertSame(123, $mtime);
+        $this->assertSame([['custom', 'db_template.tpl']], $handler->calls);
+    }
+
+    public function testFetchReadsTemplateFromFilesystem(): void
+    {
+        $GLOBALS['xoopsConfig']['template_set'] = 'custom';
+
+        $handler = new class () {
+            public $calls = 0;
+
+            public function find($tplset, $tpl_module = null, $tpl_refid = null, $tpl_type = null, $tpl_name = null, $orderby = false)
+            {
+                $this->calls++;
+                return [];
+            }
+        };
+        $GLOBALS['smarty_resource_db_handlers']['tplfile'] = $handler;
+
+        $file = tempnam(sys_get_temp_dir(), 'tpl');
+        file_put_contents($file, 'file contents');
+
+        $resource = new Smarty_Resource_Db();
+        $source = null;
+        $mtime = null;
+
+        $resource->fetch($file, $source, $mtime);
+
+        $this->assertSame('file contents', $source);
+        $this->assertSame(filemtime($file), $mtime);
+        $this->assertSame(2, $handler->calls);
+
+        unlink($file);
+    }
+
+    public function testFetchHandlesMissingFilesystemTemplate(): void
+    {
+        $GLOBALS['xoopsConfig']['template_set'] = 'custom';
+
+        $handler = new class () {
+            public function find($tplset, $tpl_module = null, $tpl_refid = null, $tpl_type = null, $tpl_name = null, $orderby = false)
+            {
+                return [];
+            }
+        };
+        $GLOBALS['smarty_resource_db_handlers']['tplfile'] = $handler;
+
+        $resource = new Smarty_Resource_Db();
+        $source = 'initial';
+        $mtime = 1;
+
+        $resource->fetch('/path/does/not/exist.tpl', $source, $mtime);
+
+        $this->assertNull($source);
+        $this->assertNull($mtime);
+    }
+
+    public function testDbTplInfoCachesLookups(): void
+    {
+        $GLOBALS['xoopsConfig']['template_set'] = 'custom';
+
+        $handler = new class () {
+            public $calls = 0;
+
+            public function find($tplset, $tpl_module = null, $tpl_refid = null, $tpl_type = null, $tpl_name = null, $orderby = false)
+            {
+                $this->calls++;
+                return [];
+            }
+        };
+        $GLOBALS['smarty_resource_db_handlers']['tplfile'] = $handler;
+
+        $resource = new Smarty_Resource_Db();
+        $method = new ReflectionMethod(Smarty_Resource_Db::class, 'dbTplInfo');
+        $method->setAccessible(true);
+
+        $first = $method->invoke($resource, 'cache_test.tpl');
+        $second = $method->invoke($resource, 'cache_test.tpl');
+
+        $this->assertSame('cache_test.tpl', $first);
+        $this->assertSame($first, $second);
+        $this->assertSame(2, $handler->calls);
+    }
+}

--- a/tests/unit/SqlUtilityTest.php
+++ b/tests/unit/SqlUtilityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/database/sqlutility.php';
+
+class SqlUtilityTest extends TestCase
+{
+    public function testSplitMySqlFileSeparatesStatementsAndSkipsComments(): void
+    {
+        $sql = "SELECT 1;\n-- comment to ignore\nINSERT INTO t VALUES('a; b');\n# hash comment\nUPDATE t SET col='value';";
+
+        $statements = [];
+        $result = SqlUtility::splitMySqlFile($statements, $sql);
+
+        $this->assertTrue($result);
+        $this->assertSame([
+            'SELECT 1',
+            "INSERT INTO t VALUES('a; b')",
+            "UPDATE t SET col='value'",
+        ], $statements);
+    }
+
+    public function testSplitMySqlFileReturnsRemainderWhenStringUnterminated(): void
+    {
+        $sql = "INSERT INTO t VALUES('unfinished";
+        $statements = [];
+
+        $result = SqlUtility::splitMySqlFile($statements, $sql);
+
+        $this->assertTrue($result);
+        $this->assertSame([$sql], $statements);
+    }
+
+    public function testPrefixQueryReplacesTableNames(): void
+    {
+        $prefixed = SqlUtility::prefixQuery('INSERT INTO table1 (id) VALUES(1)', 'pre');
+
+        $this->assertIsArray($prefixed);
+        $this->assertSame('INSERT INTO pre_table1 (id) VALUES(1)', $prefixed[0]);
+    }
+
+    public function testPrefixQueryHandlesDropTable(): void
+    {
+        $prefixed = SqlUtility::prefixQuery('DROP TABLE table1', 'myprefix');
+
+        $this->assertIsArray($prefixed);
+        $this->assertSame('DROP TABLE myprefix_table1', $prefixed[0]);
+    }
+
+    public function testPrefixQueryReturnsFalseForUnsupportedStatements(): void
+    {
+        $this->assertFalse(SqlUtility::prefixQuery('SELECT * FROM table1', 'pre'));
+    }
+}

--- a/tests/unit/TarTest.php
+++ b/tests/unit/TarTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/class.tar.php';
+
+class TarTest extends TestCase
+{
+    public function testComputeUnsignedChecksum(): void
+    {
+        $tar = new Tar();
+        $block = str_repeat(' ', 512);
+
+        $this->assertSame(16384, $tar->__computeUnsignedChecksum($block));
+    }
+
+    public function testParseNullPaddedString(): void
+    {
+        $tar = new Tar();
+
+        $this->assertSame('abc', $tar->__parseNullPaddedString("abc\0def"));
+    }
+
+    public function testAddFileContainsAndRemove(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'tar_file_');
+        file_put_contents($file, "hello world");
+
+        $tar = new Tar();
+        $this->assertTrue($tar->addFile($file));
+        $this->assertTrue($tar->containsFile($file));
+        $this->assertSame(1, $tar->numFiles);
+
+        $this->assertTrue($tar->removeFile($file));
+        $this->assertFalse($tar->containsFile($file));
+        $this->assertSame(0, $tar->numFiles);
+
+        unlink($file);
+    }
+
+    public function testAddDirectoryContainsAndRemove(): void
+    {
+        $dir = sys_get_temp_dir() . '/tar_dir_' . uniqid();
+        mkdir($dir);
+
+        $tar = new Tar();
+        $this->assertTrue($tar->addDirectory($dir));
+        $this->assertTrue($tar->containsDirectory($dir));
+        $this->assertSame(1, $tar->numDirectories);
+
+        $this->assertTrue($tar->removeDirectory($dir));
+        $this->assertFalse($tar->containsDirectory($dir));
+        $this->assertSame(0, $tar->numDirectories);
+
+        rmdir($dir);
+    }
+
+    public function testGenerateAndParseTarOutput(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'tar_parse_');
+        file_put_contents($file, "sample content");
+
+        $tar = new Tar();
+        $tar->addFile($file);
+        $output = $tar->toTarOutput('sample.tar', false);
+
+        $this->assertNotFalse($output);
+
+        $reader = new Tar();
+        $reader->tar_file = $output;
+        $this->assertTrue($reader->__parseTar());
+        $this->assertSame(1, $reader->numFiles);
+        $parsed = $reader->getFile($file);
+
+        $this->assertIsArray($parsed);
+        $this->assertSame('sample content', $parsed['file']);
+
+        unlink($file);
+    }
+
+    public function testAppendTarWithGzip(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'tar_gz_');
+        file_put_contents($file, "gzipped content");
+
+        $tar = new Tar();
+        $tar->addFile($file);
+
+        $archive = tempnam(sys_get_temp_dir(), 'tar_archive_');
+        $this->assertTrue($tar->toTar($archive, true));
+
+        $reader = new Tar();
+        $this->assertTrue($reader->appendTar($archive));
+        $this->assertTrue($reader->isGzipped);
+        $this->assertTrue($reader->containsFile($file));
+
+        unlink($file);
+        unlink($archive);
+    }
+
+    public function testSaveTarWritesFileWhenFilenameProvided(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'tar_save_');
+        file_put_contents($file, 'save content');
+
+        $archive = tempnam(sys_get_temp_dir(), 'tar_saved_');
+        $tar = new Tar();
+        $tar->filename = $archive;
+        $tar->addFile($file);
+
+        $this->assertTrue($tar->saveTar());
+        $this->assertFileExists($archive);
+
+        unlink($file);
+        unlink($archive);
+    }
+
+    public function testSaveTarFailsWithoutFilename(): void
+    {
+        $tar = new Tar();
+
+        $this->assertFalse($tar->saveTar());
+    }
+}

--- a/tests/unit/ThemeSetParserHandlersTest.php
+++ b/tests/unit/ThemeSetParserHandlersTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/themesetparser.php';
+
+class ThemeSetParserHandlersTest extends TestCase
+{
+    private function createParser(): object
+    {
+        return new class('') extends XoopsThemeSetParser {
+            private $parentTag = null;
+            private $creditsData = null;
+
+            public function setParentTagOverride(string $tag): void
+            {
+                $this->parentTag = $tag;
+            }
+
+            public function getParentTag()
+            {
+                return $this->parentTag;
+            }
+
+            public function setCreditsData($data): void
+            {
+                $this->creditsData = $data;
+            }
+
+            public function getCreditsData()
+            {
+                return $this->creditsData;
+            }
+        };
+    }
+
+    /**
+     * @dataProvider handlerNameProvider
+     */
+    public function testHandlerNames(XmlTagHandler $handler, string $expected): void
+    {
+        $this->assertSame($expected, $handler->getName());
+    }
+
+    public function handlerNameProvider(): array
+    {
+        return [
+            [new ThemeSetAuthorHandler(), 'author'],
+            [new ThemeSetDateCreatedHandler(), 'dateCreated'],
+            [new ThemeSetDescriptionHandler(), 'description'],
+            [new ThemeSetEmailHandler(), 'email'],
+            [new ThemeSetFileTypeHandler(), 'fileType'],
+            [new ThemeSetGeneratorHandler(), 'generator'],
+            [new ThemeSetImageHandler(), 'image'],
+            [new ThemeSetLinkHandler(), 'link'],
+            [new ThemeSetModuleHandler(), 'module'],
+            [new ThemeSetNameHandler(), 'name'],
+            [new ThemeSetTagHandler(), 'tag'],
+            [new ThemeSetTemplateHandler(), 'template'],
+        ];
+    }
+
+    /**
+     * @dataProvider themeSetFieldProvider
+     */
+    public function testThemeSetLevelCharacterHandlers(XmlTagHandler $handler, string $parent, string $key): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride($parent);
+        $value = 'value';
+
+        $handler->handleCharacterData($parser, $value);
+        $this->assertSame($value, $parser->getThemeSetData($key));
+    }
+
+    public function themeSetFieldProvider(): array
+    {
+        return [
+            [new ThemeSetDateCreatedHandler(), 'themeset', 'date'],
+            [new ThemeSetGeneratorHandler(), 'themeset', 'generator'],
+            [new ThemeSetNameHandler(), 'themeset', 'name'],
+        ];
+    }
+
+    public function testAuthorHandlersResetAndStoreCredits(): void
+    {
+        $parser  = $this->createParser();
+        $handler = new ThemeSetAuthorHandler();
+
+        $parser->setTempArr('name', 'stale');
+        $handler->handleBeginElement($parser, $attributes = []);
+        $this->assertSame([], $parser->getTempArr());
+
+        $parser->setParentTagOverride('author');
+        (new ThemeSetNameHandler())->handleCharacterData($parser, $name = 'John Doe');
+        (new ThemeSetEmailHandler())->handleCharacterData($parser, $email = 'john@example.com');
+        (new ThemeSetLinkHandler())->handleCharacterData($parser, $link = 'https://example.com');
+
+        $handler->handleEndElement($parser);
+
+        $this->assertSame(
+            ['name' => $name, 'email' => $email, 'link' => $link],
+            $parser->getCreditsData()
+        );
+    }
+
+    /**
+     * @dataProvider descriptionHandlerProvider
+     */
+    public function testDescriptionHandlerRoutesToTemp(XmlTagHandler $handler, string $parent): void
+    {
+        $parser = $this->createParser();
+        $parser->setParentTagOverride($parent);
+        $value = 'details';
+
+        $handler->handleCharacterData($parser, $value);
+
+        $this->assertSame(['description' => $value], $parser->getTempArr());
+    }
+
+    public function descriptionHandlerProvider(): array
+    {
+        return [
+            [new ThemeSetDescriptionHandler(), 'template'],
+            [new ThemeSetDescriptionHandler(), 'image'],
+        ];
+    }
+
+    public function testTemplateHandlerResetsAndStoresTemplateData(): void
+    {
+        $parser  = $this->createParser();
+        $handler = new ThemeSetTemplateHandler();
+
+        $parser->setTempArr('name', 'stale');
+        $handler->handleBeginElement($parser, $attributes = ['name' => 'theme.html']);
+        (new ThemeSetModuleHandler())->handleCharacterData($parser, $module = 'system');
+        (new ThemeSetFileTypeHandler())->handleCharacterData($parser, $type = 'module');
+        (new ThemeSetDescriptionHandler())->handleCharacterData($parser, $desc = 'Main template');
+
+        $handler->handleEndElement($parser);
+
+        $templates = $parser->getTemplatesData();
+        $this->assertCount(1, $templates);
+        $this->assertSame(
+            ['name' => 'theme.html', 'module' => $module, 'type' => $type, 'description' => $desc],
+            $templates[0]
+        );
+    }
+
+    public function testImageHandlerResetsAndStoresImageData(): void
+    {
+        $parser  = $this->createParser();
+        $handler = new ThemeSetImageHandler();
+
+        $parser->setTempArr('name', 'old');
+        $handler->handleBeginElement($parser, [0 => 'logo.png']);
+        $parser->setParentTagOverride('image');
+        (new ThemeSetModuleHandler())->handleCharacterData($parser, $module = 'system');
+        (new ThemeSetDescriptionHandler())->handleCharacterData($parser, $desc = 'Logo');
+        (new ThemeSetTagHandler())->handleCharacterData($parser, $tag = 'main');
+
+        $handler->handleEndElement($parser);
+
+        $images = $parser->getImagesData();
+        $this->assertCount(1, $images);
+        $this->assertSame(
+            ['name' => 'logo.png', 'module' => $module, 'description' => $desc, 'tag' => $tag],
+            $images[0]
+        );
+    }
+}

--- a/tests/unit/TinyMCETest.php
+++ b/tests/unit/TinyMCETest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopslists.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce7/TinyMCE.php';
+
+if (!function_exists('xoops_getcss')) {
+    function xoops_getcss($theme = '')
+    {
+        return XOOPS_THEME_URL . '/tinymce.css';
+    }
+}
+
+class TinyMCETest extends TestCase
+{
+    private string $themePath;
+    private string $pluginBase;
+    private string $settingsFile;
+
+    protected function setUp(): void
+    {
+        $this->themePath = sys_get_temp_dir() . '/tinymce_theme';
+        $this->pluginBase = XOOPS_ROOT_PATH . '/tinymce_test/js/tinymce/plugins';
+        $this->settingsFile = sys_get_temp_dir() . '/tinymce_settings.php';
+
+        $this->prepareTheme();
+        $this->preparePlugins();
+        $this->prepareSettings();
+
+        $GLOBALS['xoops'] = new class($this->settingsFile) {
+            private $settingsFile;
+            public function __construct($settingsFile)
+            {
+                $this->settingsFile = $settingsFile;
+            }
+            public function path($path)
+            {
+                return $this->settingsFile;
+            }
+        };
+        $GLOBALS['xoopsConfig'] = ['theme_set' => 'default'];
+
+        TinyMCE::$listOfElementsTinymce = [];
+        TinyMCE::$lastOfElementsTinymce = '';
+    }
+
+    private function prepareTheme(): void
+    {
+        if (!defined('XOOPS_THEME_PATH')) {
+            define('XOOPS_THEME_PATH', $this->themePath);
+        }
+        if (!defined('XOOPS_THEME_URL')) {
+            define('XOOPS_THEME_URL', 'http://example.com/theme');
+        }
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'http://example.com');
+        }
+
+        if (!is_dir($this->themePath)) {
+            mkdir($this->themePath, 0777, true);
+        }
+        file_put_contents($this->themePath . '/tinymce.css', "@import url(sub.css);\nbody{}\n");
+        file_put_contents($this->themePath . '/sub.css', '/* nested */');
+    }
+
+    private function preparePlugins(): void
+    {
+        if (!is_dir($this->pluginBase)) {
+            mkdir($this->pluginBase, 0777, true);
+        }
+        @mkdir($this->pluginBase . '/alpha', 0777, true);
+        @mkdir($this->pluginBase . '/beta', 0777, true);
+    }
+
+    private function prepareSettings(): void
+    {
+        file_put_contents($this->settingsFile, '<?php return ['
+            . "'language' => 'fr',"
+            . "'theme' => 'simple',"
+            . "'mode' => 'textareas',"
+            . "'plugins' => 'alpha,delta',"
+            . "'content_css' => 'existing',"
+            . '];');
+    }
+
+    public function testConstructorTracksElementsAndRootPath(): void
+    {
+        $editor = new TinyMCE(['rootpath' => '/tinymce_test', 'elements' => 'editor1']);
+
+        $this->assertSame('/tinymce_test/js/tinymce', $editor->rootpath);
+        $this->assertSame('editor1', TinyMCE::$lastOfElementsTinymce);
+        $this->assertSame(['editor1'], TinyMCE::$listOfElementsTinymce);
+        $this->assertSame('editor1', $editor->config['elements']);
+    }
+
+    public function testInitMergesConfigAndLoadsPluginsAndCss(): void
+    {
+        $editor = new TinyMCE([
+            'rootpath' => '/tinymce_test',
+            'elements' => 'editor2',
+            'language' => 'es',
+            'theme' => 'dark',
+            'mode' => 'specific_textareas',
+            'plugins' => ['beta', 'gamma'],
+        ]);
+
+        $editor->init();
+
+        $this->assertSame('es', $editor->setting['language']);
+        $this->assertSame('dark', $editor->setting['theme']);
+        $this->assertSame('specific_textareas', $editor->setting['mode']);
+        $this->assertSame('alpha,beta,gamma', $editor->setting['plugins']);
+        $this->assertSame([
+            'http://example.com/theme/tinymce.css',
+            'http://example.com/theme/sub.css',
+        ], $editor->setting['content_css']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRenderOutputsScriptAndRawFunctions(): void
+    {
+        $editor = new TinyMCE([
+            'rootpath' => '/tinymce_test',
+            'elements' => 'editor3',
+        ]);
+
+        $output = $editor->render([
+            'selector' => '#editor3',
+            'debug' => true,
+            'setup' => 'function(editor) { console.log(editor.id); }',
+        ]);
+
+        $this->assertStringContainsString("tinymce.min.js", $output);
+        $this->assertStringContainsString('TinyMCE Rendering', $output);
+        $this->assertStringContainsString('#editor3', $output);
+        $this->assertStringContainsString('function(editor) { console.log(editor.id); }', $output);
+    }
+}

--- a/tests/unit/XmlTagHandlerTest.php
+++ b/tests/unit/XmlTagHandlerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/xmltaghandler.php';
+
+class XmlTagHandlerTest extends TestCase
+{
+    public function testGetNameDefaultsToEmptyString(): void
+    {
+        $handler = new XmlTagHandler();
+
+        $this->assertSame('', $handler->getName());
+    }
+
+    public function testDefaultHandlersAreNoOps(): void
+    {
+        $handler = new XmlTagHandler();
+        $parser  = new stdClass();
+        $attributes = ['foo' => 'bar'];
+        $data       = 'content';
+
+        $this->assertNull($handler->handleBeginElement($parser, $attributes));
+        $this->assertSame(['foo' => 'bar'], $attributes, 'Attributes are unchanged');
+
+        $this->assertNull($handler->handleCharacterData($parser, $data));
+        $this->assertSame('content', $data, 'Data is unchanged');
+
+        $this->assertNull($handler->handleEndElement($parser));
+    }
+}

--- a/tests/unit/XoopsApiTest.php
+++ b/tests/unit/XoopsApiTest.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xoopsapi.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpctag.php';
+
+class XoopsApiTest extends TestCase
+{
+    private string $newsStoryFile;
+
+    protected function setUp(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $newsStoryDir = XOOPS_ROOT_PATH . '/modules/news/class';
+        $this->newsStoryFile = $newsStoryDir . '/class.newsstory.php';
+        if (!is_dir($newsStoryDir)) {
+            mkdir($newsStoryDir, 0777, true);
+        }
+        if (!file_exists($this->newsStoryFile)) {
+            file_put_contents($this->newsStoryFile, $this->buildNewsStoryStub());
+        }
+        require_once $this->newsStoryFile;
+        if (method_exists(NewsStory::class, 'reset')) {
+            NewsStory::reset();
+        }
+    }
+
+    public function testNewPostAddsAuthFaultWhenUserInvalid(): void
+    {
+        $params = ['blog', 'baduser', 'badpass', []];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->checkUserResult = false;
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(104, $fault->_code);
+    }
+
+    public function testNewPostRequiresAdminToPublishImmediately(): void
+    {
+        $params = ['blog', 'user', 'pass', ['title' => 'Hello'], 1];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->postFields = ['title' => ['required' => true]];
+        $api->isAdminResult = false;
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(111, $fault->_code);
+    }
+
+    public function testNewPostStoresStoryAndReturnsId(): void
+    {
+        $params = ['blog', 'user', 'pass', ['title' => 'Hello', 'hometext' => 'Body', 'moretext' => 'More'], 1];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->postFields = [
+            'title' => ['required' => true],
+            'hometext' => ['required' => false],
+            'moretext' => ['required' => false],
+        ];
+        $api->tagValues = [];
+        $api->user = new class {
+            public function getVar($name)
+            {
+                return 42;
+            }
+        };
+        $api->isadmin = true;
+        NewsStory::$storeResult = 789;
+
+        $api->newPost();
+
+        $this->assertCount(1, $response->_tags);
+        $result = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcString::class, $result);
+        $this->assertSame('789', $result->_value);
+    }
+
+    public function testEditPostAddsMissingFieldFault(): void
+    {
+        $params = ['id', 'user', 'pass', ['xoops_text' => '<title></title>'], true];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->postFields = ['title' => ['required' => true]];
+        $api->tagValues = ['title' => ''];
+
+        $api->editPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(109, $fault->_code);
+    }
+
+    public function testEditPostRequiresAdmin(): void
+    {
+        $params = ['id', 'user', 'pass', ['title' => 'Updated', 'xoops_text' => '<title>Updated</title>'], true];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->postFields = ['title' => ['required' => true]];
+        $api->tagValues = ['title' => 'Updated'];
+        $api->isAdminResult = false;
+        NewsStory::$storeResult = true;
+
+        $api->editPost();
+
+        $this->assertCount(1, $response->_tags);
+        $fault = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcFault::class, $fault);
+        $this->assertSame(111, $fault->_code);
+    }
+
+    public function testDeletePostRemovesStoryWhenAdmin(): void
+    {
+        $params = ['story', 'user', 'pass'];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->isAdminResult = true;
+        NewsStory::$deleteResult = true;
+
+        $api->deletePost();
+
+        $this->assertCount(1, $response->_tags);
+        $result = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcBoolean::class, $result);
+        $this->assertSame(1, $result->_value);
+    }
+
+    public function testGetPostReturnsStructuredResponse(): void
+    {
+        $params = ['story', 'user', 'pass'];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->isAdminResult = true;
+        $api->user = new stdClass();
+
+        $story = new NewsStory('story');
+        $story->setUid(55);
+        $story->setPublished(1234567890);
+        $story->setTitle('Headline');
+        $story->setHometext('Intro');
+        $story->setBodytext('Details');
+
+        $api->getPost();
+
+        $this->assertCount(1, $response->_tags);
+        $struct = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcStruct::class, $struct);
+        $names = array_column($struct->_tags, 'name');
+        $this->assertContains('postid', $names);
+        $this->assertContains('description', $names);
+    }
+
+    public function testGetRecentPostsBuildsArray(): void
+    {
+        $params = ['blog', 'user', 'pass', 0, 2];
+        $response = new XoopsXmlRpcResponse();
+        $api = new XoopsApiDouble($params, $response, $this->createDummyModule());
+        $api->isAdminResult = true;
+        $api->user = new stdClass();
+        $first = new NewsStory(7);
+        $first->setUid(1);
+        $first->setPublished(10);
+        $first->setTitle('First');
+        $first->setHometext('Intro');
+        $first->setBodytext('Body');
+        $second = new NewsStory(8);
+        $second->setUid(2);
+        $second->setPublished(20);
+        $second->setTitle('Second');
+        $second->setHometext('Intro2');
+        $second->setBodytext('Body2');
+        NewsStory::$allPublished = [$first, $second];
+
+        $api->getRecentPosts();
+
+        $this->assertCount(1, $response->_tags);
+        $arrayTag = $response->_tags[0];
+        $this->assertInstanceOf(XoopsXmlRpcArray::class, $arrayTag);
+        $this->assertCount(2, $arrayTag->_tags);
+    }
+
+    private function createDummyModule(): object
+    {
+        return new class {
+            public function getVar($name)
+            {
+                return $name;
+            }
+        };
+    }
+
+    private function buildNewsStoryStub(): string
+    {
+        return <<<'PHP'
+<?php
+class NewsStory
+{
+    public static $storeResult = 123;
+    public static $deleteResult = true;
+    public static $allPublished = [];
+
+    public $id;
+    public $uid = 0;
+    public $published = 0;
+    public $title = '';
+    public $hometext = '';
+    public $bodytext = '';
+    public $type;
+    public $approved = false;
+    public $topicId = 0;
+    public $hostname = '';
+    public $nohtml = 0;
+    public $nosmiley = 0;
+    public $notifyPub = 0;
+    public $topicalign = '';
+
+    public function __construct($id = null)
+    {
+        $this->id = $id ?? 999;
+    }
+
+    public static function reset(): void
+    {
+        self::$storeResult = 123;
+        self::$deleteResult = true;
+        self::$allPublished = [];
+    }
+
+    public static function getAllPublished($limit = 0, $start = 0, $param = null)
+    {
+        return self::$allPublished;
+    }
+
+    public function setType($type): void
+    {
+        $this->type = $type;
+    }
+
+    public function setApproved($flag): void
+    {
+        $this->approved = (bool) $flag;
+    }
+
+    public function setPublished($time): void
+    {
+        $this->published = $time;
+    }
+
+    public function setTopicId($id): void
+    {
+        $this->topicId = $id;
+    }
+
+    public function setTitle($title): void
+    {
+        $this->title = $title;
+    }
+
+    public function setBodytext($text): void
+    {
+        $this->bodytext = $text;
+    }
+
+    public function setHometext($text): void
+    {
+        $this->hometext = $text;
+    }
+
+    public function setUid($uid): void
+    {
+        $this->uid = $uid;
+    }
+
+    public function setHostname($host): void
+    {
+        $this->hostname = $host;
+    }
+
+    public function setNohtml($flag): void
+    {
+        $this->nohtml = $flag;
+    }
+
+    public function setNosmiley($flag): void
+    {
+        $this->nosmiley = $flag;
+    }
+
+    public function setNotifyPub($flag): void
+    {
+        $this->notifyPub = $flag;
+    }
+
+    public function setTopicalign($align): void
+    {
+        $this->topicalign = $align;
+    }
+
+    public function uid()
+    {
+        return $this->uid;
+    }
+
+    public function published()
+    {
+        return $this->published;
+    }
+
+    public function storyid()
+    {
+        return $this->id;
+    }
+
+    public function storyId()
+    {
+        return $this->id;
+    }
+
+    public function title($format = null)
+    {
+        return $this->title;
+    }
+
+    public function hometext($format = null)
+    {
+        return $this->hometext;
+    }
+
+    public function bodytext($format = null)
+    {
+        return $this->bodytext;
+    }
+
+    public function store()
+    {
+        return self::$storeResult;
+    }
+
+    public function delete()
+    {
+        return self::$deleteResult;
+    }
+}
+PHP;
+    }
+}
+
+class XoopsApiDouble extends XoopsApi
+{
+    public $postFields = [];
+    public $tagValues = [];
+    public $checkUserResult = true;
+    public $isAdminResult = true;
+
+    public function _checkUser($username, $password)
+    {
+        return $this->checkUserResult;
+    }
+
+    public function &_getPostFields($post_id = null, $blog_id = null)
+    {
+        return $this->postFields;
+    }
+
+    public function _getTagCdata(&$text, $tag, $remove = true)
+    {
+        return $this->tagValues[$tag] ?? '';
+    }
+
+    public function _checkAdmin()
+    {
+        return $this->isAdminResult;
+    }
+}

--- a/tests/unit/XoopsAuthTest.php
+++ b/tests/unit/XoopsAuthTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/auth.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/auth_ads.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/authfactory.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/auth_ldap.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/auth_provisionning.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/auth_xoops.php';
+require_once XOOPS_ROOT_PATH . '/kernel/user.php';
+
+if (!defined('XOOPS_CONF_AUTH')) {
+    define('XOOPS_CONF_AUTH', 1);
+}
+if (!defined('XOOPS_CONF')) {
+    define('XOOPS_CONF', 2);
+}
+if (!defined('_NONE')) {
+    define('_NONE', 'none');
+}
+if (!defined('_AUTH_MSG_AUTH_METHOD')) {
+    define('_AUTH_MSG_AUTH_METHOD', 'using %s');
+}
+if (!defined('_US_INCORRECTLOGIN')) {
+    define('_US_INCORRECTLOGIN', 'incorrect');
+}
+if (!defined('_AUTH_LDAP_EXTENSION_NOT_LOAD')) {
+    define('_AUTH_LDAP_EXTENSION_NOT_LOAD', 'ldap missing');
+}
+if (!defined('_AUTH_LDAP_USER_NOT_FOUND')) {
+    define('_AUTH_LDAP_USER_NOT_FOUND', 'user not found %s %s %s');
+}
+if (!defined('_AUTH_LDAP_SERVER_NOT_FOUND')) {
+    define('_AUTH_LDAP_SERVER_NOT_FOUND', 'server not found');
+}
+if (!defined('_AUTH_LDAP_XOOPS_USER_NOTFOUND')) {
+    define('_AUTH_LDAP_XOOPS_USER_NOTFOUND', 'xoops user %s not found');
+}
+if (!defined('_XO_ER_CLASSNOTFOUND')) {
+    define('_XO_ER_CLASSNOTFOUND', 'class not found');
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return $GLOBALS['xoops_auth_handlers'][$name] ?? null;
+    }
+}
+
+if (!function_exists('redirect_header')) {
+    function redirect_header($url, $time = 0, $message = '')
+    {
+        $GLOBALS['redirects'][] = [$url, $time, $message];
+    }
+}
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static function getDatabaseConnection()
+        {
+            return 'dao-connection';
+        }
+    }
+}
+
+if (!isset($GLOBALS['xoops'])) {
+    $GLOBALS['xoops'] = new class {
+        public function path($path)
+        {
+            return XOOPS_ROOT_PATH . '/' . ltrim($path, '/');
+        }
+    };
+}
+
+class XoopsAuthTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['xoopsConfig'] = ['debug_mode' => 1];
+        $GLOBALS['xoops_auth_handlers'] = [];
+        $GLOBALS['redirects'] = [];
+        $GLOBALS['xoopsLogger'] = new class {
+            public array $errors = [];
+
+            public function triggerError($message, $code, $file, $line, $errorType)
+            {
+                $this->errors[] = [$message, $code, $file, $line, $errorType];
+            }
+        };
+    }
+
+    public function testBaseAuthStoresDaoAndErrors(): void
+    {
+        $auth = new XoopsAuth('dao');
+        $auth->auth_method = 'ldap';
+        $auth->setErrors(10, ' failed ');
+
+        $this->assertSame(['10' => 'failed'], $auth->getErrors());
+        $this->assertStringContainsString('failed', $auth->getHtmlErrors());
+        $this->assertStringContainsString('ldap', $auth->getHtmlErrors());
+    }
+
+    public function testHtmlErrorsWhenDebugDisabled(): void
+    {
+        $GLOBALS['xoopsConfig']['debug_mode'] = 0;
+        $auth = new XoopsAuth(null);
+        $auth->setErrors(0, 'ignored');
+
+        $this->assertSame('incorrect', $auth->getHtmlErrors());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAuthFactoryCreatesXoopsAuthInstance(): void
+    {
+        $GLOBALS['xoops_auth_handlers']['config'] = new class {
+            public function getConfigsByCat($cat)
+            {
+                return [
+                    'auth_method'       => 'xoops',
+                    'ldap_users_bypass' => [],
+                ];
+            }
+        };
+
+        $auth = XoopsAuthFactory::getAuthConnection('user');
+
+        $this->assertInstanceOf(XoopsAuthXoops::class, $auth);
+        $this->assertSame('dao-connection', $auth->_dao);
+        $this->assertSame($auth, XoopsAuthFactory::getAuthConnection('other'));
+    }
+
+    public function testAuthXoopsAuthenticateSetsErrorsOnFailure(): void
+    {
+        $member = $this->createMock(stdClass::class);
+        $member->method('loginUser')->willReturn(false);
+        $GLOBALS['xoops_auth_handlers']['member'] = $member;
+
+        $auth = new XoopsAuthXoops(null);
+        $result = $auth->authenticate('u', 'p');
+
+        $this->assertFalse($result);
+        $this->assertSame([1 => 'incorrect'], $auth->getErrors());
+    }
+
+    public function testAuthXoopsAuthenticateReturnsUser(): void
+    {
+        $user = new stdClass();
+        $member = $this->createMock(stdClass::class);
+        $member->expects($this->once())->method('loginUser')->with('user', 'pass')->willReturn($user);
+        $GLOBALS['xoops_auth_handlers']['member'] = $member;
+
+        $auth = new XoopsAuthXoops(null);
+        $this->assertSame($user, $auth->authenticate('user', 'pass'));
+    }
+
+    public function testAuthLdapCp1252ConversionUsesMap(): void
+    {
+        if (extension_loaded('ldap')) {
+            $this->markTestSkipped('cp1252 map is independent of LDAP extension state.');
+        }
+        $GLOBALS['xoops_auth_handlers']['config'] = new class {
+            public function getConfigsByCat($cat)
+            {
+                return [
+                    'ldap_use_TLS'          => false,
+                    'ldap_loginname_asdn'   => true,
+                    'ldap_loginldap_attr'   => 'uid',
+                    'ldap_filter_person'    => '',
+                    'ldap_server'           => 'ldap',
+                    'ldap_port'             => '389',
+                    'ldap_version'          => '3',
+                    'ldap_domain_name'      => 'domain',
+                    'ldap_provisionning'    => false,
+                    'ldap_provisionning_upd'=> false,
+                    'ldap_field_mapping'    => '',
+                    'ldap_provisionning_group' => [],
+                ];
+            }
+        };
+
+        $auth = new XoopsAuthLdap(null);
+        $converted = $auth->cp1252_to_utf8("\xc2\x80 symbol");
+
+        $this->assertStringContainsString("\xe2\x82\xac", $converted);
+    }
+
+    public function testAuthLdapAuthenticateWithoutExtensionAddsError(): void
+    {
+        if (extension_loaded('ldap')) {
+            $this->markTestSkipped('LDAP extension present');
+        }
+        $GLOBALS['xoops_auth_handlers']['config'] = new class {
+            public function getConfigsByCat($cat)
+            {
+                return [
+                    'ldap_use_TLS'          => false,
+                    'ldap_loginname_asdn'   => true,
+                    'ldap_loginldap_attr'   => 'uid',
+                    'ldap_filter_person'    => '',
+                    'ldap_server'           => 'ldap',
+                    'ldap_port'             => '389',
+                    'ldap_version'          => '3',
+                    'ldap_domain_name'      => 'domain',
+                    'ldap_provisionning'    => false,
+                    'ldap_provisionning_upd'=> false,
+                    'ldap_field_mapping'    => '',
+                    'ldap_provisionning_group' => [],
+                ];
+            }
+        };
+
+        $auth = new XoopsAuthAds(null);
+        $this->assertFalse($auth->authenticate('user', 'pwd'));
+        $this->assertSame([0 => 'ldap missing'], $auth->getErrors());
+    }
+
+    public function testAuthAdsGetUpn(): void
+    {
+        $GLOBALS['xoops_auth_handlers']['config'] = new class {
+            public function getConfigsByCat($cat)
+            {
+                return [
+                    'ldap_use_TLS'          => false,
+                    'ldap_loginname_asdn'   => true,
+                    'ldap_loginldap_attr'   => 'uid',
+                    'ldap_filter_person'    => '',
+                    'ldap_server'           => 'ldap',
+                    'ldap_port'             => '389',
+                    'ldap_version'          => '3',
+                    'ldap_domain_name'      => 'example.com',
+                    'ldap_provisionning'    => false,
+                    'ldap_provisionning_upd'=> false,
+                    'ldap_field_mapping'    => '',
+                    'ldap_provisionning_group' => [],
+                ];
+            }
+        };
+
+        $auth = new XoopsAuthAds(null);
+        $this->assertSame('alice@example.com', $auth->getUPN('alice'));
+    }
+
+    public function testProvisionningSyncAddsUser(): void
+    {
+        $memberHandler = new class {
+            public array $insertedUsers = [];
+            public array $groups = [];
+
+            public function createUser()
+            {
+                return new XoopsUser();
+            }
+
+            public function insertUser($user)
+            {
+                $this->insertedUsers[] = $user;
+
+                return true;
+            }
+
+            public function addUserToGroup($groupId, $uid)
+            {
+                $this->groups[] = [$groupId, $uid];
+            }
+
+            public function getUsers()
+            {
+                return [];
+            }
+        };
+
+        $GLOBALS['xoops_auth_handlers']['member'] = $memberHandler;
+        $GLOBALS['xoops_auth_handlers']['config'] = new class {
+            public function getConfigsByCat($cat)
+            {
+                if ($cat === XOOPS_CONF_AUTH) {
+                    return [
+                        'ldap_provisionning'       => true,
+                        'ldap_provisionning_upd'   => true,
+                        'ldap_field_mapping'       => 'email=mail',
+                        'ldap_provisionning_group' => [99],
+                    ];
+                }
+
+                return [
+                    'default_TZ' => '0',
+                    'theme_set'  => 'default',
+                    'com_mode'   => 'flat',
+                    'com_order'  => 0,
+                ];
+            }
+        };
+
+        $auth = new XoopsAuth();
+        $provision = new XoopsAuthProvisionning($auth);
+        $user = $provision->sync(['mail' => ['a@example.com']], 'alice', 'pw');
+
+        $this->assertInstanceOf(XoopsUser::class, $user);
+        $this->assertNotEmpty($memberHandler->insertedUsers);
+        $this->assertSame([[99, $user->getVar('uid')]], $memberHandler->groups);
+        $this->assertSame('a@example.com', $user->getVar('email'));
+    }
+
+    public function testProvisionningSyncUpdatesExistingUser(): void
+    {
+        $existingUser = new XoopsUser();
+        $existingUser->setVar('uid', 11);
+        $memberHandler = new class ($existingUser) {
+            private XoopsUser $user;
+            public function __construct($user)
+            {
+                $this->user = $user;
+            }
+
+            public function getUsers()
+            {
+                return [$this->user];
+            }
+
+            public function insertUser($user)
+            {
+                return true;
+            }
+        };
+
+        $GLOBALS['xoops_auth_handlers']['member'] = $memberHandler;
+        $GLOBALS['xoops_auth_handlers']['config'] = new class {
+            public function getConfigsByCat($cat)
+            {
+                if ($cat === XOOPS_CONF_AUTH) {
+                    return [
+                        'ldap_provisionning'       => true,
+                        'ldap_provisionning_upd'   => true,
+                        'ldap_field_mapping'       => 'name=cn',
+                        'ldap_provisionning_group' => [],
+                    ];
+                }
+
+                return [
+                    'default_TZ' => '0',
+                    'theme_set'  => 'default',
+                    'com_mode'   => 'flat',
+                    'com_order'  => 0,
+                ];
+            }
+        };
+
+        $auth = new XoopsAuth();
+        $provision = new XoopsAuthProvisionning($auth);
+        $user = $provision->sync(['cn' => ['Alice']], 'alice', 'pw');
+
+        $this->assertSame('Alice', $user->getVar('name'));
+        $this->assertSame(11, $user->getVar('uid'));
+    }
+}

--- a/tests/unit/XoopsAvatarTest.php
+++ b/tests/unit/XoopsAvatarTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/avatar.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsAvatarTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $avatar = new XoopsAvatar();
+
+        $this->assertNull($avatar->getVar('avatar_id'));
+        $this->assertSame(1, $avatar->getVar('avatar_display'));
+        $this->assertSame(0, $avatar->getVar('avatar_weight'));
+        $this->assertSame(0, $avatar->getVar('avatar_type'));
+    }
+
+    public function testUserCountAccessorsCastToInt(): void
+    {
+        $avatar = new XoopsAvatar();
+        $avatar->setUserCount(7.9);
+
+        $this->assertSame(7, $avatar->getUserCount());
+    }
+
+    public function testIdHelperReturnsStoredValue(): void
+    {
+        $avatar = new XoopsAvatar();
+        $avatar->setVar('avatar_id', 12);
+
+        $this->assertSame(12, $avatar->id());
+    }
+}
+
+class XoopsAvatarHandlerTest extends TestCase
+{
+    public function testCreateReturnsFreshOrExistingObjects(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler  = new XoopsAvatarHandler($database);
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsAvatar::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetLoadsAvatarFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_avatar WHERE avatar_id=7')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'avatar_id'       => 7,
+            'avatar_file'     => 'avatar.png',
+            'avatar_name'     => 'Example Avatar',
+            'avatar_mimetype' => 'image/png',
+            'avatar_created'  => 123,
+            'avatar_display'  => 1,
+            'avatar_weight'   => 2,
+            'avatar_type'     => 'S',
+        ]);
+
+        $handler = new XoopsAvatarHandler($database);
+        $avatar  = $handler->get(7);
+
+        $this->assertInstanceOf(XoopsAvatar::class, $avatar);
+        $this->assertSame('avatar.png', $avatar->getVar('avatar_file'));
+        $this->assertSame('Example Avatar', $avatar->getVar('avatar_name'));
+        $this->assertFalse($avatar->isNew());
+    }
+
+    public function testInsertAssignsIdentifierToNewAvatar(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(fn($value) => "'{$value}'");
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(21);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(function ($sql) {
+                return strpos($sql, 'INSERT INTO pref_avatar') !== false
+                    && strpos($sql, "'avatar.png'") !== false
+                    && strpos($sql, "'Avatar Name'") !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsAvatarHandler($database);
+
+        $avatar = new XoopsAvatar();
+        $avatar->setVar('avatar_file', 'avatar.png');
+        $avatar->setVar('avatar_name', 'Avatar Name');
+        $avatar->setVar('avatar_mimetype', 'image/png');
+        $avatar->setVar('avatar_display', 1);
+        $avatar->setVar('avatar_weight', 3);
+        $avatar->setVar('avatar_type', 'S');
+        $avatar->setDirty();
+        $avatar->setNew();
+
+        $this->assertTrue($handler->insert($avatar));
+        $this->assertSame(21, $avatar->getVar('avatar_id'));
+    }
+
+    public function testDeleteExecutesCleanupQueries(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ['DELETE FROM pref_avatar WHERE avatar_id = 5'],
+                ['DELETE FROM pref_avatar_user_link WHERE avatar_id = 5']
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsAvatarHandler($database);
+        $avatar  = new XoopsAvatar();
+        $avatar->setVar('avatar_id', 5);
+
+        $this->assertTrue($handler->delete($avatar));
+    }
+
+    public function testGetObjectsReturnsListOfAvatars(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls([
+            'avatar_id'       => 11,
+            'avatar_file'     => 'first.png',
+            'avatar_name'     => 'First',
+            'avatar_mimetype' => 'image/png',
+            'avatar_created'  => 456,
+            'avatar_display'  => 1,
+            'avatar_weight'   => 4,
+            'avatar_type'     => 'S',
+            'count'           => 2,
+        ], false);
+
+        $handler = new XoopsAvatarHandler($database);
+        $results = $handler->getObjects();
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(XoopsAvatar::class, $results[0]);
+        $this->assertSame(2, $results[0]->getUserCount());
+    }
+
+    public function testGetCountReturnsRowCount(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(*) FROM pref_avatar')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([4]);
+
+        $handler = new XoopsAvatarHandler($database);
+
+        $this->assertSame(4, $handler->getCount());
+    }
+
+    public function testAddUserReplacesExistingEntries(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ['DELETE FROM pref_avatar_user_link WHERE user_id = 9'],
+                ['INSERT INTO pref_avatar_user_link (avatar_id, user_id) VALUES (7, 9)']
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsAvatarHandler($database);
+
+        $this->assertTrue($handler->addUser(7, 9));
+    }
+
+    public function testGetUserReturnsLinkedIdentifiers(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT user_id FROM pref_avatar_user_link WHERE avatar_id=13')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(['user_id' => 3], false);
+
+        $handler = new XoopsAvatarHandler($database);
+        $avatar  = new XoopsAvatar();
+        $avatar->setVar('avatar_id', 13);
+
+        $this->assertSame([3], $handler->getUser($avatar));
+    }
+
+    public function testGetListUsesCriteriaToFilterAvatars(): void
+    {
+        if (!defined('_NONE')) {
+            define('_NONE', '_NONE');
+        }
+
+        $database = $this->createDatabaseMock();
+        $handler  = $this->getMockBuilder(XoopsAvatarHandler::class)
+            ->setConstructorArgs([$database])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $avatar = new XoopsAvatar();
+        $avatar->setVar('avatar_id', 2);
+        $avatar->setVar('avatar_file', 'custom.png');
+        $avatar->setVar('avatar_name', 'Custom');
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class), true)
+            ->willReturn([
+                2 => $avatar,
+            ]);
+
+        $list = $handler->getList('C', true);
+
+        $this->assertSame([
+            'blank.gif' => _NONE,
+            'custom.png' => 'Custom',
+        ], $list);
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'error',
+                'fetchRow',
+                'quote',
+                'genId',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsBlockInstanceTest.php
+++ b/tests/unit/XoopsBlockInstanceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/blockinstance.php';
+
+class XoopsBlockInstanceTest extends TestCase
+{
+    private $previousLogger;
+    private array $messages;
+
+    protected function setUp(): void
+    {
+        $this->previousLogger = $GLOBALS['xoopsLogger'] ?? null;
+        $this->messages       = [];
+        $GLOBALS['xoopsLogger'] = new class {
+            public array $messages = [];
+
+            public function addDeprecated($message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+        $GLOBALS['xoopsLogger']->messages =& $this->messages;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['xoopsLogger'] = $this->previousLogger;
+    }
+
+    public function testMagicCallLogsDeprecatedMessageAndReturnsNull(): void
+    {
+        $instance = new XoopsBlockInstance();
+
+        $this->assertNull($instance->dynamicMethod('foo', 'bar'));
+        $this->assertCount(1, $this->messages);
+        $this->assertStringContainsString("XoopsBlockInstance", $this->messages[0]);
+        $this->assertStringContainsString("dynamicMethod", $this->messages[0]);
+        $this->assertStringContainsString('not executed', $this->messages[0]);
+    }
+
+    public function testMagicSetLogsDeprecatedMessage(): void
+    {
+        $instance = new XoopsBlockInstance();
+
+        $instance->property = 'value';
+        $this->assertCount(1, $this->messages);
+        $this->assertStringContainsString("XoopsBlockInstance", $this->messages[0]);
+        $this->assertStringContainsString('property', $this->messages[0]);
+        $this->assertStringContainsString('not set', $this->messages[0]);
+    }
+
+    public function testMagicGetLogsDeprecatedMessageAndReturnsNull(): void
+    {
+        $instance = new XoopsBlockInstance();
+
+        $this->assertNull($instance->missing);
+        $this->assertCount(1, $this->messages);
+        $this->assertStringContainsString("XoopsBlockInstance", $this->messages[0]);
+        $this->assertStringContainsString('missing', $this->messages[0]);
+        $this->assertStringContainsString('not available', $this->messages[0]);
+    }
+}
+
+class XoopsBlockInstanceHandlerTest extends TestCase
+{
+    private $previousLogger;
+    private array $messages;
+
+    protected function setUp(): void
+    {
+        $this->previousLogger = $GLOBALS['xoopsLogger'] ?? null;
+        $this->messages       = [];
+        $GLOBALS['xoopsLogger'] = new class {
+            public array $messages = [];
+
+            public function addDeprecated($message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+        $GLOBALS['xoopsLogger']->messages =& $this->messages;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['xoopsLogger'] = $this->previousLogger;
+    }
+
+    public function testMagicCallLogsDeprecatedMessageAndReturnsNull(): void
+    {
+        $handler = new XoopsBlockInstanceHandler();
+
+        $this->assertNull($handler->perform('foo'));
+        $this->assertCount(1, $this->messages);
+        $this->assertStringContainsString("XoopsBlockInstanceHandler", $this->messages[0]);
+        $this->assertStringContainsString("perform", $this->messages[0]);
+        $this->assertStringContainsString('not executed', $this->messages[0]);
+    }
+
+    public function testMagicSetLogsDeprecatedMessage(): void
+    {
+        $handler = new XoopsBlockInstanceHandler();
+
+        $handler->property = 'value';
+        $this->assertCount(1, $this->messages);
+        $this->assertStringContainsString("XoopsBlockInstanceHandler", $this->messages[0]);
+        $this->assertStringContainsString('property', $this->messages[0]);
+        $this->assertStringContainsString('not set', $this->messages[0]);
+    }
+
+    public function testMagicGetLogsDeprecatedMessageAndReturnsNull(): void
+    {
+        $handler = new XoopsBlockInstanceHandler();
+
+        $this->assertNull($handler->missing);
+        $this->assertCount(1, $this->messages);
+        $this->assertStringContainsString("XoopsBlockInstanceHandler", $this->messages[0]);
+        $this->assertStringContainsString('missing', $this->messages[0]);
+        $this->assertStringContainsString('not available', $this->messages[0]);
+    }
+}

--- a/tests/unit/XoopsBlockTest.php
+++ b/tests/unit/XoopsBlockTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/block.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsBlockTest extends TestCase
+{
+    public function testConstructorSetsDefaultVariables(): void
+    {
+        $block = new XoopsBlock();
+
+        $this->assertNull($block->getVar('bid'));
+        $this->assertSame(0, $block->getVar('mid'));
+        $this->assertSame(0, $block->getVar('func_num'));
+        $this->assertSame(0, $block->getVar('weight'));
+        $this->assertSame(0, $block->getVar('visible'));
+    }
+
+    public function testIdHelperReturnsIdentifier(): void
+    {
+        $block = new XoopsBlock();
+        $block->setVar('bid', 42);
+
+        $this->assertSame(42, $block->id());
+        $this->assertSame(42, $block->bid());
+    }
+
+    public function testIsCustomDetectsCustomBlockTypes(): void
+    {
+        $block = new XoopsBlock();
+
+        $block->setVar('block_type', 'C');
+        $this->assertTrue($block->isCustom());
+
+        $block->setVar('block_type', 'E');
+        $this->assertTrue($block->isCustom());
+
+        $block->setVar('block_type', 'S');
+        $this->assertFalse($block->isCustom());
+    }
+
+    public function testBuildContentAlignsOutput(): void
+    {
+        $block = new XoopsBlock();
+
+        $this->assertSame('dbfirstcontent', $block->buildContent(0, 'content', 'dbfirst'));
+        $this->assertSame('contentdb', $block->buildContent(1, 'content', 'db'));
+        $this->assertNull($block->buildContent(2, 'content', 'db'));
+    }
+
+    public function testBuildTitlePrefersNewTitleWhenProvided(): void
+    {
+        $block = new XoopsBlock();
+
+        $this->assertSame('original', $block->buildTitle('original'));
+        $this->assertSame('new', $block->buildTitle('original', 'new'));
+    }
+}
+
+class XoopsBlockHandlerTest extends TestCase
+{
+    public function testCreateReturnsNewOrExistingBlock(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler  = new XoopsBlockHandler($database);
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsBlock::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesBlockFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_newblocks WHERE bid=4')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'bid'        => 4,
+            'name'       => 'Test block',
+            'block_type' => 'S',
+        ]);
+
+        $handler = new XoopsBlockHandler($database);
+        $block   = $handler->get(4);
+
+        $this->assertInstanceOf(XoopsBlock::class, $block);
+        $this->assertSame('Test block', $block->getVar('name'));
+        $this->assertFalse($block->isNew());
+    }
+
+    public function testInsertPersistsNewBlockAndAssignsId(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(33);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(static function ($sql) {
+                return strpos($sql, 'INSERT INTO pref_newblocks') !== false
+                    && strpos($sql, "'sidebar'") !== false
+                    && strpos($sql, "'My Block'") !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsBlockHandler($database);
+
+        $block = new XoopsBlock();
+        $block->setVar('mid', 2);
+        $block->setVar('func_num', 1);
+        $block->setVar('options', 'opt1');
+        $block->setVar('name', 'My Block');
+        $block->setVar('title', 'Title');
+        $block->setVar('content', 'Content');
+        $block->setVar('side', 1);
+        $block->setVar('weight', 0);
+        $block->setVar('visible', 1);
+        $block->setVar('block_type', 'S');
+        $block->setVar('c_type', 'H');
+        $block->setVar('isactive', 1);
+        $block->setVar('dirname', 'sidebar');
+        $block->setVar('func_file', 'block.php');
+        $block->setVar('show_func', 'show');
+        $block->setVar('edit_func', 'edit');
+        $block->setVar('template', 'block.tpl');
+        $block->setVar('bcachetime', 30);
+        $block->setDirty();
+        $block->setNew();
+
+        $this->assertTrue($handler->insert($block));
+        $this->assertSame(33, $block->getVar('bid'));
+    }
+
+    public function testDeleteRemovesBlockAndLinks(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ['DELETE FROM pref_newblocks WHERE bid = 8'],
+                ['DELETE FROM pref_block_module_link WHERE block_id = 8']
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsBlockHandler($database);
+        $block   = new XoopsBlock();
+        $block->setVar('bid', 8);
+
+        $this->assertTrue($handler->delete($block));
+    }
+
+    public function testGetObjectsReturnsBlocks(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with(
+                'SELECT DISTINCT(b.bid), b.* FROM pref_newblocks b LEFT JOIN pref_block_module_link l ON b.bid=l.block_id WHERE visible=1',
+                5,
+                2
+            )
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls([
+            'bid'        => 9,
+            'name'       => 'Block name',
+            'block_type' => 'S',
+        ], false);
+
+        $handler  = new XoopsBlockHandler($database);
+        $criteria = $this->createMock(CriteriaElement::class);
+        $criteria->method('renderWhere')->willReturn('WHERE visible=1');
+        $criteria->method('getLimit')->willReturn(5);
+        $criteria->method('getStart')->willReturn(2);
+
+        $blocks = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $blocks);
+        $this->assertArrayHasKey(9, $blocks);
+        $this->assertInstanceOf(XoopsBlock::class, $blocks[9]);
+    }
+
+    public function testGetListUsesCustomTitles(): void
+    {
+        $handler = $this->getMockBuilder(XoopsBlockHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $customBlock = new XoopsBlock();
+        $customBlock->setVar('bid', 7);
+        $customBlock->setVar('block_type', 'C');
+        $customBlock->setVar('title', 'Custom Title');
+
+        $regularBlock = new XoopsBlock();
+        $regularBlock->setVar('bid', 8);
+        $regularBlock->setVar('block_type', 'S');
+        $regularBlock->setVar('name', 'Regular Name');
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with(null, true)
+            ->willReturn([
+                7 => $customBlock,
+                8 => $regularBlock,
+            ]);
+
+        $list = $handler->getList();
+
+        $this->assertSame([
+            7 => 'Custom Title',
+            8 => 'Regular Name',
+        ], $list);
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'error',
+                'fetchRow',
+                'quote',
+                'genId',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsCacheTest.php
+++ b/tests/unit/XoopsCacheTest.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+if (!function_exists('apc_cache_info')) {
+    $GLOBALS['apc_cache'] = [];
+
+    function apc_cache_info($type = '')
+    {
+        return [];
+    }
+
+    function apc_store($key, $value, $duration = null)
+    {
+        $GLOBALS['apc_cache'][$key] = $value;
+
+        return true;
+    }
+
+    function apc_fetch($key)
+    {
+        return $GLOBALS['apc_cache'][$key] ?? false;
+    }
+
+    function apc_delete($key)
+    {
+        if (is_array($key)) {
+            $failed = [];
+            foreach ($key as $entry) {
+                if (!isset($GLOBALS['apc_cache'][$entry])) {
+                    $failed[] = $entry;
+                    continue;
+                }
+                unset($GLOBALS['apc_cache'][$entry]);
+            }
+
+            return $failed ?: true;
+        }
+        unset($GLOBALS['apc_cache'][$key]);
+
+        return true;
+    }
+
+    function apc_clear_cache($type = '')
+    {
+        $GLOBALS['apc_cache'] = [];
+
+        return true;
+    }
+}
+
+if (!class_exists('Memcache')) {
+    if (!defined('MEMCACHE_COMPRESSED')) {
+        define('MEMCACHE_COMPRESSED', 0);
+    }
+
+    class Memcache
+    {
+        public array $servers = [];
+        public array $data = [];
+
+        public function addServer($host, $port = 11211)
+        {
+            $this->servers[] = [$host, $port];
+
+            return true;
+        }
+
+        public function set($key, $value, $compress, $duration)
+        {
+            $this->data[$key] = $value;
+
+            return true;
+        }
+
+        public function get($key)
+        {
+            return $this->data[$key] ?? false;
+        }
+
+        public function delete($key)
+        {
+            unset($this->data[$key]);
+
+            return true;
+        }
+
+        public function flush()
+        {
+            $this->data = [];
+
+            return true;
+        }
+
+        public function getServerStatus($host, $port)
+        {
+            return 1;
+        }
+
+        public function connect($host, $port)
+        {
+            $this->servers[] = [$host, $port];
+
+            return true;
+        }
+    }
+}
+
+if (!class_exists('XoopsLoad')) {
+    class XoopsLoad
+    {
+        public static function load($class)
+        {
+            return true;
+        }
+    }
+}
+
+if (!class_exists('XoopsFile')) {
+    class XoopsFile
+    {
+        public $folder;
+        public $name;
+
+        public function __construct($path)
+        {
+            $this->folder = new class {
+                public $path;
+
+                public function cd($path)
+                {
+                    $this->path = $path;
+                    if (!is_dir($path)) {
+                        mkdir($path, 0777, true);
+                    }
+
+                    return $path;
+                }
+
+                public function inPath($path, $reverse = true)
+                {
+                    return str_starts_with($path, $this->path);
+                }
+            };
+            $this->folder->cd(dirname($path));
+        }
+
+        public static function getHandler($name, $path, $create)
+        {
+            return new self($path);
+        }
+
+        public function pwd()
+        {
+            return $this->folder->path;
+        }
+
+        public function write($contents)
+        {
+            $target = $this->folder->path . '/' . $this->name;
+
+            return false !== file_put_contents($target, $contents);
+        }
+
+        public function read($bytes = false)
+        {
+            $target = $this->folder->path . '/' . $this->name;
+            if (!file_exists($target)) {
+                return false;
+            }
+            $contents = file_get_contents($target);
+            if ($bytes === true) {
+                return $contents;
+            }
+            if (is_int($bytes)) {
+                return substr($contents, 0, $bytes);
+            }
+
+            return $contents;
+        }
+
+        public function close()
+        {
+        }
+
+        public function delete()
+        {
+            $target = $this->folder->path . '/' . $this->name;
+            if (file_exists($target)) {
+                unlink($target);
+            }
+
+            return true;
+        }
+
+        public function lastChange()
+        {
+            $target = $this->folder->path . '/' . $this->name;
+
+            return file_exists($target) ? filemtime($target) : false;
+        }
+    }
+}
+
+if (!class_exists('XoopsUtility')) {
+    class XoopsUtility
+    {
+        public static function recursive($callback, $data)
+        {
+            return array_map($callback, $data);
+        }
+    }
+}
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static function getDatabaseConnection()
+        {
+            return 'db';
+        }
+    }
+}
+
+require_once XOOPS_ROOT_PATH . '/kernel/object.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria/compo.php';
+require_once XOOPS_ROOT_PATH . '/class/cache/xoopscache.php';
+require_once XOOPS_ROOT_PATH . '/class/cache/apc.php';
+require_once XOOPS_ROOT_PATH . '/class/cache/file.php';
+require_once XOOPS_ROOT_PATH . '/class/cache/memcache.php';
+require_once XOOPS_ROOT_PATH . '/class/cache/model.php';
+
+class XoopsCacheDummy extends XoopsCacheEngine
+{
+    public array $written = [];
+    public array $readKeys = [];
+    public array $deleted = [];
+    public array $cleared = [];
+    public bool $gcCalled = false;
+
+    public function init($settings = [])
+    {
+        parent::init($settings);
+
+        return true;
+    }
+
+    public function gc()
+    {
+        $this->gcCalled = true;
+    }
+
+    public function write($key, $value, $duration = null)
+    {
+        $this->written[] = [$key, $value, $duration, $this->settings];
+
+        return true;
+    }
+
+    public function read($key)
+    {
+        $this->readKeys[] = $key;
+
+        return 'value-' . $key;
+    }
+
+    public function delete($key)
+    {
+        $this->deleted[] = $key;
+
+        return true;
+    }
+
+    public function clear($check)
+    {
+        $this->cleared[] = $check;
+
+        return true;
+    }
+}
+
+class XoopsCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $instance = XoopsCache::getInstance();
+        $ref = new ReflectionObject($instance);
+        foreach (['engine' => [], 'configs' => [], 'name' => null] as $property => $value) {
+            $prop = $ref->getProperty($property);
+            $prop->setAccessible(true);
+            $prop->setValue($instance, $value);
+        }
+        $GLOBALS['apc_cache'] = [];
+    }
+
+    public function testConfigSetsEngineAndSettings(): void
+    {
+        $cache = XoopsCache::getInstance();
+
+        $config = $cache->config('demo', ['engine' => 'dummy', 'duration' => 10, 'probability' => 1]);
+
+        $this->assertSame('dummy', $config['engine']);
+        $this->assertSame('demo', (new ReflectionObject($cache))->getProperty('name')->getValue($cache));
+        $this->assertInstanceOf(XoopsCacheDummy::class, (new ReflectionObject($cache))->getProperty('engine')->getValue($cache)['dummy']);
+    }
+
+    public function testWriteReadAndDeleteUseEngineWithPrefixedKeys(): void
+    {
+        $cache = XoopsCache::getInstance();
+        $cache->config('demo', ['engine' => 'dummy', 'duration' => 5, 'probability' => 1]);
+
+        $this->assertTrue(XoopsCache::write('abc/def', 'payload', 2));
+        $readValue = XoopsCache::read('abc/def');
+        $this->assertStringContainsString('value-', (string) $readValue);
+        $this->assertTrue(XoopsCache::delete('abc/def'));
+
+        $engine = (new ReflectionObject($cache))->getProperty('engine')->getValue($cache)['dummy'];
+        $expectedKey = substr(md5(XOOPS_URL), 0, 8) . '_abc_def';
+        $this->assertSame($expectedKey, $engine->written[0][0]);
+        $this->assertSame([$expectedKey], $engine->readKeys);
+        $this->assertSame([$expectedKey], $engine->deleted);
+    }
+
+    public function testIsInitializedAndSettingsAccess(): void
+    {
+        $cache = XoopsCache::getInstance();
+        $cache->config('demo', ['engine' => 'dummy', 'duration' => 5]);
+
+        $this->assertTrue($cache->isInitialized('dummy'));
+        $settings = $cache->settings('dummy');
+        $this->assertSame(5, $settings['duration']);
+    }
+
+    public function testKeySanitization(): void
+    {
+        $cache = XoopsCache::getInstance();
+        $this->assertSame('a_b_c', $cache->key('a/b.c'));
+        $this->assertFalse($cache->key(''));
+    }
+
+    public function testCacheEngineInitializationDefaults(): void
+    {
+        $engine = new XoopsCacheEngine();
+        $engine->init(['duration' => 50]);
+
+        $this->assertSame(50, $engine->settings['duration']);
+        $this->assertSame(100, $engine->settings['probability']);
+    }
+
+    public function testApcEngineProvidesBasicOperations(): void
+    {
+        $engine = new XoopsCacheApc();
+        $this->assertTrue($engine->init());
+
+        $this->assertTrue($engine->write('apc-key', 'value', 10));
+        $this->assertSame('value', $engine->read('apc-key'));
+        $this->assertTrue($engine->delete('apc-key'));
+        $this->assertTrue($engine->clear());
+    }
+
+    public function testMemcacheEngineUsesConfiguredServers(): void
+    {
+        $engine = new XoopsCacheMemcache();
+        $this->assertTrue($engine->init(['servers' => ['localhost:22122']]));
+
+        $this->assertTrue($engine->write('mem-key', 'value', 3));
+        $this->assertSame('value', $engine->read('mem-key'));
+        $this->assertTrue($engine->delete('mem-key'));
+        $this->assertTrue($engine->clear());
+    }
+
+    public function testCacheModelObjectInitialization(): void
+    {
+        $object = new XoopsCacheModelObject();
+        $this->assertNull($object->getVar('key'));
+        $this->assertNull($object->getVar('data'));
+        $this->assertNull($object->getVar('expires'));
+    }
+
+    public function testCacheModelHandlerConfiguration(): void
+    {
+        $database = new class {
+            public function prefix($name)
+            {
+                return 'pref_' . $name;
+            }
+        };
+
+        $handler = new XoopsCacheModelHandler($database);
+
+        $this->assertSame('pref_cache_model', $handler->table);
+        $this->assertSame(XoopsCacheModelHandler::KEYNAME, $handler->keyName);
+        $this->assertSame(XoopsCacheModelHandler::CLASSNAME, $handler->className);
+    }
+
+    public function testCacheModelReadWriteAndCleanup(): void
+    {
+        $model = new class {
+            public string $keyname = 'key';
+            public $inserted;
+            public array $deleted = [];
+            public $allCriteria;
+
+            public function create()
+            {
+                return new XoopsCacheModelObject();
+            }
+
+            public function insert($object)
+            {
+                $this->inserted = $object;
+
+                return true;
+            }
+
+            public function delete($key)
+            {
+                $this->deleted[] = $key;
+
+                return true;
+            }
+
+            public function deleteAll($criteria = null)
+            {
+                $this->allCriteria = $criteria;
+
+                return 'cleared';
+            }
+
+            public function getAll($criteria)
+            {
+                $this->allCriteria = $criteria;
+
+                return [serialize(['hello' => 'world'])];
+            }
+        };
+
+        $engine = new XoopsCacheModel();
+        $engine->fields = ['data', 'expires'];
+        $engine->model = $model;
+
+        $this->assertTrue($engine->write('cache-key', ['hello' => 'world'], 5));
+        $this->assertSame('cleared', $engine->clear());
+        $this->assertSame(['hello' => 'world'], $engine->read('cache-key'));
+        $this->assertTrue($engine->delete('cache-key'));
+        $this->assertInstanceOf(Criteria::class, $model->allCriteria);
+
+        $expires = $model->inserted->getVar('expires');
+        $this->assertGreaterThanOrEqual(time(), $expires - 5);
+    }
+}

--- a/tests/unit/XoopsCaptchaTest.php
+++ b/tests/unit/XoopsCaptchaTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+if (!function_exists('xoops_loadLanguage')) {
+    function xoops_loadLanguage($name, $domain = '', $language = null)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('xoops_load')) {
+    function xoops_load($name)
+    {
+        return true;
+    }
+}
+
+if (!class_exists('Xmf\\Request')) {
+    class Request
+    {
+        public static array $post = [];
+
+        public static function getString($key, $default = '', $method = 'POST')
+        {
+            return $method === 'POST' ? (self::$post[$key] ?? $default) : $default;
+        }
+    }
+}
+
+if (!class_exists('Xmf\\IPAddress')) {
+    class IPAddress
+    {
+        public static function fromRequest()
+        {
+            return new self();
+        }
+
+        public function asReadable()
+        {
+            return '127.0.0.1';
+        }
+    }
+}
+
+if (!class_exists('XoopsPreload')) {
+    class XoopsPreload
+    {
+        public array $events = [];
+
+        public static function getInstance()
+        {
+            static $instance;
+            $instance ??= new self();
+
+            return $instance;
+        }
+
+        public function triggerEvent($name, $result)
+        {
+            $this->events[] = [$name, $result];
+        }
+    }
+}
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'http://localhost');
+}
+
+if (!defined('_CAPTCHA_CAPTION')) {
+    define('_CAPTCHA_CAPTION', 'captcha');
+    define('_CAPTCHA_INVALID_CODE', 'invalid');
+    define('_CAPTCHA_TOOMANYATTEMPTS', 'too many');
+    define('_CAPTCHA_RULE_TEXT', 'rule text');
+    define('_CAPTCHA_MAXATTEMPTS', 'max %d');
+    define('_CAPTCHA_RULE_IMAGE', 'image rule');
+    define('_CAPTCHA_RULE_CASEINSENSITIVE', 'case insensitive');
+    define('_CAPTCHA_RULE_CASESENSITIVE', 'case sensitive');
+    define('_CAPTCHA_REFRESH', 'refresh');
+}
+
+require_once XOOPS_ROOT_PATH . '/class/captcha/xoopscaptcha.php';
+require_once XOOPS_ROOT_PATH . '/class/captcha/text.php';
+require_once XOOPS_ROOT_PATH . '/class/captcha/image.php';
+require_once XOOPS_ROOT_PATH . '/class/captcha/recaptcha2.php';
+require_once XOOPS_ROOT_PATH . '/class/captcha/image/scripts/image.php';
+
+class DummyCaptchaHandler extends XoopsCaptchaMethod
+{
+    public bool $verifyResult = true;
+    public bool $garbageDestroyed = false;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->config = ['name' => 'dummy'];
+    }
+
+    public function verify($sessionName = null)
+    {
+        return $this->verifyResult;
+    }
+
+    public function destroyGarbage()
+    {
+        $this->garbageDestroyed = true;
+    }
+
+    public function render()
+    {
+        return '<input name="' . $this->config['name'] . '">';
+    }
+}
+
+class RecaptchaStub extends XoopsCaptchaRecaptcha2
+{
+    public array $mockResponse = ['success' => true];
+
+    public function verify($sessionName = null)
+    {
+        if (isset($this->mockResponse['success']) && true === $this->mockResponse['success']) {
+            return true;
+        }
+        $captchaInstance = \XoopsCaptcha::getInstance();
+        foreach ($this->mockResponse['error-codes'] ?? [] as $msg) {
+            $captchaInstance->message[] = $msg;
+        }
+
+        return false;
+    }
+}
+
+final class XoopsCaptchaTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+        Request::$post = [];
+    }
+
+    public function testCaptchaLoadsHandlerAndRenders(): void
+    {
+        $captcha = XoopsCaptcha::getInstance();
+        $captcha->setConfigs([
+            'name' => 'mycaptcha',
+            'mode' => 'text',
+            'maxattempts' => 2,
+            'skipmember' => false,
+        ]);
+        $captcha->active = true;
+        $handler = $captcha->loadHandler();
+
+        $this->assertInstanceOf(XoopsCaptchaText::class, $handler);
+        $rendered = $captcha->render();
+        $this->assertStringContainsString('name="mycaptcha"', $rendered);
+        $this->assertSame(0, $_SESSION['mycaptcha_attempt']);
+        $this->assertSame(2, $_SESSION['mycaptcha_maxattempts']);
+    }
+
+    public function testVerifyTracksAttemptsAndMessages(): void
+    {
+        $captcha = XoopsCaptcha::getInstance();
+        $captcha->name = 'mycaptcha';
+        $captcha->active = true;
+        $captcha->handler = new DummyCaptchaHandler();
+        $captcha->config = ['maxattempts' => 1];
+        $_SESSION['mycaptcha_attempt'] = 0;
+
+        $this->assertFalse($captcha->verify());
+        $this->assertSame(1, $_SESSION['mycaptcha_attempt']);
+        $this->assertStringContainsString(_CAPTCHA_INVALID_CODE, $captcha->getMessage());
+    }
+
+    public function testCaptchaMethodComparison(): void
+    {
+        $method = new XoopsCaptchaMethod();
+        $method->config = ['casesensitive' => false];
+        $_SESSION['code_attempt_code'] = 'AbC';
+        Request::$post['code_attempt'] = 'abc';
+
+        $this->assertTrue($method->verify('code_attempt'));
+    }
+
+    public function testImageRenderProducesMarkup(): void
+    {
+        $handler = new XoopsCaptcha();
+        $image = new XoopsCaptchaImage($handler);
+        $image->config = [
+            'name' => 'imgcaptcha',
+            'num_chars' => 5,
+            'casesensitive' => false,
+            'maxattempts' => 3,
+        ];
+        $html = $image->render();
+
+        $this->assertStringContainsString('xoops_captcha_refresh', $html);
+        $this->assertStringContainsString('name="imgcaptcha"', $html);
+    }
+
+    public function testImageHandlerGeneratesCode(): void
+    {
+        $imageHandler = new XoopsCaptchaImageHandler();
+        $imageHandler->config['num_chars'] = 6;
+        $imageHandler->config['casesensitive'] = false;
+        $imageHandler->config['skip_characters'] = 'abc';
+        $imageHandler->invalid = false;
+
+        $this->assertTrue($imageHandler->generateCode());
+        $this->assertSame(6, strlen($imageHandler->code));
+        $this->assertSame($_SESSION['captcha_name_code'] ?? null, null);
+    }
+
+    public function testImageHandlerCreateImageInvalid(): void
+    {
+        $imageHandler = new XoopsCaptchaImageHandler();
+        $imageHandler->invalid = true;
+
+        $this->assertNull($imageHandler->createImage());
+    }
+
+    public function testRecaptchaRenderAndErrorHandling(): void
+    {
+        $recaptcha = new RecaptchaStub();
+        $recaptcha->config = [
+            'website_key' => 'site',
+            'secret_key' => 'secret',
+        ];
+        $rendered = $recaptcha->render();
+        $this->assertStringContainsString('g-recaptcha', $rendered);
+
+        $recaptcha->mockResponse = ['success' => false, 'error-codes' => ['bad-request']];
+        $this->assertFalse($recaptcha->verify());
+        $this->assertContains('bad-request', XoopsCaptcha::getInstance()->message);
+    }
+}

--- a/tests/unit/XoopsCommentRendererTest.php
+++ b/tests/unit/XoopsCommentRendererTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static $connection;
+
+        public static function getDatabaseConnection()
+        {
+            return static::$connection;
+        }
+    }
+}
+
+if (!class_exists('XoopsTpl')) {
+    class XoopsTpl
+    {
+        public array $assigned = [];
+        public array $appended = [];
+
+        public function assign($key, $value): void
+        {
+            $this->assigned[$key] = $value;
+        }
+
+        public function append($key, $value): void
+        {
+            $this->appended[$key][] = $value;
+        }
+    }
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return new class {
+            public function getUser($id)
+            {
+                return null;
+            }
+        };
+    }
+}
+
+if (!function_exists('formatTimestamp')) {
+    function formatTimestamp($time, $format = null)
+    {
+        return 'ts-' . $time;
+    }
+}
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'http://example.com');
+}
+
+if (!defined('XOOPS_COMMENT_PENDING')) {
+    define('XOOPS_COMMENT_PENDING', 1);
+    define('XOOPS_COMMENT_ACTIVE', 2);
+    define('XOOPS_COMMENT_HIDDEN', 3);
+}
+
+if (!defined('_CM_PENDING')) {
+    define('_CM_PENDING', 'pending');
+    define('_CM_ACTIVE', 'active');
+    define('_CM_HIDDEN', 'hidden');
+}
+
+require_once XOOPS_ROOT_PATH . '/class/commentrenderer.php';
+
+class StubComment extends XoopsObject
+{
+    public function __construct(array $values)
+    {
+        parent::__construct();
+        foreach ($values as $key => $value) {
+            $this->initVar($key, XOBJ_DTYPE_OTHER, $value, false);
+        }
+    }
+}
+
+class XoopsCommentRendererTest extends TestCase
+{
+    public function testRenderFlatViewSkipsInactiveWhenNotAdmin(): void
+    {
+        $tpl       = new XoopsTpl();
+        $renderer  = new XoopsCommentRenderer($tpl, false, false);
+        $anonymous = 'anon';
+        $GLOBALS['xoopsConfig']['anonymous'] = $anonymous;
+
+        $renderer->setComments($comments = [
+            new StubComment([
+                'com_id'      => 1,
+                'com_pid'     => 0,
+                'com_uid'     => 0,
+                'com_user'    => '',
+                'com_url'     => '',
+                'com_title'   => 'First',
+                'com_text'    => 'Hello',
+                'com_status'  => XOOPS_COMMENT_ACTIVE,
+                'com_created' => 10,
+                'com_modified'=> 11,
+                'com_icon'    => 'icon.gif',
+            ]),
+            new StubComment([
+                'com_id'      => 2,
+                'com_pid'     => 0,
+                'com_uid'     => 0,
+                'com_user'    => '',
+                'com_url'     => '',
+                'com_title'   => 'Second',
+                'com_text'    => 'World',
+                'com_status'  => XOOPS_COMMENT_PENDING,
+                'com_created' => 20,
+                'com_modified'=> 21,
+                'com_icon'    => 'icon.gif',
+            ]),
+        ]);
+
+        $renderer->renderFlatView(false);
+
+        $this->assertCount(1, $tpl->appended['comments']);
+        $this->assertSame('Hello', $tpl->appended['comments'][0]['text']);
+        $this->assertSame($anonymous, $tpl->appended['comments'][0]['poster']['uname']);
+    }
+
+    public function testRenderFlatViewAdminShowsStatusAndAllComments(): void
+    {
+        $tpl      = new XoopsTpl();
+        $renderer = new XoopsCommentRenderer($tpl, false, false);
+        $GLOBALS['xoopsConfig']['anonymous'] = 'anon';
+
+        $renderer->setComments($comments = [
+            new StubComment([
+                'com_id'      => 3,
+                'com_pid'     => 0,
+                'com_uid'     => 0,
+                'com_user'    => '',
+                'com_url'     => '',
+                'com_title'   => 'Third',
+                'com_text'    => 'Admin text',
+                'com_status'  => XOOPS_COMMENT_HIDDEN,
+                'com_created' => 30,
+                'com_modified'=> 31,
+                'com_icon'    => 'icon.gif',
+            ]),
+        ]);
+
+        $renderer->renderFlatView(true);
+
+        $this->assertCount(1, $tpl->appended['comments']);
+        $this->assertStringContainsString(_CM_HIDDEN, $tpl->appended['comments'][0]['text']);
+    }
+
+    public function testGetTitleIconDefaultsWhenFileMissing(): void
+    {
+        $tpl      = new XoopsTpl();
+        $renderer = new XoopsCommentRenderer($tpl, true, true);
+
+        $GLOBALS['xoops'] = new class {
+            public function path($path)
+            {
+                return sys_get_temp_dir() . '/' . $path;
+            }
+        };
+
+        $icon = $renderer->_getTitleIcon('missing.gif');
+
+        $this->assertStringContainsString('no_posticon.gif', $icon);
+    }
+}

--- a/tests/unit/XoopsCommentTest.php
+++ b/tests/unit/XoopsCommentTest.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/comment.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsCommentTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $comment = new XoopsComment();
+
+        $this->assertNull($comment->getVar('com_id'));
+        $this->assertSame(0, $comment->getVar('com_pid'));
+        $this->assertSame(0, $comment->getVar('com_uid'));
+        $this->assertSame(0, $comment->getVar('com_status'));
+        $this->assertSame(0, $comment->getVar('dohtml'));
+    }
+
+    public function testIdHelperReturnsStoredValue(): void
+    {
+        $comment = new XoopsComment();
+        $comment->setVar('com_id', 15);
+
+        $this->assertSame(15, $comment->id());
+        $this->assertSame(15, $comment->com_id());
+    }
+
+    public function testIsRootComparesCommentAndRootId(): void
+    {
+        $comment = new XoopsComment();
+        $comment->setVar('com_id', 3);
+        $comment->setVar('com_rootid', 3);
+
+        $this->assertTrue($comment->isRoot());
+
+        $comment->setVar('com_rootid', 4);
+        $this->assertFalse($comment->isRoot());
+    }
+}
+
+class XoopsCommentHandlerTest extends TestCase
+{
+    public function testCreateReturnsFreshOrExistingComments(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler  = new XoopsCommentHandler($database);
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsComment::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetLoadsCommentFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_xoopscomments WHERE com_id=7')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'com_id'     => 7,
+            'com_title'  => 'Hello',
+            'com_text'   => 'World',
+            'com_rootid' => 1,
+            'com_pid'    => 0,
+        ]);
+
+        $handler = new XoopsCommentHandler($database);
+        $comment = $handler->get(7);
+
+        $this->assertInstanceOf(XoopsComment::class, $comment);
+        $this->assertSame('Hello', $comment->getVar('com_title'));
+        $this->assertFalse($comment->isNew());
+    }
+
+    public function testInsertAssignsIdentifierToNewComment(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(fn($value) => "'{$value}'");
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(21);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(function ($sql) {
+                return strpos($sql, 'INSERT INTO pref_xoopscomments') !== false
+                    && strpos($sql, "'Sample title'") !== false
+                    && strpos($sql, "'Sample text'") !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsCommentHandler($database);
+
+        $comment = new XoopsComment();
+        $comment->setVar('com_pid', 0);
+        $comment->setVar('com_modid', 1);
+        $comment->setVar('com_title', 'Sample title');
+        $comment->setVar('com_text', 'Sample text');
+        $comment->setVar('com_created', 123);
+        $comment->setVar('com_modified', 0);
+        $comment->setVar('com_uid', 11);
+        $comment->setDirty();
+        $comment->setNew();
+
+        $this->assertTrue($handler->insert($comment));
+        $this->assertSame(21, $comment->getVar('com_id'));
+    }
+
+    public function testInsertUpdatesExistingComment(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(fn($value) => "'{$value}'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(function ($sql) {
+                return strpos($sql, 'UPDATE pref_xoopscomments SET') === 0
+                    && strpos($sql, 'WHERE com_id = 8') !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsCommentHandler($database);
+
+        $comment = new XoopsComment();
+        $comment->setVar('com_id', 8);
+        $comment->setVar('com_pid', 0);
+        $comment->setVar('com_modid', 1);
+        $comment->setVar('com_title', 'Updated title');
+        $comment->setVar('com_text', 'Updated text');
+        $comment->setVar('com_created', 10);
+        $comment->setVar('com_modified', 20);
+        $comment->setVar('com_uid', 9);
+        $comment->unsetNew();
+        $comment->setDirty();
+
+        $this->assertTrue($handler->insert($comment));
+    }
+
+    public function testDeleteExecutesDeleteQuery(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_xoopscomments WHERE com_id = 5')
+            ->willReturn(true);
+
+        $handler = new XoopsCommentHandler($database);
+        $comment = new XoopsComment();
+        $comment->setVar('com_id', 5);
+
+        $this->assertTrue($handler->delete($comment));
+    }
+
+    public function testGetObjectsReturnsListOfComments(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls([
+            'com_id'     => 11,
+            'com_title'  => 'First',
+            'com_text'   => 'Text',
+            'com_rootid' => 1,
+            'com_pid'    => 0,
+        ], false);
+
+        $handler = new XoopsCommentHandler($database);
+        $results = $handler->getObjects();
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(XoopsComment::class, $results[0]);
+        $this->assertSame('First', $results[0]->getVar('com_title'));
+    }
+
+    public function testGetCountReturnsRowCount(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(*) FROM pref_xoopscomments')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([4]);
+
+        $handler = new XoopsCommentHandler($database);
+
+        $this->assertSame(4, $handler->getCount());
+    }
+
+    public function testDeleteAllAppliesCriteriaWhenProvided(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_xoopscomments WHERE com_status=1')
+            ->willReturn(true);
+
+        $criteria = $this->getMockBuilder(CriteriaElement::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['renderWhere'])
+            ->getMock();
+        $criteria->method('renderWhere')->willReturn('WHERE com_status=1');
+
+        $handler = new XoopsCommentHandler($database);
+
+        $this->assertTrue($handler->deleteAll($criteria));
+    }
+
+    public function testGetListUsesTitleMapping(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $comment = new XoopsComment();
+        $comment->setVar('com_id', 2);
+        $comment->setVar('com_title', 'Comment title');
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with(null, true)
+            ->willReturn([
+                2 => $comment,
+            ]);
+
+        $this->assertSame([2 => 'Comment title'], $handler->getList());
+    }
+
+    public function testGetByItemIdDelegatesToGetObjects(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class))
+            ->willReturn(['result']);
+
+        $this->assertSame(['result'], $handler->getByItemId(1, 2, 'ASC', 3, 5, 0));
+    }
+
+    public function testGetCountByItemIdDelegatesToGetCount(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getCount'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getCount')
+            ->with($this->isInstanceOf(CriteriaCompo::class))
+            ->willReturn(6);
+
+        $this->assertSame(6, $handler->getCountByItemId(1, 2, 0));
+    }
+
+    public function testGetTopCommentsDelegatesToGetObjects(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class))
+            ->willReturn(['top']);
+
+        $this->assertSame(['top'], $handler->getTopComments(1, 2, 'DESC', 0));
+    }
+
+    public function testGetThreadDelegatesToGetObjects(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class))
+            ->willReturn(['thread']);
+
+        $this->assertSame(['thread'], $handler->getThread(1, 2, 0));
+    }
+
+    public function testUpdateByFieldMarksCommentDirtyAndInserts(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['insert'])
+            ->getMock();
+
+        $comment = new XoopsComment();
+        $comment->unsetNew();
+        $comment->setVar('com_title', 'before');
+
+        $handler->expects($this->once())
+            ->method('insert')
+            ->with($this->isInstanceOf(XoopsComment::class))
+            ->willReturn(true);
+
+        $this->assertTrue($handler->updateByField($comment, 'com_title', 'after'));
+        $this->assertSame('after', $comment->getVar('com_title'));
+        $this->assertTrue($comment->isDirty());
+    }
+
+    public function testDeleteByModuleUsesDeleteAll(): void
+    {
+        $handler = $this->getMockBuilder(XoopsCommentHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['deleteAll'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('deleteAll')
+            ->with($this->isInstanceOf(Criteria::class))
+            ->willReturn(true);
+
+        $this->assertTrue($handler->deleteByModule(3));
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'error',
+                'fetchRow',
+                'quote',
+                'genId',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsCommentsTest.php
+++ b/tests/unit/XoopsCommentsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopscomments.php';
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static $connection;
+
+        public static function getDatabaseConnection()
+        {
+            return static::$connection;
+        }
+    }
+}
+
+if (!class_exists('XoopsLogger')) {
+    class XoopsLogger
+    {
+        public function addDeprecated($message): void {}
+    }
+}
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'http://example.com');
+}
+
+if (!defined('_DB_QUERY_ERROR')) {
+    define('_DB_QUERY_ERROR', 'Query error: %s');
+}
+
+$GLOBALS['xoopsLogger'] = new XoopsLogger();
+$GLOBALS['xoopsConfig']['language'] = 'english';
+$GLOBALS['xoopsConfig']['anonymous'] = 'anon';
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return null;
+    }
+}
+
+class FakeCommentsDb
+{
+    public array $queries = [];
+    public array $executions = [];
+    public array $rows = [];
+    public $resultSet = true;
+    public $rowsNum = 1;
+    public $genIdValue = 0;
+    public $insertId = 0;
+
+    public function query($sql)
+    {
+        $this->queries[] = $sql;
+        return 'result';
+    }
+
+    public function isResultSet($result)
+    {
+        return $this->resultSet;
+    }
+
+    public function fetchArray($result)
+    {
+        return array_shift($this->rows);
+    }
+
+    public function exec($sql)
+    {
+        $this->executions[] = $sql;
+        return true;
+    }
+
+    public function genId($seq)
+    {
+        return $this->genIdValue;
+    }
+
+    public function getInsertId()
+    {
+        return $this->insertId;
+    }
+
+    public function prefix($table)
+    {
+        return 'pref_' . $table;
+    }
+
+    public function error()
+    {
+        return 'db error';
+    }
+}
+
+class XoopsCommentsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->db = new FakeCommentsDb();
+        XoopsDatabaseFactory::$connection = $this->db;
+    }
+
+    public function testConstructorInitializesVariables(): void
+    {
+        $comment = new XoopsComments('pref_table');
+
+        $this->assertSame('pref_table', $comment->ctable);
+        $this->assertNull($comment->getVar('comment_id'));
+        $this->assertSame(0, $comment->getVar('pid'));
+        $this->assertSame(1, $comment->getVar('nohtml'));
+    }
+
+    public function testLoadAssignsFetchedValues(): void
+    {
+        $this->db->rows[] = [
+            'comment_id' => 5,
+            'subject'    => 'Loaded',
+        ];
+        $comment = new XoopsComments('pref_table');
+        $comment->load(5);
+
+        $this->assertSame('Loaded', $comment->getVar('subject'));
+        $this->assertSame('SELECT * FROM pref_table WHERE comment_id=5', $this->db->queries[0]);
+    }
+
+    public function testStoreInsertsNewCommentWhenNoId(): void
+    {
+        $this->db->genIdValue = 0;
+        $this->db->insertId   = 22;
+
+        $comment = new XoopsComments('pref_table');
+        $comment->setVar('pid', 0);
+        $comment->setVar('item_id', 1);
+        $comment->setVar('subject', 'Subject');
+        $comment->setVar('comment', 'Body');
+        $comment->setVar('user_id', 7);
+        $comment->setVar('ip', '127.0.0.1');
+        $comment->setVar('nohtml', 0);
+        $comment->setVar('nosmiley', 1);
+        $comment->setVar('noxcode', 0);
+        $comment->setVar('icon', 'icon.gif');
+
+        $result = $comment->store();
+
+        $this->assertSame(22, $result);
+        $this->assertStringContainsString('INSERT INTO pref_table', $this->db->executions[0]);
+    }
+
+    public function testStoreUpdatesExistingComment(): void
+    {
+        $comment = new XoopsComments('pref_table');
+        $comment->setVar('comment_id', 9);
+        $comment->setVar('comment', 'Updated');
+        $comment->setVar('subject', 'Title');
+        $comment->setVar('nohtml', 1);
+        $comment->setVar('nosmiley', 0);
+        $comment->setVar('noxcode', 1);
+        $comment->setVar('icon', 'ico.gif');
+
+        $result = $comment->store();
+
+        $this->assertSame(9, $result);
+        $this->assertStringContainsString('UPDATE pref_table', $this->db->executions[0]);
+    }
+}

--- a/tests/unit/XoopsConfigCategoryTest.php
+++ b/tests/unit/XoopsConfigCategoryTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/configcategory.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsConfigCategoryTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $category = new XoopsConfigCategory();
+
+        $this->assertNull($category->getVar('confcat_id'));
+        $this->assertNull($category->getVar('confcat_name'));
+        $this->assertSame(0, $category->getVar('confcat_order'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $category = new XoopsConfigCategory();
+        $category->setVar('confcat_id', 4);
+        $category->setVar('confcat_name', 'general');
+        $category->setVar('confcat_order', 9);
+
+        $this->assertSame(4, $category->id());
+        $this->assertSame(4, $category->confcat_id());
+        $this->assertSame('general', $category->confcat_name());
+        $this->assertSame(9, $category->confcat_order());
+    }
+}
+
+class XoopsConfigCategoryHandlerTest extends TestCase
+{
+    public function testCreateReturnsNewOrExistingCategory(): void
+    {
+        $handler = new XoopsConfigCategoryHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsConfigCategory::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesCategoryFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_configcategory WHERE confcat_id=2')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'confcat_id'    => 2,
+            'confcat_name'  => 'General',
+            'confcat_order' => 1,
+        ]);
+
+        $handler  = new XoopsConfigCategoryHandler($database);
+        $category = $handler->get(2);
+
+        $this->assertInstanceOf(XoopsConfigCategory::class, $category);
+        $this->assertSame('General', $category->getVar('confcat_name'));
+        $this->assertFalse($category->isNew());
+    }
+
+    public function testInsertCreatesNewCategory(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(10);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(static function ($sql) {
+                return strpos($sql, 'INSERT INTO pref_configcategory') !== false
+                    && strpos($sql, "'Mail'") !== false
+                    && strpos($sql, '4') !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsConfigCategoryHandler($database);
+
+        $category = $handler->create();
+        $category->setVar('confcat_name', 'Mail');
+        $category->setVar('confcat_order', 4);
+
+        $this->assertSame(10, $handler->insert($category));
+        $this->assertSame(10, $category->getVar('confcat_id'));
+    }
+
+    public function testInsertUpdatesExistingCategory(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_configcategory SET confcat_name ='))
+            ->willReturn(true);
+
+        $handler = new XoopsConfigCategoryHandler($database);
+
+        $category = $handler->create(false);
+        $category->setNew(false);
+        $category->setVar('confcat_id', 3);
+        $category->setVar('confcat_name', 'Updated');
+        $category->setVar('confcat_order', 2);
+
+        $this->assertSame(3, $handler->insert($category));
+    }
+
+    public function testDeleteRemovesCategory(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_configcategory WHERE confcat_id = 5')
+            ->willReturn(true);
+
+        $handler = new XoopsConfigCategoryHandler($database);
+
+        $category = $handler->create(false);
+        $category->setVar('confcat_id', 5);
+
+        $this->assertTrue($handler->delete($category));
+    }
+
+    public function testGetObjectsReturnsCategoriesUsingCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_configcategory WHERE (confcat_order > 2) ORDER BY confcat_name DESC', 5, 1)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'confcat_id'    => 6,
+                'confcat_name'  => 'Display',
+                'confcat_order' => 3,
+            ],
+            [
+                'confcat_id'    => 7,
+                'confcat_name'  => 'Mail',
+                'confcat_order' => 4,
+            ],
+            false
+        );
+
+        $handler  = new XoopsConfigCategoryHandler($database);
+        $criteria = new Criteria('confcat_order', 2, '>');
+        $criteria->setSort('confcat_name');
+        $criteria->setOrder('DESC');
+        $criteria->setLimit(5);
+        $criteria->setStart(1);
+
+        $categories = $handler->getObjects($criteria);
+
+        $this->assertCount(2, $categories);
+        $this->assertSame('Display', $categories[0]->getVar('confcat_name'));
+        $this->assertSame('Mail', $categories[1]->getVar('confcat_name'));
+    }
+
+    public function testGetCatByModuleLogsDeprecated(): void
+    {
+        $logger = new class {
+            public array $messages = [];
+
+            public function addDeprecated($message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+
+        $previousLogger       = $GLOBALS['xoopsLogger'] ?? null;
+        $GLOBALS['xoopsLogger'] = $logger;
+
+        try {
+            $handler = new XoopsConfigCategoryHandler($this->createDatabaseMock());
+
+            $this->assertFalse($handler->getCatByModule(1));
+            $this->assertNotEmpty($logger->messages);
+            $this->assertStringContainsString('deprecated', $logger->messages[0]);
+        } finally {
+            $GLOBALS['xoopsLogger'] = $previousLogger;
+        }
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'quote',
+                'genId',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsConfigHandlerTest.php
+++ b/tests/unit/XoopsConfigHandlerTest.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/config.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsConfigHandlerTest extends TestCase
+{
+    public function testConstructorInitializesItemAndOptionHandlers(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $this->assertInstanceOf(XoopsConfigItemHandler::class, $handler->_cHandler);
+        $this->assertInstanceOf(XoopsConfigOptionHandler::class, $handler->_oHandler);
+    }
+
+    public function testCreateConfigUsesConfigItemHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+
+        $handler->_cHandler->expects($this->once())
+            ->method('create')
+            ->willReturn('created');
+
+        $this->assertSame('created', $handler->createConfig());
+    }
+
+    public function testGetConfigLoadsOptionsWhenRequested(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $config = new XoopsConfigItem();
+        $config->setVar('conf_id', 99);
+
+        $option = new XoopsConfigOption();
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $handler->_cHandler->method('get')->with(99)->willReturn($config);
+
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(Criteria::class), false)
+            ->willReturn([$option]);
+
+        $result = $handler->getConfig(99, true);
+
+        $this->assertSame($config, $result);
+        $this->assertSame([$option], $result->getConfOptions());
+    }
+
+    public function testInsertConfigInsertsOptionsAndClearsCache(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $config = new XoopsConfigItem();
+        $config->setVar('conf_id', 7);
+        $config->setVar('conf_modid', 12);
+        $config->setVar('conf_catid', 3);
+
+        $option = new XoopsConfigOption();
+        $config->setConfOptions([$option]);
+
+        $handler->_cachedConfigs[12][3] = ['cached' => 'value'];
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['insert'])
+            ->getMock();
+        $handler->_cHandler->expects($this->once())
+            ->method('insert')
+            ->with($config)
+            ->willReturn(true);
+
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['insert'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('insert')
+            ->with($this->isInstanceOf(XoopsConfigOption::class))
+            ->willReturn(true);
+
+        $this->assertTrue($handler->insertConfig($config));
+        $this->assertSame(7, $option->getVar('conf_id'));
+        $this->assertArrayNotHasKey(3, $handler->_cachedConfigs[12] ?? []);
+    }
+
+    public function testDeleteConfigRemovesOptionsAndClearsCache(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $config = new XoopsConfigItem();
+        $config->setVar('conf_id', 15);
+        $config->setVar('conf_modid', 2);
+        $config->setVar('conf_catid', 1);
+
+        $option = new XoopsConfigOption();
+        $option->setVar('confop_id', 3);
+        $config->setConfOptions([$option]);
+
+        $handler->_cachedConfigs[2][1] = ['preset'];
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['delete'])
+            ->getMock();
+        $handler->_cHandler->expects($this->once())
+            ->method('delete')
+            ->with($config)
+            ->willReturn(true);
+
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['delete'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('delete')
+            ->with($option)
+            ->willReturn(true);
+
+        $this->assertTrue($handler->deleteConfig($config));
+        $this->assertArrayNotHasKey(1, $handler->_cachedConfigs[2] ?? []);
+    }
+
+    public function testGetConfigsDelegatesToConfigHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $criteria = new Criteria('conf_modid', 1);
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+        $handler->_cHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($criteria, true)
+            ->willReturn(['objects']);
+
+        $this->assertSame(['objects'], $handler->getConfigs($criteria, true, true));
+    }
+
+    public function testGetConfigCountDelegatesToConfigHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+        $criteria = new Criteria('conf_id', 1);
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getCount'])
+            ->getMock();
+        $handler->_cHandler->expects($this->once())
+            ->method('getCount')
+            ->with($criteria)
+            ->willReturn(4);
+
+        $this->assertSame(4, $handler->getConfigCount($criteria));
+    }
+
+    public function testGetConfigsByCatBuildsCachedList(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $config = new XoopsConfigItem();
+        $config->setVar('conf_name', 'site_name');
+        $config->setVar('conf_valuetype', 'text');
+        $config->setVar('conf_value', 'XOOPS');
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+        $handler->_cHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class), true)
+            ->willReturn([1 => $config]);
+
+        $first = $handler->getConfigsByCat(5, 8);
+        $second = $handler->getConfigsByCat(5, 8);
+
+        $this->assertSame(['site_name' => 'XOOPS'], $first);
+        $this->assertSame($first, $second);
+    }
+
+    public function testCreateConfigOptionUsesOptionHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('create')
+            ->willReturn('option');
+
+        $this->assertSame('option', $handler->createConfigOption());
+    }
+
+    public function testGetConfigOptionUsesOptionHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('get')
+            ->with(4)
+            ->willReturn('opt');
+
+        $this->assertSame('opt', $handler->getConfigOption(4));
+    }
+
+    public function testGetConfigOptionsDelegatesToOptionHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+        $criteria = new Criteria('conf_id', 2);
+
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($criteria, true)
+            ->willReturn(['opts']);
+
+        $this->assertSame(['opts'], $handler->getConfigOptions($criteria, true));
+    }
+
+    public function testGetConfigOptionsCountDelegatesToOptionHandler(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+        $criteria = new Criteria('conf_id', 2);
+
+        $handler->_oHandler = $this->getMockBuilder(XoopsConfigOptionHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getCount'])
+            ->getMock();
+        $handler->_oHandler->expects($this->once())
+            ->method('getCount')
+            ->with($criteria)
+            ->willReturn(9);
+
+        $this->assertSame(9, $handler->getConfigOptionsCount($criteria));
+    }
+
+    public function testGetConfigListCachesResult(): void
+    {
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $config = new XoopsConfigItem();
+        $config->setVar('conf_name', 'theme');
+        $config->setVar('conf_valuetype', 'text');
+        $config->setVar('conf_value', 'default');
+
+        $handler->_cHandler = $this->getMockBuilder(XoopsConfigItemHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+        $handler->_cHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class))
+            ->willReturn([$config]);
+
+        $first = $handler->getConfigList(22, 0);
+        $second = $handler->getConfigList(22, 0);
+
+        $this->assertSame(['theme' => 'default'], $first);
+        $this->assertSame($first, $second);
+    }
+
+    public function testDeleteConfigOptionReturnsFalseAndLogsDeprecation(): void
+    {
+        $previousLogger = $GLOBALS['xoopsLogger'] ?? null;
+        $messages       = [];
+        $GLOBALS['xoopsLogger'] = new class {
+            public array $messages = [];
+
+            public function addDeprecated($message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+        $GLOBALS['xoopsLogger']->messages =& $messages;
+
+        $handler = new XoopsConfigHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->deleteConfigOption($this->createMock(Criteria::class)));
+        $this->assertNotEmpty($messages);
+
+        $GLOBALS['xoopsLogger'] = $previousLogger;
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'error',
+                'fetchRow',
+                'quote',
+                'genId',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsConfigItemTest.php
+++ b/tests/unit/XoopsConfigItemTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/configitem.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsConfigItemTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $config = new XoopsConfigItem();
+
+        $this->assertNull($config->getVar('conf_id'));
+        $this->assertNull($config->getVar('conf_modid'));
+        $this->assertNull($config->getVar('conf_catid'));
+        $this->assertNull($config->getVar('conf_name'));
+        $this->assertNull($config->getVar('conf_title'));
+        $this->assertNull($config->getVar('conf_value'));
+        $this->assertNull($config->getVar('conf_desc'));
+        $this->assertNull($config->getVar('conf_formtype'));
+        $this->assertNull($config->getVar('conf_valuetype'));
+        $this->assertSame(0, $config->getVar('conf_order'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $config = new XoopsConfigItem();
+        $config->setVar('conf_id', 11);
+        $config->setVar('conf_modid', 22);
+        $config->setVar('conf_catid', 33);
+        $config->setVar('conf_name', 'sitename');
+        $config->setVar('conf_title', 'Site Name');
+        $config->setVar('conf_value', 'XOOPS');
+        $config->setVar('conf_desc', 'Description');
+        $config->setVar('conf_formtype', 'textbox');
+        $config->setVar('conf_valuetype', 'text');
+        $config->setVar('conf_order', 44);
+
+        $this->assertSame(11, $config->id());
+        $this->assertSame(11, $config->conf_id());
+        $this->assertSame(22, $config->conf_modid());
+        $this->assertSame(33, $config->conf_catid());
+        $this->assertSame('sitename', $config->conf_name());
+        $this->assertSame('Site Name', $config->conf_title());
+        $this->assertSame('XOOPS', $config->conf_value());
+        $this->assertSame('Description', $config->conf_desc());
+        $this->assertSame('textbox', $config->conf_formtype());
+        $this->assertSame('text', $config->conf_valuetype());
+        $this->assertSame(44, $config->conf_order());
+    }
+
+    public function testGetConfValueForOutputCastsTypes(): void
+    {
+        $config = new XoopsConfigItem();
+
+        $config->setVar('conf_valuetype', 'int');
+        $config->setVar('conf_value', '7');
+        $this->assertSame(7, $config->getConfValueForOutput());
+
+        $config->setVar('conf_valuetype', 'array');
+        $config->setVar('conf_value', serialize(['one' => 1]));
+        $this->assertSame(['one' => 1], $config->getConfValueForOutput());
+
+        $config->setVar('conf_valuetype', 'array');
+        $config->setVar('conf_value', 'not-serialized');
+        $this->assertSame([], $config->getConfValueForOutput());
+
+        $config->setVar('conf_valuetype', 'float');
+        $config->setVar('conf_value', '3.25');
+        $this->assertSame(3.25, $config->getConfValueForOutput());
+
+        $config->setVar('conf_valuetype', 'textarea');
+        $config->setVar('conf_value', "multi\nline");
+        $this->assertSame("multi\nline", $config->getConfValueForOutput());
+
+        $config->setVar('conf_valuetype', 'text');
+        $config->setVar('conf_value', 'raw');
+        $this->assertSame('raw', $config->getConfValueForOutput());
+    }
+
+    public function testSetConfValueForInputStoresExpectedRepresentation(): void
+    {
+        $config = new XoopsConfigItem();
+
+        $config->setVar('conf_valuetype', 'array');
+        $value = 'a|b|c';
+        $config->setConfValueForInput($value);
+        $this->assertSame(serialize(['a', 'b', 'c']), $config->getVar('conf_value', 'n'));
+
+        $config->setVar('conf_valuetype', 'text');
+        $value = '  trimmed  ';
+        $config->setConfValueForInput($value);
+        $this->assertSame('trimmed', $config->getVar('conf_value', 'n'));
+
+        $config->setVar('conf_valuetype', 'other');
+        $value = 'kept';
+        $config->setConfValueForInput($value);
+        $this->assertSame('kept', $config->getVar('conf_value', 'n'));
+    }
+
+    public function testConfOptionsCanBeManaged(): void
+    {
+        $config  = new XoopsConfigItem();
+        $option1 = new stdClass();
+        $option2 = new stdClass();
+
+        $config->setConfOptions([$option1, $option2]);
+        $options = $config->getConfOptions();
+
+        $this->assertSame([$option1, $option2], $options);
+
+        $config->clearConfOptions();
+        $this->assertSame([], $config->getConfOptions());
+    }
+}
+
+class XoopsConfigItemHandlerTest extends TestCase
+{
+    public function testCreateReturnsNewOrExistingItem(): void
+    {
+        $handler = new XoopsConfigItemHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsConfigItem::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesItemFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_config WHERE conf_id=12')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'conf_id'       => 12,
+            'conf_modid'    => 1,
+            'conf_catid'    => 2,
+            'conf_name'     => 'theme',
+            'conf_title'    => 'Theme',
+            'conf_value'    => 'default',
+            'conf_desc'     => 'desc',
+            'conf_formtype' => 'select',
+            'conf_valuetype'=> 'text',
+            'conf_order'    => 3,
+        ]);
+
+        $handler = new XoopsConfigItemHandler($database);
+
+        $item = $handler->get(12);
+
+        $this->assertInstanceOf(XoopsConfigItem::class, $item);
+        $this->assertSame('theme', $item->getVar('conf_name'));
+        $this->assertFalse($item->isNew());
+    }
+
+    public function testInsertCreatesNewItem(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(9);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(static function ($sql) {
+                return strpos($sql, 'INSERT INTO pref_config') !== false
+                    && strpos($sql, "'sitename'") !== false
+                    && strpos($sql, "'Site Name'") !== false
+                    && strpos($sql, "'text'") !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsConfigItemHandler($database);
+
+        $item = $handler->create();
+        $item->setVar('conf_modid', 1);
+        $item->setVar('conf_catid', 2);
+        $item->setVar('conf_name', 'sitename');
+        $item->setVar('conf_title', 'Site Name');
+        $item->setVar('conf_value', 'XOOPS');
+        $item->setVar('conf_desc', 'description');
+        $item->setVar('conf_formtype', 'textbox');
+        $item->setVar('conf_valuetype', 'text');
+        $item->setVar('conf_order', 4);
+
+        $this->assertTrue($handler->insert($item));
+        $this->assertSame(9, $item->getVar('conf_id'));
+    }
+
+    public function testInsertUpdatesExistingItem(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_config SET conf_modid ='))
+            ->willReturn(true);
+
+        $handler = new XoopsConfigItemHandler($database);
+
+        $item = $handler->create(false);
+        $item->setNew(false);
+        $item->setVar('conf_id', 4);
+        $item->setVar('conf_modid', 1);
+        $item->setVar('conf_catid', 2);
+        $item->setVar('conf_name', 'updated');
+        $item->setVar('conf_title', 'Updated');
+        $item->setVar('conf_value', 'value');
+        $item->setVar('conf_desc', 'desc');
+        $item->setVar('conf_formtype', 'textbox');
+        $item->setVar('conf_valuetype', 'text');
+        $item->setVar('conf_order', 5);
+
+        $this->assertTrue($handler->insert($item));
+    }
+
+    public function testDeleteRemovesItem(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_config WHERE conf_id = 8')
+            ->willReturn(true);
+
+        $handler = new XoopsConfigItemHandler($database);
+
+        $item = $handler->create(false);
+        $item->setVar('conf_id', 8);
+
+        $this->assertTrue($handler->delete($item));
+    }
+
+    public function testGetObjectsReturnsItemsUsingCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_config WHERE (conf_order > 1) ORDER BY conf_order ASC', 3, 0)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'conf_id'       => 1,
+                'conf_modid'    => 1,
+                'conf_catid'    => 1,
+                'conf_name'     => 'first',
+                'conf_title'    => 'First',
+                'conf_value'    => 'one',
+                'conf_desc'     => 'desc',
+                'conf_formtype' => 'textbox',
+                'conf_valuetype'=> 'text',
+                'conf_order'    => 2,
+            ],
+            [
+                'conf_id'       => 2,
+                'conf_modid'    => 1,
+                'conf_catid'    => 1,
+                'conf_name'     => 'second',
+                'conf_title'    => 'Second',
+                'conf_value'    => 'two',
+                'conf_desc'     => 'desc',
+                'conf_formtype' => 'textbox',
+                'conf_valuetype'=> 'text',
+                'conf_order'    => 3,
+            ],
+            false
+        );
+
+        $handler  = new XoopsConfigItemHandler($database);
+        $criteria = new Criteria('conf_order', 1, '>');
+        $criteria->setOrder('ASC');
+        $criteria->setLimit(3);
+
+        $items = $handler->getObjects($criteria);
+
+        $this->assertCount(2, $items);
+        $this->assertSame('first', $items[0]->getVar('conf_name'));
+        $this->assertSame('second', $items[1]->getVar('conf_name'));
+    }
+
+    public function testGetCountReturnsNumberOfRows(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_config WHERE (conf_modid = 1)')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([5]);
+
+        $handler  = new XoopsConfigItemHandler($database);
+        $criteria = new Criteria('conf_modid', 1);
+
+        $this->assertSame(5, $handler->getCount($criteria));
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'quote',
+                'genId',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsConfigOptionTest.php
+++ b/tests/unit/XoopsConfigOptionTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/configoption.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsConfigOptionTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $option = new XoopsConfigOption();
+
+        $this->assertNull($option->getVar('confop_id'));
+        $this->assertNull($option->getVar('confop_name'));
+        $this->assertNull($option->getVar('confop_value'));
+        $this->assertSame(0, $option->getVar('conf_id'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $option = new XoopsConfigOption();
+        $option->setVar('confop_id', 9);
+        $option->setVar('confop_name', 'option_name');
+        $option->setVar('confop_value', 'value');
+        $option->setVar('conf_id', 3);
+
+        $this->assertSame(9, $option->id());
+        $this->assertSame(9, $option->confop_id());
+        $this->assertSame('option_name', $option->confop_name());
+        $this->assertSame('value', $option->confop_value());
+        $this->assertSame(3, $option->conf_id());
+    }
+}
+
+class XoopsConfigOptionHandlerTest extends TestCase
+{
+    public function testCreateReturnsNewOrExistingOption(): void
+    {
+        $handler = new XoopsConfigOptionHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsConfigOption::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesOptionFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_configoption WHERE confop_id=7')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'confop_id'    => 7,
+            'confop_name'  => 'name',
+            'confop_value' => 'val',
+            'conf_id'      => 2,
+        ]);
+
+        $handler = new XoopsConfigOptionHandler($database);
+
+        $option = $handler->get(7);
+
+        $this->assertInstanceOf(XoopsConfigOption::class, $option);
+        $this->assertSame('name', $option->getVar('confop_name'));
+        $this->assertFalse($option->isNew());
+    }
+
+    public function testInsertCreatesNewOption(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(12);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(static function ($sql) {
+                return strpos($sql, 'INSERT INTO pref_configoption') !== false
+                    && strpos($sql, "'name'") !== false
+                    && strpos($sql, "'value'") !== false
+                    && strpos($sql, '3') !== false;
+            }))
+            ->willReturn(true);
+
+        $handler = new XoopsConfigOptionHandler($database);
+
+        $option = $handler->create();
+        $option->setVar('confop_name', 'name');
+        $option->setVar('confop_value', 'value');
+        $option->setVar('conf_id', 3);
+
+        $this->assertSame(12, $handler->insert($option));
+        $this->assertSame(12, $option->getVar('confop_id'));
+    }
+
+    public function testInsertUpdatesExistingOption(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_configoption SET confop_name ='))
+            ->willReturn(true);
+
+        $handler = new XoopsConfigOptionHandler($database);
+
+        $option = $handler->create(false);
+        $option->setNew(false);
+        $option->setVar('confop_id', 4);
+        $option->setVar('confop_name', 'updated');
+        $option->setVar('confop_value', 'changed');
+        $option->setVar('conf_id', 1);
+
+        $this->assertSame(4, $handler->insert($option));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsConfigOptionHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesOption(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_configoption WHERE confop_id = 8')
+            ->willReturn(true);
+
+        $handler = new XoopsConfigOptionHandler($database);
+
+        $option = $handler->create(false);
+        $option->setVar('confop_id', 8);
+
+        $this->assertTrue($handler->delete($option));
+    }
+
+    public function testGetObjectsReturnsOptionsUsingCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_configoption WHERE (conf_id = 2) ORDER BY confop_id ASC', 5, 0)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'confop_id'    => 1,
+                'confop_name'  => 'first',
+                'confop_value' => 'one',
+                'conf_id'      => 2,
+            ],
+            [
+                'confop_id'    => 2,
+                'confop_name'  => 'second',
+                'confop_value' => 'two',
+                'conf_id'      => 2,
+            ],
+            false
+        );
+
+        $handler  = new XoopsConfigOptionHandler($database);
+        $criteria = new Criteria('conf_id', 2);
+        $criteria->setOrder('ASC');
+        $criteria->setLimit(5);
+
+        $options = $handler->getObjects($criteria);
+
+        $this->assertCount(2, $options);
+        $this->assertSame('first', $options[0]->getVar('confop_name'));
+        $this->assertSame('second', $options[1]->getVar('confop_name'));
+    }
+
+    public function testGetCountReturnsNumberOfRows(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(*) as `count` FROM pref_configoption WHERE (conf_id = 5)')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturn(['count' => 4]);
+        $database->expects($this->once())->method('freeRecordSet')->with('result');
+
+        $handler  = new XoopsConfigOptionHandler($database);
+        $criteria = new Criteria('conf_id', 5);
+
+        $this->assertSame(4, $handler->getCount($criteria));
+    }
+
+    public function testGetCountThrowsRuntimeExceptionWhenQueryFails(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_configoption');
+        $database->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(false);
+        $database->method('error')->willReturn('db error');
+
+        $handler = new XoopsConfigOptionHandler($database);
+
+        $this->expectException(RuntimeException::class);
+        $handler->getCount();
+    }
+
+    private function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'genId',
+                'getInsertId',
+                'quote',
+                'freeRecordSet',
+                'error',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsDatabaseFactoryTest.php
+++ b/tests/unit/XoopsDatabaseFactoryTest.php
@@ -1,0 +1,160 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('XoopsPreload', false)) {
+    class XoopsPreload
+    {
+        public array $events = [];
+        private static $instance;
+
+        public static function getInstance()
+        {
+            if (!isset(self::$instance)) {
+                self::$instance = new self();
+            }
+            return self::$instance;
+        }
+
+        public function triggerEvent($name, $args)
+        {
+            $this->events[] = [$name, $args];
+        }
+    }
+}
+
+if (!class_exists('XoopsLogger', false)) {
+    class XoopsLogger
+    {
+        public static $instance;
+
+        public static function getInstance()
+        {
+            if (!isset(self::$instance)) {
+                self::$instance = new self();
+            }
+            return self::$instance;
+        }
+    }
+}
+
+if (!class_exists('XoopsmysqlDatabaseBase', false)) {
+    class XoopsmysqlDatabaseBase
+    {
+        public static $shouldConnect = true;
+        public $logger;
+        public $prefix;
+        public $connected = false;
+
+        public function setLogger($logger)
+        {
+            $this->logger = $logger;
+        }
+
+        public function setPrefix($prefix)
+        {
+            $this->prefix = $prefix;
+        }
+
+        public function connect()
+        {
+            $this->connected = true;
+            return static::$shouldConnect;
+        }
+    }
+}
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class XoopsDatabaseFactoryTest extends TestCase
+{
+    private string $rootPath;
+
+    protected function setUp(): void
+    {
+        $this->rootPath = sys_get_temp_dir() . '/xoops_db_factory_' . uniqid();
+        mkdir($this->rootPath . '/class/database', 0777, true);
+        if (!defined('XOOPS_ROOT_PATH')) {
+            define('XOOPS_ROOT_PATH', $this->rootPath);
+        }
+        if (!defined('XOOPS_DB_TYPE')) {
+            define('XOOPS_DB_TYPE', 'mysql');
+        }
+        if (!defined('XOOPS_DB_PREFIX')) {
+            define('XOOPS_DB_PREFIX', 'xoops');
+        }
+        $this->createStubDatabaseFile();
+        require_once dirname(__DIR__, 2) . '/htdocs/class/database/databasefactory.php';
+    }
+
+    private function createStubDatabaseFile(): void
+    {
+        $file = $this->rootPath . '/class/database/' . XOOPS_DB_TYPE . 'database.php';
+        $contents = <<<'PHP'
+<?php
+class XoopsmysqlDatabaseSafe extends XoopsmysqlDatabaseBase {}
+class XoopsmysqlDatabaseProxy extends XoopsmysqlDatabaseBase {}
+PHP;
+        file_put_contents($file, $contents);
+    }
+
+    public function testGetDatabaseConnectionCreatesAndConnects(): void
+    {
+        $db = XoopsDatabaseFactory::getDatabaseConnection();
+
+        $this->assertInstanceOf(XoopsmysqlDatabaseBase::class, $db);
+        $this->assertTrue($db->connected);
+        $this->assertSame(XoopsLogger::getInstance(), $db->logger);
+        $this->assertSame('xoops', $db->prefix);
+
+        $events = XoopsPreload::getInstance()->events;
+        $this->assertCount(1, $events);
+        $this->assertSame('core.class.database.databasefactory.connection', $events[0][0]);
+        $this->assertSame('XoopsmysqlDatabaseSafe', $events[0][1][0]);
+    }
+
+    public function testGetDatabaseConnectionThrowsOnFailedConnect(): void
+    {
+        XoopsmysqlDatabaseBase::$shouldConnect = false;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to connect to database');
+
+        XoopsDatabaseFactory::getDatabaseConnection();
+    }
+
+    public function testGetDatabaseConnectionWarnsWhenFileMissing(): void
+    {
+        unlink($this->rootPath . '/class/database/' . XOOPS_DB_TYPE . 'database.php');
+
+        $message = null;
+        set_error_handler(static function ($errno, $errstr) use (&$message) {
+            $message = $errstr;
+            return true;
+        });
+        $db = XoopsDatabaseFactory::getDatabaseConnection();
+        restore_error_handler();
+
+        $this->assertNull($db);
+        $this->assertStringContainsString('Failed to load database of type: mysql', $message);
+    }
+
+    public function testGetDatabaseReturnsDatabaseInstance(): void
+    {
+        $db = XoopsDatabaseFactory::getDatabase();
+
+        $this->assertInstanceOf(XoopsmysqlDatabaseBase::class, $db);
+        $this->assertFalse($db->connected);
+        $this->assertSame($db, XoopsDatabaseFactory::getDatabase());
+    }
+
+    public function testGetDatabaseUsesProxyWhenDefined(): void
+    {
+        define('XOOPS_DB_PROXY', true);
+
+        $db = XoopsDatabaseFactory::getDatabase();
+
+        $this->assertInstanceOf(XoopsmysqlDatabaseProxy::class, $db);
+    }
+}

--- a/tests/unit/XoopsDownloaderTest.php
+++ b/tests/unit/XoopsDownloaderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/downloader.php';
+
+class XoopsDownloaderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (function_exists('header_remove')) {
+            header_remove();
+        }
+    }
+
+    public function testConstructorLeavesPropertiesNull(): void
+    {
+        $downloader = new XoopsDownloader();
+
+        $this->assertNull($downloader->mimetype);
+        $this->assertNull($downloader->ext);
+        $this->assertNull($downloader->archiver);
+    }
+
+    public function testHeaderOutputsIeSpecificCachingHeaders(): void
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)';
+        $downloader               = new XoopsDownloader();
+        $downloader->mimetype     = 'text/plain';
+
+        $downloader->_header('example.txt');
+
+        $headers = headers_list();
+        $this->assertContains('Content-Type: text/plain', $headers);
+        $this->assertContains('Content-Disposition: attachment; filename="example.txt"', $headers);
+        $this->assertContains('Expires: 0', $headers);
+        $this->assertContains('Cache-Control: must-revalidate, post-check=0, pre-check=0', $headers);
+        $this->assertContains('Pragma: public', $headers);
+    }
+
+    public function testHeaderOutputsGenericCachingHeadersForNonIe(): void
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'Firefox/120.0';
+        $downloader               = new XoopsDownloader();
+        $downloader->mimetype     = 'application/octet-stream';
+
+        $downloader->_header('binary.bin');
+
+        $headers = headers_list();
+        $this->assertContains('Content-Type: application/octet-stream', $headers);
+        $this->assertContains('Content-Disposition: attachment; filename="binary.bin"', $headers);
+        $this->assertContains('Expires: 0', $headers);
+        $this->assertContains('Pragma: no-cache', $headers);
+    }
+}

--- a/tests/unit/XoopsFilterInputTest.php
+++ b/tests/unit/XoopsFilterInputTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/xoops_lib/vendor/autoload.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsfilterinput.php';
+
+class XoopsFilterInputTest extends TestCase
+{
+    public function testGetInstanceReturnsSubclassSingleton(): void
+    {
+        $instanceOne = XoopsFilterInput::getInstance();
+        $instanceTwo = XoopsFilterInput::getInstance();
+
+        $this->assertInstanceOf(XoopsFilterInput::class, $instanceOne);
+        $this->assertSame($instanceOne, $instanceTwo);
+    }
+
+    public function testGetInstanceSeparatesBySignature(): void
+    {
+        $allowLinks = XoopsFilterInput::getInstance(['a']);
+        $allowImages = XoopsFilterInput::getInstance(['img']);
+
+        $this->assertNotSame($allowLinks, $allowImages);
+    }
+
+    public function testProcessRemovesScriptTags(): void
+    {
+        $filter = XoopsFilterInput::getInstance();
+
+        $this->assertSame('alert(1)ok', $filter->process('<script>alert(1)</script>ok'));
+    }
+
+    public function testCleanCastsToInteger(): void
+    {
+        $this->assertSame(42, XoopsFilterInput::clean('42cats', 'int'));
+    }
+}

--- a/tests/unit/XoopsFolderHandlerTest.php
+++ b/tests/unit/XoopsFolderHandlerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/file/folder.php';
+
+class XoopsFolderHandlerTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->baseDir = sys_get_temp_dir() . '/xoopsfolder_' . uniqid();
+        mkdir($this->baseDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeIfExists($this->baseDir);
+        parent::tearDown();
+    }
+
+    private function removeIfExists(string $path): void
+    {
+        if (is_file($path)) {
+            unlink($path);
+
+            return;
+        }
+        if (is_dir($path)) {
+            $items = scandir($path);
+            if ($items) {
+                foreach ($items as $item) {
+                    if ($item === '.' || $item === '..') {
+                        continue;
+                    }
+                    $this->removeIfExists($path . DIRECTORY_SEPARATOR . $item);
+                }
+            }
+            rmdir($path);
+        }
+    }
+
+    public function testConstructorCreatesDirectoryAndSetsWorkingPath(): void
+    {
+        $target = $this->baseDir . '/created';
+        $this->assertDirectoryDoesNotExist($target);
+
+        $handler = new XoopsFolderHandler($target, true, '0755');
+
+        $this->assertDirectoryExists($target);
+        $this->assertSame(realpath($target), $handler->pwd());
+    }
+
+    public function testReadAndFindReturnsSortedEntries(): void
+    {
+        $dir = $this->baseDir . '/sub';
+        mkdir($dir);
+        file_put_contents($this->baseDir . '/a.txt', '');
+        file_put_contents($this->baseDir . '/b.md', '');
+
+        $handler = new XoopsFolderHandler($this->baseDir, false);
+        [$dirs, $files] = $handler->read(true);
+
+        $this->assertSame(['sub'], $dirs);
+        $this->assertSame(['a.txt', 'b.md'], $files);
+        $this->assertSame(['a.txt'], $handler->find('.*\.txt'));
+    }
+
+    public function testFindRecursiveReturnsFullPathsAndRestoresWorkingDir(): void
+    {
+        $nested = $this->baseDir . '/n1/n2';
+        mkdir($nested, 0777, true);
+        $targetFile = $nested . '/c.txt';
+        file_put_contents($targetFile, 'content');
+
+        $handler = new XoopsFolderHandler($this->baseDir, false);
+        $original = $handler->pwd();
+
+        $results = $handler->findRecursive('.*\.txt', true);
+
+        $this->assertSame([$targetFile], $results);
+        $this->assertSame($original, $handler->pwd());
+    }
+
+    public function testDeleteRemovesDirectoriesAndRecordsMessages(): void
+    {
+        $path = $this->baseDir . '/remove_me';
+        mkdir($path);
+        file_put_contents($path . '/file.txt', 'bye');
+
+        $handler = new XoopsFolderHandler($this->baseDir, false);
+        $this->assertTrue($handler->delete($path));
+
+        $this->assertDirectoryDoesNotExist($path);
+        $this->assertNotEmpty($handler->messages());
+        $this->assertEmpty($handler->errors());
+    }
+}

--- a/tests/unit/XoopsFormElementsExtraTest.php
+++ b/tests/unit/XoopsFormElementsExtraTest.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+if (!defined('_SHORTDATESTRING')) {
+    define('_SHORTDATESTRING', 'Y-m-d');
+}
+
+if (!function_exists('xoops_load')) {
+    function xoops_load($name)
+    {
+        return true;
+    }
+}
+
+if (!class_exists('XoopsLogger')) {
+    class XoopsLogger
+    {
+        public array $deprecated = [];
+
+        public function addDeprecated($message)
+        {
+            $this->deprecated[] = $message;
+        }
+    }
+}
+
+$GLOBALS['xoopsLogger'] = $GLOBALS['xoopsLogger'] ?? new XoopsLogger();
+
+if (!class_exists('DummyRenderer')) {
+    class DummyRenderer
+    {
+        public array $calls = [];
+
+        public function __call($name, $arguments)
+        {
+            $this->calls[] = [$name, $arguments];
+
+            return '<' . $name . '>';
+        }
+    }
+}
+
+if (!class_exists('XoopsFormRenderer')) {
+    class XoopsFormRenderer
+    {
+        private static $instance;
+        private $renderer;
+
+        public function __construct()
+        {
+            $this->renderer = new DummyRenderer();
+        }
+
+        public static function getInstance()
+        {
+            if (!self::$instance) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        public function get()
+        {
+            return $this->renderer;
+        }
+    }
+}
+
+if (!class_exists('XoopsCaptcha')) {
+    class XoopsCaptcha
+    {
+        public array $configs = [];
+        public bool $active = true;
+        public static $instance;
+
+        public static function getInstance()
+        {
+            if (!self::$instance) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        public function setConfigs(array $configs)
+        {
+            $this->configs = $configs + $this->configs;
+        }
+
+        public function setConfig($name, $val)
+        {
+            $this->configs[$name] = $val;
+
+            return $val;
+        }
+
+        public function isActive()
+        {
+            return $this->active;
+        }
+
+        public function getCaption()
+        {
+            return 'captcha-caption';
+        }
+
+        public function render()
+        {
+            return '[captcha]';
+        }
+
+        public function renderValidationJS()
+        {
+            return 'validate-captcha';
+        }
+    }
+}
+
+if (!class_exists('XoopsEditorHandler')) {
+    class XoopsEditorHandler
+    {
+        public static $instance;
+
+        public static function getInstance()
+        {
+            if (!self::$instance) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        public function get($name, $options = [], $nohtml = false, $OnFailure = '')
+        {
+            return new class($name, $options) {
+                public $name;
+                public $options;
+                public bool $_required = false;
+                public string $caption = '';
+
+                public function __construct($name, $options)
+                {
+                    $this->name    = $name;
+                    $this->options = $options;
+                }
+
+                public function renderValidationJS()
+                {
+                    return 'editor-validation';
+                }
+
+                public function setName($name)
+                {
+                    $this->name = $name;
+                }
+
+                public function setCaption($caption)
+                {
+                    $this->caption = $caption;
+                }
+            };
+        }
+    }
+}
+
+if (!class_exists('XoopsLists')) {
+    class XoopsLists
+    {
+        public static function getCountryList()
+        {
+            return ['US' => 'United States', 'CA' => 'Canada'];
+        }
+
+        public static function getTimeZoneList()
+        {
+            return ['UTC' => 'UTC'];
+        }
+
+        public static function getThemesList()
+        {
+            return ['default' => 'Default'];
+        }
+    }
+}
+
+if (!class_exists('XoopsCache')) {
+    class XoopsCache
+    {
+        public static function read($key)
+        {
+            return [1 => 'CachedUser'];
+        }
+
+        public static function write($key, $value, $ttl)
+        {
+            return true;
+        }
+    }
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        if ($name === 'member') {
+            return new class {
+                public function getUserList($criteria)
+                {
+                    return [2 => 'SelectedUser'];
+                }
+
+                public function getUserCount()
+                {
+                    return 1;
+                }
+            };
+        }
+
+        return null;
+    }
+}
+
+if (!class_exists('Criteria')) {
+    class Criteria
+    {
+        public function __construct($column = '', $value = null, $operator = '=')
+        {
+        }
+
+        public function setSort($sort)
+        {
+        }
+
+        public function setOrder($order)
+        {
+        }
+    }
+}
+
+if (!class_exists('CriteriaCompo')) {
+    class CriteriaCompo extends Criteria
+    {
+        public function setLimit($limit)
+        {
+        }
+    }
+}
+
+if (!class_exists('XoopsTheme')) {
+    class XoopsTheme
+    {
+        public array $assigned = [];
+
+        public function assign($key, $value)
+        {
+            $this->assigned[$key] = $value;
+        }
+    }
+}
+
+if (!class_exists('XoopsSecurity')) {
+    class XoopsSecurity
+    {
+        public function createToken($timeout = 0, $name = 'XOOPS_TOKEN')
+        {
+            return 'token';
+        }
+    }
+}
+
+$GLOBALS['xoopsSecurity'] = $GLOBALS['xoopsSecurity'] ?? new XoopsSecurity();
+$GLOBALS['xoopsConfig']   = $GLOBALS['xoopsConfig'] ?? ['anonymous' => 'Anon'];
+
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formbutton.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formbuttontray.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formcaptcha.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formcheckbox.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formcolorpicker.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formdatetime.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formdhtmltextarea.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formeditor.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelement.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelementtray.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formfile.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formhidden.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formhiddentoken.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formlabel.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formpassword.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formradio.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formradioyn.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselect.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselectcheckgroup.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselectcountry.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselecteditor.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselectgroup.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselectlang.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselectmatchoption.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselecttheme.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselecttimezone.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formselectuser.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formtext.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formtextarea.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formtextdateselect.php';
+
+class XoopsFormElementsExtraTest extends TestCase
+{
+    public function testButtonsRenderThroughRenderer(): void
+    {
+        $button = new XoopsFormButton('Caption', 'btn', 'click', 'submit');
+        $tray   = new XoopsFormButtonTray('actions', 'save');
+
+        $this->assertSame('submit', $button->getType());
+        $this->assertSame('save', $tray->getValue());
+        $this->assertSame('submit', $tray->getType());
+        $this->assertSame('<renderFormButton>', $button->render());
+        $this->assertSame('<renderFormButtonTray>', $tray->render());
+    }
+
+    public function testCaptchaUsesHandler(): void
+    {
+        $captcha = new XoopsFormCaptcha('', 'mycaptcha');
+        $this->assertSame('mycaptcha', $captcha->captchaHandler->configs['name']);
+        $this->assertSame('[captcha]', $captcha->render());
+        $this->assertSame('validate-captcha', $captcha->renderValidationJS());
+
+        $captcha->captchaHandler->active = false;
+        $hiddenCaptcha                   = new XoopsFormCaptcha('hidden', 'hiddenName');
+        $this->assertTrue($hiddenCaptcha->isHidden());
+    }
+
+    public function testElementTrayAndHiddenFields(): void
+    {
+        $tray = new XoopsFormElementTray('Tray', '/', 'tray');
+        $hid  = new XoopsFormHidden('hid', '123');
+        $token = new XoopsFormHiddenToken('token_name');
+
+        $tray->addElement($hid, true);
+        $required = $tray->getRequired();
+
+        $this->assertTrue($tray->isContainer());
+        $this->assertTrue($tray->isRequired());
+        $this->assertSame($hid, $required[0]);
+        $this->assertSame('123', $hid->getValue());
+        $this->assertNotEmpty($token->getValue());
+    }
+
+    public function testChoiceElementsManageOptions(): void
+    {
+        $check = new XoopsFormCheckBox('Check', 'choices', ['a']);
+        $check->addOption('a', 'Alpha');
+        $check->addOptionArray(['b' => 'Beta']);
+        $this->assertSame(['a' => 'Alpha', 'b' => 'Beta'], $check->getOptions());
+
+        $radio = new XoopsFormRadio('Radio', 'radio', 'x');
+        $radio->addOption('x', 'Ex');
+        $this->assertSame('radio', $radio->getName());
+        $this->assertSame(['x' => 'Ex'], $radio->getOptions());
+
+        $yesNo = new XoopsFormRadioYN('YN', 'yn', 1);
+        $this->assertArrayHasKey(1, $yesNo->getOptions());
+    }
+
+    public function testSelectVariantsCollectOptions(): void
+    {
+        $select = new XoopsFormSelect('Select', 'sel', 'one', 1, false);
+        $select->addOptionArray(['one' => 'One', 'two' => 'Two']);
+        $this->assertSame(['one' => 'One', 'two' => 'Two'], $select->getOptions());
+
+        $match = new XoopsFormSelectMatchOption('Match', 'match', 'start');
+        $this->assertNotEmpty($match->getOptions());
+
+        $lang = new XoopsFormSelectLang('Lang', 'lang', 'english');
+        $this->assertNotEmpty($lang->getOptions());
+
+        $country = new XoopsFormSelectCountry('Country', 'country', 'CA');
+        $this->assertArrayHasKey('CA', $country->getOptions());
+
+        $tz = new XoopsFormSelectTimezone('TZ', 'tz', 'UTC');
+        $this->assertArrayHasKey('UTC', $tz->getOptions());
+
+        $theme = new XoopsFormSelectTheme('Theme', 'theme', 'default', 1, false);
+        $this->assertArrayHasKey('default', $theme->getOptions());
+
+        $group = new XoopsFormSelectGroup('Group', 'group', false, 1, true);
+        $this->assertTrue($group->isMultiple());
+
+        $checkGroup = new XoopsFormSelectCheckGroup('CheckGroup', 'chk', false);
+        $this->assertTrue($checkGroup->isMultiple());
+
+        $editor = new XoopsFormSelectEditor(new XoopsTheme(), 'ed', 'plain');
+        $this->assertNotEmpty($editor->getOptions());
+
+        $user = new XoopsFormSelectUser('User', 'user', true, 2, 1, false);
+        $elements = $user->getElements();
+        $this->assertNotEmpty($elements);
+    }
+
+    public function testTextualElements(): void
+    {
+        $text = new XoopsFormText('Text', 'txt', 10, 255, 'value');
+        $this->assertSame('value', $text->getValue());
+
+        $area = new XoopsFormTextArea('Area', 'area', 'body', 3, 40);
+        $this->assertSame('body', $area->getValue());
+
+        $dateSelect = new XoopsFormTextDateSelect('Date', 'date', 15, 0);
+        $this->assertSame(15, $dateSelect->getSize());
+
+        $dhtml = new XoopsFormDhtmlTextArea('DHTML', 'dhtml', 'content', 5, 50, 'hidden', ['editor' => 'plain']);
+        $this->assertNotNull($dhtml->htmlEditor);
+
+        $editor = new XoopsFormEditor('Editor', 'textarea', ['name' => 'textarea'], false);
+        $this->assertNotNull($editor->editor);
+
+        $pass = new XoopsFormPassword('Password', 'pass', 10, 255, 'secret');
+        $this->assertSame('secret', $pass->getValue());
+
+        $color = new XoopsFormColorPicker('Color', 'color', '#fff');
+        $this->assertSame('#fff', $color->getValue());
+
+        $dt = new XoopsFormDateTime('DateTime', 'dt', 15, 0, XoopsFormDateTime::SHOW_BOTH);
+        $this->assertTrue($dt->isContainer());
+        $this->assertNotEmpty($dt->getElements());
+
+        $file = new XoopsFormFile('File', 'file', 2048);
+        $this->assertSame(2048, $file->getMaxFileSize());
+
+        $label = new XoopsFormLabel('Label', 'value');
+        $this->assertSame('value', $label->getValue());
+    }
+}

--- a/tests/unit/XoopsFormRendererBootstrapTest.php
+++ b/tests/unit/XoopsFormRendererBootstrapTest.php
@@ -1,0 +1,208 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../htdocs/class/xoopsform/renderer/XoopsFormRendererInterface.php';
+require_once __DIR__ . '/../../htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php';
+require_once __DIR__ . '/../../htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php';
+require_once __DIR__ . '/../../htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php';
+
+if (!defined('_DELETE')) {
+    define('_DELETE', 'Delete Me');
+}
+if (!defined('_CANCEL')) {
+    define('_CANCEL', 'Cancel Now');
+}
+if (!defined('_RESET')) {
+    define('_RESET', 'Reset All');
+}
+
+if (!class_exists('XoopsFormButton')) {
+    class XoopsFormButton
+    {
+        protected $type;
+        protected $name;
+        protected $value;
+        protected $extra;
+
+        public function __construct($type, $name, $value, $extra = '')
+        {
+            $this->type = $type;
+            $this->name = $name;
+            $this->value = $value;
+            $this->extra = $extra;
+        }
+
+        public function getType()
+        {
+            return $this->type;
+        }
+
+        public function getName()
+        {
+            return $this->name;
+        }
+
+        public function getValue()
+        {
+            return $this->value;
+        }
+
+        public function getExtra()
+        {
+            return $this->extra;
+        }
+    }
+}
+
+if (!class_exists('XoopsFormButtonTray')) {
+    class XoopsFormButtonTray extends XoopsFormButton
+    {
+        public $_showDelete = false;
+    }
+}
+
+if (!class_exists('XoopsFormCheckBox')) {
+    class XoopsFormCheckBox
+    {
+        public $columns = 0;
+        protected $name;
+        protected $options;
+        protected $value;
+        protected $extra;
+        protected $delimeter;
+
+        public function __construct($name, array $options, $value, $columns = 0, $extra = '', $delimeter = '')
+        {
+            $this->name = $name;
+            $this->options = $options;
+            $this->value = $value;
+            $this->columns = $columns;
+            $this->extra = $extra;
+            $this->delimeter = $delimeter;
+        }
+
+        public function getName()
+        {
+            return $this->name;
+        }
+
+        public function setName($name)
+        {
+            $this->name = $name;
+        }
+
+        public function getOptions()
+        {
+            return $this->options;
+        }
+
+        public function getValue()
+        {
+            return $this->value;
+        }
+
+        public function getExtra()
+        {
+            return $this->extra;
+        }
+
+        public function getDelimeter()
+        {
+            return $this->delimeter;
+        }
+    }
+}
+
+/**
+ * @covers XoopsFormRendererBootstrap3
+ * @covers XoopsFormRendererBootstrap4
+ * @covers XoopsFormRendererBootstrap5
+ */
+class XoopsFormRendererBootstrapTest extends TestCase
+{
+    public function buttonProvider()
+    {
+        return [
+            ['XoopsFormRendererBootstrap3', 'btn btn-default'],
+            ['XoopsFormRendererBootstrap4', 'btn btn-secondary'],
+            ['XoopsFormRendererBootstrap5', 'btn btn-secondary'],
+        ];
+    }
+
+    /**
+     * @dataProvider buttonProvider
+     */
+    public function testRenderFormButtonAddsExpectedBootstrapClass($className, $expectedClass)
+    {
+        $renderer = new $className();
+        $button = new XoopsFormButton('submit', 'save', 'Save', ' data-extra="yes"');
+
+        $html = $renderer->renderFormButton($button);
+
+        $this->assertStringContainsString($expectedClass, $html);
+        $this->assertMatchesRegularExpression('/type=["\']submit["\']/', $html);
+        $this->assertStringContainsString('Save', $html);
+        $this->assertStringContainsString('data-extra="yes"', $html);
+    }
+
+    public function buttonTrayProvider()
+    {
+        return [
+            ['XoopsFormRendererBootstrap3', 'btn btn-danger', 'btn btn-success', "type=\"submit\""],
+            ['XoopsFormRendererBootstrap4', 'btn btn-danger', 'btn btn-success', "type=\"submit\""],
+            ['XoopsFormRendererBootstrap5', 'btn btn-danger', 'btn btn-success', "type=\"submit\""],
+        ];
+    }
+
+    /**
+     * @dataProvider buttonTrayProvider
+     */
+    public function testRenderFormButtonTrayShowsDeleteAndSubmit($className, $deleteClass, $submitClass, $submitType)
+    {
+        $renderer = new $className();
+        $tray = new XoopsFormButtonTray('submit', 'go', 'Go!', ' data-extra="tray"');
+        $tray->_showDelete = true;
+
+        $html = $renderer->renderFormButtonTray($tray);
+
+        $this->assertStringContainsString($deleteClass, $html);
+        $this->assertStringContainsString(_DELETE, $html);
+        $this->assertStringContainsString(_CANCEL, $html);
+        $this->assertStringContainsString($submitClass, $html);
+        $this->assertMatchesRegularExpression('/type=["\']submit["\']/', $html);
+        $this->assertStringContainsString('data-extra="tray"', $html);
+    }
+
+    public function checkBoxProvider()
+    {
+        $options = [
+            'one' => 'First Option',
+            'two' => 'Second Option',
+        ];
+
+        return [
+            ['XoopsFormRendererBootstrap3', $options],
+            ['XoopsFormRendererBootstrap4', $options],
+            ['XoopsFormRendererBootstrap5', $options],
+        ];
+    }
+
+    /**
+     * @dataProvider checkBoxProvider
+     */
+    public function testRenderFormCheckBoxRespectsColumnsAndChecksValues($className, $options)
+    {
+        $renderer = new $className();
+        $element = new XoopsFormCheckBox('choices', $options, ['two'], 0, ' data-extra="check"', ' | ');
+
+        $html = $renderer->renderFormCheckBox($element);
+        $this->assertStringContainsString('checkbox-inline', $html);
+        $this->assertStringContainsString('choices[]', $html);
+        $this->assertStringContainsString('data-extra="check"', $html);
+        $this->assertStringContainsString('checked', $html);
+
+        $element->columns = 2;
+        $html = $renderer->renderFormCheckBox($element);
+        $this->assertStringContainsString('col-md-2', $html);
+    }
+}

--- a/tests/unit/XoopsFormTest.php
+++ b/tests/unit/XoopsFormTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/form.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelement.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelementtray.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formtext.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formhiddentoken.php';
+
+if (!class_exists('XoopsSecurity')) {
+    class XoopsSecurity
+    {
+        public array $calls = [];
+
+        public function createToken($timeout = 0, $name = 'XOOPS_TOKEN')
+        {
+            $this->calls[] = [$timeout, $name];
+
+            return 'generated-token';
+        }
+    }
+}
+
+if (!class_exists('DummyFormElement')) {
+    class DummyFormElement extends XoopsFormElement
+    {
+        private $value;
+        private $validationJs;
+
+        public function __construct(string $name, string $caption = '', string $validationJs = '')
+        {
+            $this->setName($name);
+            $this->setCaption($caption);
+            $this->validationJs = $validationJs ?: "if (!myform.{$name}.value) { return false; }";
+        }
+
+        public function isContainer()
+        {
+            return false;
+        }
+
+        public function setValue($value): void
+        {
+            $this->value = $value;
+        }
+
+        public function getValue($encode = false)
+        {
+            return $encode ? htmlspecialchars((string) $this->value, ENT_QUOTES | ENT_HTML5) : $this->value;
+        }
+
+        public function render()
+        {
+            return '<input name="' . $this->_name . '" />';
+        }
+
+        public function renderValidationJS()
+        {
+            return $this->validationJs;
+        }
+    }
+}
+
+if (!class_exists('DummyTpl')) {
+    class DummyTpl
+    {
+        public array $assigned = [];
+
+        public function assign($key, $value): void
+        {
+            $this->assigned[$key] = $value;
+        }
+    }
+}
+
+class XoopsFormTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['xoopsSecurity'] = new XoopsSecurity();
+    }
+
+    public function testConstructorSetsDefaultsAndAddsToken(): void
+    {
+        $form = new XoopsForm('My © title', 'myform', '/submit.php?foo=bar', 'GET', true, 'summary & more');
+
+        $this->assertSame('My © title', $form->getTitle());
+        $this->assertSame('My &copy; title', $form->getTitle(true));
+        $this->assertSame('myform', $form->getName(false));
+        $this->assertSame('myform', $form->getName());
+        $this->assertSame('/submit.php?foo=bar', $form->getAction(false));
+        $this->assertSame('/submit.php?foo=bar', htmlspecialchars_decode($form->getAction()));
+        $this->assertSame('get', $form->getMethod());
+        $this->assertSame('summary & more', $form->getSummary());
+        $this->assertSame('summary &amp; more', $form->getSummary(true));
+
+        $elements = $form->getElements();
+        $this->assertNotEmpty($elements);
+        $this->assertInstanceOf(XoopsFormHiddenToken::class, $elements[0]);
+        $this->assertNotEmpty($GLOBALS['xoopsSecurity']->calls);
+    }
+
+    public function testAddElementTracksRequiredAndStrings(): void
+    {
+        $form = new XoopsForm('title', 'simple', '/action.php', 'post', false);
+        $element = new DummyFormElement('field', 'Caption');
+
+        $form->addElement($element, true);
+        $form->addElement('literal-break');
+
+        $elements = $form->getElements();
+        $this->assertSame($element, $elements[0]);
+        $this->assertSame('literal-break', $elements[1]);
+
+        $required = $form->getRequired();
+        $this->assertSame([$element], $required);
+        $this->assertTrue($element->isRequired());
+    }
+
+    public function testGetElementsRecursesThroughContainers(): void
+    {
+        $form = new XoopsForm('title', 'recurse', '/action.php', 'post', false);
+        $tray = new XoopsFormElementTray('tray', '|', 'trayname');
+        $child = new DummyFormElement('child', 'Child');
+        $tray->addElement($child, true);
+
+        $form->addElement($tray);
+
+        $flat = $form->getElements(true);
+        $this->assertSame([$child], $flat);
+
+        $required = $form->getRequired();
+        $this->assertSame([$child], $required);
+    }
+
+    public function testSetAndGetElementValues(): void
+    {
+        $form = new XoopsForm('title', 'values', '/action.php', 'post', false);
+        $one = new DummyFormElement('one');
+        $two = new DummyFormElement('two');
+        $form->addElement($one);
+        $form->addElement($two);
+
+        $form->setElementValue('one', 'first');
+        $form->setElementValues(['one' => 'alpha', 'two' => 'beta']);
+
+        $this->assertSame('alpha', $form->getElementValue('one'));
+        $this->assertSame(['one' => 'alpha', 'two' => 'beta'], $form->getElementValues());
+        $this->assertSame(['one' => 'alpha', 'two' => 'beta'], $form->getElementValues(true));
+    }
+
+    public function testClassExtraAndSummaryHelpers(): void
+    {
+        $form = new XoopsForm('title', 'css', '/action.php', 'post', false, 'initial');
+        $form->setClass(' primary ');
+        $form->setClass('secondary');
+        $form->setExtra('data-one="1"');
+        $form->setExtra('checked');
+
+        $this->assertSame('primary secondary', $form->getClass());
+        $this->assertSame(' data-one="1" checked', $form->getExtra());
+        $this->assertSame('initial', $form->getSummary());
+    }
+
+    public function testRenderValidationJsIncludesElementSnippets(): void
+    {
+        $form = new XoopsForm('title', 'validate', '/action.php', 'post', false);
+        $form->addElement(new DummyFormElement('field', 'Caption', 'if (!myform.field.value) { return false; }'));
+
+        $js = $form->renderValidationJS();
+
+        $this->assertStringContainsString('xoopsFormValidate_validate', $js);
+        $this->assertStringContainsString('if (!myform.field.value)', $js);
+        $this->assertStringContainsString('<script type=\'text/javascript\'>', $js);
+    }
+
+    public function testAssignBuildsTemplateArray(): void
+    {
+        $form = new XoopsForm('title', 'assign', '/action.php', 'post', false);
+        $element = new DummyFormElement('assign_name', 'Caption');
+        $element->_required = true;
+        $form->addElement($element);
+        $form->addElement('raw-chunk');
+        $form->setExtra('data-extra="1"');
+
+        $tpl = new DummyTpl();
+        $form->assign($tpl);
+
+        $this->assertArrayHasKey('assign', $tpl->assigned);
+        $assigned = $tpl->assigned['assign'];
+        $this->assertSame('title', $assigned['title']);
+        $this->assertSame('assign', $assigned['name']);
+        $this->assertStringContainsString('xoopsFormValidate_assign', $assigned['extra']);
+        $this->assertSame('<input name="assign_name" />', $assigned['elements']['assign_name']['body']);
+        $this->assertTrue($assigned['elements']['assign_name']['required']);
+        $this->assertSame('raw-chunk', $assigned['elements'][1]['body']);
+    }
+}

--- a/tests/unit/XoopsFormTinymceTest.php
+++ b/tests/unit/XoopsFormTinymceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce/formtinymce.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce5/formtinymce.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce7/formtinymce.php';
+
+if (!defined('_LANGCODE')) {
+    define('_LANGCODE', 'en');
+}
+if (!defined('_CHARSET')) {
+    define('_CHARSET', 'utf-8');
+}
+if (!defined('_FORM_ENTER')) {
+    define('_FORM_ENTER', 'Enter %s');
+}
+
+class XoopsFormTinymceTest extends TestCase
+{
+    public function testTinymceConfigDefaultsAndFonts(): void
+    {
+        if (!defined('_XOOPS_EDITOR_TINYMCE_FONTS')) {
+            define('_XOOPS_EDITOR_TINYMCE_FONTS', 'Arial');
+        }
+
+        $editor = new XoopsFormTinymce(['name' => 'content', 'caption' => 'Caption']);
+
+        $this->assertInstanceOf(XoopsEditor::class, $editor);
+        $this->assertSame('content', $editor->configs['elements']);
+        $this->assertSame('en_utf8', $editor->configs['language']);
+        $this->assertSame('/class/xoopseditor/tinymce', $editor->configs['rootpath']);
+        $this->assertSame('100%', $editor->configs['area_width']);
+        $this->assertSame('500px', $editor->configs['area_height']);
+        $this->assertSame('Arial', $editor->configs['fonts']);
+        $this->assertInstanceOf(TinyMCE::class, $editor->editor);
+        $this->assertTrue($editor->isActive());
+    }
+
+    public function testTinymce5LanguageOverrideAndValidation(): void
+    {
+        if (!defined('_XOOPS_EDITOR_TINYMCE5_LANGUAGE')) {
+            define('_XOOPS_EDITOR_TINYMCE5_LANGUAGE', 'ES');
+        }
+
+        $editor = new XoopsFormTinymce5(['name' => 'body', 'caption' => 'Body']);
+        $editor->_required = true;
+
+        $this->assertSame('body', $editor->configs['elements']);
+        $this->assertSame('es', $editor->configs['language']);
+        $this->assertSame('100%', $editor->configs['area_width']);
+        $this->assertSame('500px', $editor->configs['area_height']);
+        $this->assertInstanceOf(TinyMCE::class, $editor->editor);
+        $this->assertStringContainsString("tinymce.get('body')", $editor->renderValidationJS());
+        $this->assertStringContainsString('Enter Body', $editor->renderValidationJS());
+        $this->assertTrue($editor->isActive());
+    }
+
+    public function testTinymce7SelectorAndDimensions(): void
+    {
+        $editor = new XoopsFormTinymce7([
+            'name' => 'field',
+            'caption' => 'Field',
+            'width' => '250px',
+            'height' => '150px',
+        ]);
+
+        $this->assertSame('#field', $editor->configs['selector']);
+        $this->assertSame('en_utf8', $editor->configs['language']);
+        $this->assertSame('/class/xoopseditor/tinymce7', $editor->configs['rootpath']);
+        $this->assertSame('250px', $editor->configs['area_width']);
+        $this->assertSame('150px', $editor->configs['area_height']);
+        $this->assertInstanceOf(TinyMCE::class, $editor->editor);
+        $this->assertTrue($editor->isActive());
+    }
+}

--- a/tests/unit/XoopsGroupPermFormTest.php
+++ b/tests/unit/XoopsGroupPermFormTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/form.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelement.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelementtray.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formbutton.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formhiddentoken.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formhidden.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/grouppermform.php';
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'http://example.com');
+}
+
+if (!defined('XOOPS_GROUP_ANONYMOUS')) {
+    define('XOOPS_GROUP_ANONYMOUS', 0);
+}
+
+if (!defined('_SUBMIT')) {
+    define('_SUBMIT', 'Submit');
+}
+
+if (!defined('_CANCEL')) {
+    define('_CANCEL', 'Cancel');
+}
+
+if (!defined('_ALL')) {
+    define('_ALL', 'All');
+}
+
+if (!function_exists('xoops_load')) {
+    function xoops_load($name)
+    {
+        return true;
+    }
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        global $mockHandlers;
+
+        return $mockHandlers[$name] ?? null;
+    }
+}
+
+class MockGroupPermHandler
+{
+    public array $calls = [];
+    private array $map;
+
+    public function __construct(array $map)
+    {
+        $this->map = $map;
+    }
+
+    public function getItemIds($permName, $groupId, $moduleId)
+    {
+        $this->calls[] = [$permName, $groupId, $moduleId];
+
+        return $this->map[$groupId] ?? [];
+    }
+}
+
+class MockMemberHandler
+{
+    public function getGroupList()
+    {
+        return [1 => 'Admins', XOOPS_GROUP_ANONYMOUS => 'Guests'];
+    }
+}
+
+class XoopsGroupPermFormTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $mockHandlers;
+        $mockHandlers = [
+            'groupperm' => new MockGroupPermHandler([1 => [2]]),
+            'member' => new MockMemberHandler(),
+        ];
+    }
+
+    public function testConstructorAndItemAddition(): void
+    {
+        $form = new XoopsGroupPermForm('My Permission', 42, 'module_admin', 'desc text', '/return');
+        $form->addItem(1, 'Top');
+        $form->addItem(2, 'Child', 1);
+
+        $this->assertSame(42, $form->_modid);
+        $this->assertSame('module_admin', $form->_permName);
+        $this->assertSame('desc text', $form->_permDesc);
+        $this->assertArrayHasKey(0, $form->_itemTree);
+        $this->assertSame([1], $form->_itemTree[0]['children']);
+        $this->assertSame(1, $form->_itemTree[2]['parent']);
+    }
+
+    public function testRenderBuildsFormForGroups(): void
+    {
+        global $mockHandlers;
+        $mockHandlers['groupperm'] = new MockGroupPermHandler([1 => [1, 2]]);
+
+        $form = new XoopsGroupPermForm('Perm Title', 7, 'read', 'perm description', '', false);
+        $form->addItem(1, 'Section');
+        $form->addItem(2, 'Subsection', 1);
+
+        $output = $form->render();
+
+        $this->assertStringContainsString('<h4>Perm Title</h4>', $output);
+        $this->assertStringContainsString('perm description', $output);
+        $this->assertStringContainsString('Admins', $output);
+        $this->assertStringNotContainsString('Guests', $output);
+        $this->assertStringContainsString("name=\"perms[read][groups][1][1]\"", $output);
+        $this->assertStringContainsString("name=\"perms[read][groups][1][2]\"", $output);
+        $this->assertStringContainsString('xoopsCheckAllElements', $output);
+        $this->assertSame([['read', 1, 7]], $mockHandlers['groupperm']->calls);
+    }
+}
+
+class XoopsGroupFormCheckBoxTest extends TestCase
+{
+    public function testValueAndRenderingWithOptionTree(): void
+    {
+        $tree = [
+            0 => ['children' => [1]],
+            1 => ['id' => 1, 'name' => 'Root', 'children' => [2], 'allchild' => [2]],
+            2 => ['id' => 2, 'name' => 'Child', 'children' => [], 'allchild' => []],
+        ];
+
+        $checkbox = new XoopsGroupFormCheckBox('Caption', 'perms[test]', 99, [2]);
+        $checkbox->setOptionTree($tree);
+
+        $output = $checkbox->render();
+
+        $this->assertContains(2, $checkbox->_value);
+        $this->assertStringContainsString('Caption', $checkbox->getCaption());
+        $this->assertStringContainsString("perms[test][groups][99][1]", $output);
+        $this->assertStringContainsString("perms[test][groups][99][2]", $output);
+        $this->assertStringContainsString("value=\"1\" checked", $output);
+        $this->assertStringContainsString('xoopsGetElementById', $output);
+        $this->assertStringContainsString('xoopsCheckAllElements', $output);
+    }
+}

--- a/tests/unit/XoopsGroupPermTest.php
+++ b/tests/unit/XoopsGroupPermTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/groupperm.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+trait DatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsGroupPermTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $perm = new XoopsGroupPerm();
+
+        $this->assertNull($perm->getVar('gperm_id'));
+        $this->assertNull($perm->getVar('gperm_groupid'));
+        $this->assertNull($perm->getVar('gperm_itemid'));
+        $this->assertSame(0, $perm->getVar('gperm_modid'));
+        $this->assertNull($perm->getVar('gperm_name'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $perm = new XoopsGroupPerm();
+        $perm->setVar('gperm_id', 3);
+        $perm->setVar('gperm_groupid', 5);
+        $perm->setVar('gperm_itemid', 9);
+        $perm->setVar('gperm_modid', 2);
+        $perm->setVar('gperm_name', 'module_read');
+
+        $this->assertSame(3, $perm->id());
+        $this->assertSame(3, $perm->gperm_id());
+        $this->assertSame(5, $perm->gperm_groupid());
+        $this->assertSame(9, $perm->gperm_itemid());
+        $this->assertSame(2, $perm->gperm_modid());
+        $this->assertSame('module_read', $perm->gperm_name());
+    }
+}
+
+class XoopsGroupPermHandlerTest extends TestCase
+{
+    use DatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingPermission(): void
+    {
+        $handler = new XoopsGroupPermHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsGroupPerm::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesPermission(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_group_permission WHERE gperm_id = 7')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'gperm_id'     => 7,
+            'gperm_groupid'=> 1,
+            'gperm_itemid' => 10,
+            'gperm_modid'  => 3,
+            'gperm_name'   => 'view',
+        ]);
+
+        $handler = new XoopsGroupPermHandler($database);
+        $perm    = $handler->get(7);
+
+        $this->assertInstanceOf(XoopsGroupPerm::class, $perm);
+        $this->assertSame('view', $perm->getVar('gperm_name'));
+        $this->assertFalse($perm->isNew());
+    }
+
+    public function testInsertCreatesNewPermission(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_group_permission'))
+            ->willReturn(true);
+        $database->method('getInsertId')->willReturn(12);
+
+        $handler = new XoopsGroupPermHandler($database);
+
+        $perm = $handler->create();
+        $perm->setVar('gperm_groupid', 1);
+        $perm->setVar('gperm_itemid', 2);
+        $perm->setVar('gperm_modid', 3);
+        $perm->setVar('gperm_name', 'read');
+
+        $this->assertTrue($handler->insert($perm));
+        $this->assertSame(12, $perm->getVar('gperm_id'));
+    }
+
+    public function testInsertUpdatesExistingPermission(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_group_permission SET'))
+            ->willReturn(true);
+
+        $handler = new XoopsGroupPermHandler($database);
+
+        $perm = $handler->create(false);
+        $perm->setNew(false);
+        $perm->setVar('gperm_id', 4);
+        $perm->setVar('gperm_groupid', 2);
+        $perm->setVar('gperm_itemid', 9);
+        $perm->setVar('gperm_modid', 1);
+        $perm->setVar('gperm_name', 'edit');
+
+        $this->assertTrue($handler->insert($perm));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsGroupPermHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesPermission(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_group_permission WHERE gperm_id = 8')
+            ->willReturn(true);
+
+        $handler = new XoopsGroupPermHandler($database);
+
+        $perm = $handler->create(false);
+        $perm->setVar('gperm_id', 8);
+
+        $this->assertTrue($handler->delete($perm));
+    }
+
+    public function testGetObjectsReturnsPermissionsWithCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_group_permission WHERE (gperm_id > 0)', 1, 0)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'gperm_id'      => 1,
+                'gperm_groupid' => 2,
+                'gperm_itemid'  => 3,
+                'gperm_modid'   => 4,
+                'gperm_name'    => 'module_admin',
+            ],
+            false
+        );
+
+        $handler  = new XoopsGroupPermHandler($database);
+        $criteria = new Criteria('gperm_id', 0, '>');
+        $criteria->setLimit(1);
+
+        $objects = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $objects);
+        $this->assertArrayHasKey(1, $objects);
+        $this->assertSame('module_admin', $objects[1]->getVar('gperm_name'));
+    }
+
+    public function testGetCountReturnsValue(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(*) FROM pref_group_permission WHERE (gperm_modid = 1)')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([5]);
+
+        $handler  = new XoopsGroupPermHandler($database);
+        $criteria = new Criteria('gperm_modid', 1);
+
+        $this->assertSame(5, $handler->getCount($criteria));
+    }
+
+    public function testDeleteAllExecutes(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_group_permission WHERE (gperm_groupid = 2)')
+            ->willReturn(true);
+
+        $handler  = new XoopsGroupPermHandler($database);
+        $criteria = new Criteria('gperm_groupid', 2);
+
+        $this->assertTrue($handler->deleteAll($criteria));
+    }
+
+    public function testDeleteByGroupBuildsCriteria(): void
+    {
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['deleteAll'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('deleteAll')
+            ->with($this->callback(static function ($criteria) {
+                return $criteria instanceof CriteriaCompo
+                    && str_contains($criteria->renderWhere(), 'gperm_groupid = 4')
+                    && str_contains($criteria->renderWhere(), 'gperm_modid = 1');
+            }))
+            ->willReturn(true);
+
+        $this->assertTrue($handler->deleteByGroup(4, 1));
+    }
+
+    public function testDeleteByModuleBuildsCriteria(): void
+    {
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['deleteAll'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('deleteAll')
+            ->with($this->callback(static function ($criteria) {
+                return $criteria instanceof CriteriaCompo
+                    && str_contains($criteria->renderWhere(), "gperm_modid = 3")
+                    && str_contains($criteria->renderWhere(), "gperm_name = 'access'")
+                    && str_contains($criteria->renderWhere(), 'gperm_itemid = 7');
+            }))
+            ->willReturn(true);
+
+        $this->assertTrue($handler->deleteByModule(3, 'access', 7));
+    }
+
+    public function testCheckRightReturnsTrueForAdminGroup(): void
+    {
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getCount'])
+            ->getMock();
+
+        $handler->expects($this->never())->method('getCount');
+
+        $this->assertTrue($handler->checkRight('read', 0, [XOOPS_GROUP_ADMIN], 1, true));
+    }
+
+    public function testCheckRightEvaluatesPermissions(): void
+    {
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getCount'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getCount')
+            ->with($this->callback(static function ($criteria) {
+                return $criteria instanceof CriteriaCompo
+                    && str_contains($criteria->renderWhere(), 'gperm_modid = 2')
+                    && str_contains($criteria->renderWhere(), "gperm_name = 'write'")
+                    && str_contains($criteria->renderWhere(), 'gperm_itemid = 5')
+                    && str_contains($criteria->renderWhere(), 'gperm_groupid = 4');
+            }))
+            ->willReturn(1);
+
+        $this->assertTrue($handler->checkRight('write', 5, 4, 2, false));
+    }
+
+    public function testAddRightCreatesPermission(): void
+    {
+        $createdPerm = new XoopsGroupPerm();
+
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['create', 'insert'])
+            ->getMock();
+
+        $handler->method('create')->willReturn($createdPerm);
+        $handler->expects($this->once())
+            ->method('insert')
+            ->with($createdPerm)
+            ->willReturn(true);
+
+        $this->assertTrue($handler->addRight('comment', 11, 2, 1));
+        $this->assertSame('comment', $createdPerm->getVar('gperm_name'));
+        $this->assertSame(11, $createdPerm->getVar('gperm_itemid'));
+        $this->assertSame(2, $createdPerm->getVar('gperm_groupid'));
+        $this->assertSame(1, $createdPerm->getVar('gperm_modid'));
+    }
+
+    public function testGetItemIdsCollectsUniqueValues(): void
+    {
+        $permA = new XoopsGroupPerm();
+        $permA->setVar('gperm_itemid', 3);
+        $permB = new XoopsGroupPerm();
+        $permB->setVar('gperm_itemid', 3);
+        $permC = new XoopsGroupPerm();
+        $permC->setVar('gperm_itemid', 4);
+
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->method('getObjects')->willReturn([
+            1 => $permA,
+            2 => $permB,
+            3 => $permC,
+        ]);
+
+        $items = $handler->getItemIds('view', [1, 2], 5);
+
+        $this->assertSame([3, 4], $items);
+    }
+
+    public function testGetGroupIdsCollectsValues(): void
+    {
+        $permA = new XoopsGroupPerm();
+        $permA->setVar('gperm_groupid', 2);
+        $permB = new XoopsGroupPerm();
+        $permB->setVar('gperm_groupid', 4);
+
+        $handler = $this->getMockBuilder(XoopsGroupPermHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->method('getObjects')->willReturn([
+            1 => $permA,
+            2 => $permB,
+        ]);
+
+        $groups = $handler->getGroupIds('edit', 7, 1);
+
+        $this->assertSame([2, 4], $groups);
+    }
+}

--- a/tests/unit/XoopsGroupTest.php
+++ b/tests/unit/XoopsGroupTest.php
@@ -1,0 +1,427 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/group.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+trait DatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsGroupTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $group = new XoopsGroup();
+
+        $this->assertNull($group->getVar('groupid'));
+        $this->assertNull($group->getVar('name'));
+        $this->assertNull($group->getVar('description'));
+        $this->assertNull($group->getVar('group_type'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $group = new XoopsGroup();
+        $group->setVar('groupid', 15);
+        $group->setVar('name', 'Registered Users');
+        $group->setVar('description', 'General members');
+        $group->setVar('group_type', 'User');
+
+        $this->assertSame(15, $group->id());
+        $this->assertSame(15, $group->groupid());
+        $this->assertSame('Registered Users', $group->name());
+        $this->assertSame('General members', $group->description());
+        $this->assertSame('User', $group->group_type());
+    }
+}
+
+class XoopsGroupHandlerTest extends TestCase
+{
+    use DatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingGroup(): void
+    {
+        $handler = new XoopsGroupHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsGroup::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesGroup(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_groups WHERE groupid=5')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'groupid'     => 5,
+            'name'        => 'Admins',
+            'description' => 'Site administrators',
+            'group_type'  => 'Admin',
+        ]);
+
+        $handler = new XoopsGroupHandler($database);
+        $group   = $handler->get(5);
+
+        $this->assertInstanceOf(XoopsGroup::class, $group);
+        $this->assertSame('Admins', $group->getVar('name'));
+        $this->assertFalse($group->isNew());
+    }
+
+    public function testInsertCreatesNewGroup(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_groups'))
+            ->willReturn(true);
+        $database->method('getInsertId')->willReturn(9);
+
+        $handler = new XoopsGroupHandler($database);
+
+        $group = $handler->create();
+        $group->setVar('name', 'Guests');
+        $group->setVar('description', 'Unregistered users');
+        $group->setVar('group_type', 'Anonymous');
+
+        $this->assertTrue($handler->insert($group));
+        $this->assertSame(9, $group->getVar('groupid'));
+    }
+
+    public function testInsertUpdatesExistingGroup(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_groups SET name ='))
+            ->willReturn(true);
+
+        $handler = new XoopsGroupHandler($database);
+
+        $group = $handler->create(false);
+        $group->setNew(false);
+        $group->setVar('groupid', 7);
+        $group->setVar('name', 'Members');
+        $group->setVar('description', 'Registered users');
+        $group->setVar('group_type', 'User');
+
+        $this->assertTrue($handler->insert($group));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsGroupHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesGroup(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_groups WHERE groupid = 11')
+            ->willReturn(true);
+
+        $handler = new XoopsGroupHandler($database);
+
+        $group = $handler->create(false);
+        $group->setVar('groupid', 11);
+
+        $this->assertTrue($handler->delete($group));
+    }
+
+    public function testGetObjectsReturnsGroupsWithCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_groups WHERE (groupid > 0)', 2, 0)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'groupid'     => 1,
+                'name'        => 'Webmasters',
+                'description' => 'Admins',
+                'group_type'  => 'Admin',
+            ],
+            [
+                'groupid'     => 2,
+                'name'        => 'Users',
+                'description' => 'Members',
+                'group_type'  => 'User',
+            ],
+            false
+        );
+
+        $handler  = new XoopsGroupHandler($database);
+        $criteria = new Criteria('groupid', 0, '>');
+        $criteria->setLimit(2);
+
+        $groups = $handler->getObjects($criteria, true);
+
+        $this->assertCount(2, $groups);
+        $this->assertSame('Webmasters', $groups[1]->getVar('name'));
+        $this->assertSame('Users', $groups[2]->getVar('name'));
+    }
+}
+
+class XoopsMembershipTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $membership = new XoopsMembership();
+
+        $this->assertNull($membership->getVar('linkid'));
+        $this->assertNull($membership->getVar('groupid'));
+        $this->assertNull($membership->getVar('uid'));
+    }
+}
+
+class XoopsMembershipHandlerTest extends TestCase
+{
+    use DatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingMembership(): void
+    {
+        $handler = new XoopsMembershipHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsMembership::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesMembership(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_groups_users_link WHERE linkid=3')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'linkid'  => 3,
+            'groupid' => 2,
+            'uid'     => 5,
+        ]);
+
+        $handler    = new XoopsMembershipHandler($database);
+        $membership = $handler->get(3);
+
+        $this->assertInstanceOf(XoopsMembership::class, $membership);
+        $this->assertSame(2, $membership->getVar('groupid'));
+    }
+
+    public function testInsertCreatesNewMembership(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_groups_users_link'))
+            ->willReturn(true);
+        $database->method('getInsertId')->willReturn(10);
+
+        $handler = new XoopsMembershipHandler($database);
+
+        $membership = $handler->create();
+        $membership->setVar('groupid', 4);
+        $membership->setVar('uid', 7);
+
+        $this->assertTrue($handler->insert($membership));
+        $this->assertSame(10, $membership->getVar('linkid'));
+    }
+
+    public function testInsertUpdatesExistingMembership(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_groups_users_link SET groupid ='))
+            ->willReturn(true);
+
+        $handler = new XoopsMembershipHandler($database);
+
+        $membership = $handler->create(false);
+        $membership->setNew(false);
+        $membership->setVar('linkid', 6);
+        $membership->setVar('groupid', 8);
+        $membership->setVar('uid', 12);
+
+        $this->assertTrue($handler->insert($membership));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsMembershipHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesMembership(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_groups_users_link WHERE linkid = 13')
+            ->willReturn(true);
+
+        $handler = new XoopsMembershipHandler($database);
+
+        $membership = $handler->create(false);
+        $membership->setVar('linkid', 13);
+
+        $this->assertTrue($handler->delete($membership));
+    }
+
+    public function testGetObjectsReturnsMemberships(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_groups_users_link WHERE (uid = 1)', 0, 0)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'linkid'  => 1,
+                'groupid' => 2,
+                'uid'     => 1,
+            ],
+            [
+                'linkid'  => 2,
+                'groupid' => 3,
+                'uid'     => 1,
+            ],
+            false
+        );
+
+        $handler  = new XoopsMembershipHandler($database);
+        $criteria = new Criteria('uid', 1);
+
+        $memberships = $handler->getObjects($criteria, true);
+
+        $this->assertCount(2, $memberships);
+        $this->assertSame(2, $memberships[1]->getVar('groupid'));
+        $this->assertSame(3, $memberships[2]->getVar('groupid'));
+    }
+
+    public function testGetCountReturnsNumberOfMemberships(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(*) FROM pref_groups_users_link WHERE (groupid = 9)')
+            ->willReturn('result');
+        $database->method('fetchRow')->willReturn([5]);
+
+        $handler  = new XoopsMembershipHandler($database);
+        $criteria = new Criteria('groupid', 9);
+
+        $this->assertSame(5, $handler->getCount($criteria));
+    }
+
+    public function testDeleteAllRemovesMemberships(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('DELETE FROM pref_groups_users_link WHERE (uid = 2)')
+            ->willReturn(true);
+
+        $handler  = new XoopsMembershipHandler($database);
+        $criteria = new Criteria('uid', 2);
+
+        $this->assertTrue($handler->deleteAll($criteria));
+    }
+
+    public function testGetGroupsByUserReturnsIds(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT groupid FROM pref_groups_users_link WHERE uid=4')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            ['groupid' => 1],
+            ['groupid' => 3],
+            false
+        );
+
+        $handler = new XoopsMembershipHandler($database);
+
+        $this->assertSame([1, 3], $handler->getGroupsByUser(4));
+    }
+
+    public function testGetUsersByGroupReturnsIds(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT uid FROM pref_groups_users_link WHERE groupid=6', 5, 0)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            ['uid' => 7],
+            ['uid' => 8],
+            false
+        );
+
+        $handler = new XoopsMembershipHandler($database);
+
+        $this->assertSame([7, 8], $handler->getUsersByGroup(6, 5));
+    }
+}

--- a/tests/unit/XoopsHttpGetTest.php
+++ b/tests/unit/XoopsHttpGetTest.php
@@ -1,0 +1,93 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../htdocs/class/xoopshttpget.php';
+
+class XoopsHttpGetTest extends TestCase
+{
+    public function testFetchUsesCurlWhenEnabled(): void
+    {
+        $stub = new class('http://example.com') extends XoopsHttpGet {
+            public $fetchCurlCalled = false;
+            public $fetchFopenCalled = false;
+
+            protected function fetchCurl()
+            {
+                $this->fetchCurlCalled = true;
+                $this->error = 'curl';
+                return 'curl-response';
+            }
+
+            protected function fetchFopen()
+            {
+                $this->fetchFopenCalled = true;
+                return 'fopen-response';
+            }
+        };
+
+        $this->setUseCurl($stub, true);
+
+        $this->assertSame('curl-response', $stub->fetch());
+        $this->assertTrue($stub->fetchCurlCalled);
+        $this->assertFalse($stub->fetchFopenCalled);
+        $this->assertSame('curl', $stub->getError());
+    }
+
+    public function testFetchUsesFopenWhenDisabled(): void
+    {
+        $stub = new class('http://example.com') extends XoopsHttpGet {
+            public $fetchCurlCalled = false;
+            public $fetchFopenCalled = false;
+
+            protected function fetchCurl()
+            {
+                $this->fetchCurlCalled = true;
+                return 'curl-response';
+            }
+
+            protected function fetchFopen()
+            {
+                $this->fetchFopenCalled = true;
+                $this->error = 'fopen';
+                return 'fopen-response';
+            }
+        };
+
+        $this->setUseCurl($stub, false);
+
+        $this->assertSame('fopen-response', $stub->fetch());
+        $this->assertFalse($stub->fetchCurlCalled);
+        $this->assertTrue($stub->fetchFopenCalled);
+        $this->assertSame('fopen', $stub->getError());
+    }
+
+    public function testFetchFopenReadsLocalFile(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'xoops_http_get');
+        file_put_contents($file, 'local content');
+
+        $getter = new XoopsHttpGet('file://' . $file);
+        $this->setUseCurl($getter, false);
+
+        $this->assertSame('local content', $getter->fetch());
+        $this->assertNull($getter->getError());
+
+        @unlink($file);
+    }
+
+    public function testFetchFopenHandlesMissingFile(): void
+    {
+        $getter = new XoopsHttpGet('file:///nonexistent/path/does_not_exist.txt');
+        $this->setUseCurl($getter, false);
+
+        $this->assertFalse($getter->fetch());
+        $this->assertSame('file_get_contents() failed.', $getter->getError());
+    }
+
+    private function setUseCurl(XoopsHttpGet $getter, bool $value): void
+    {
+        $property = new \ReflectionProperty(XoopsHttpGet::class, 'useCurl');
+        $property->setAccessible(true);
+        $property->setValue($getter, $value);
+    }
+}

--- a/tests/unit/XoopsImageSetTest.php
+++ b/tests/unit/XoopsImageSetTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/imageset.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsImageSetTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $imageSet = new XoopsImageSet();
+
+        $this->assertNull($imageSet->getVar('imgset_id'));
+        $this->assertNull($imageSet->getVar('imgset_name'));
+        $this->assertSame(0, $imageSet->getVar('imgset_refid'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $imageSet = new XoopsImageSet();
+        $imageSet->setVar('imgset_id', 11);
+        $imageSet->setVar('imgset_name', 'Modern');
+        $imageSet->setVar('imgset_refid', 2);
+
+        $this->assertSame(11, $imageSet->id());
+        $this->assertSame(11, $imageSet->imgset_id());
+        $this->assertSame('Modern', $imageSet->imgset_name());
+        $this->assertSame(2, $imageSet->imgset_refid());
+    }
+}
+
+trait ImageSetDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsImageSetHandlerTest extends TestCase
+{
+    use ImageSetDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingSet(): void
+    {
+        $handler = new XoopsImageSetHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsImageSet::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesSetFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_imgset WHERE imgset_id=4')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'imgset_id'   => 4,
+            'imgset_name' => 'Classic',
+            'imgset_refid' => 7,
+        ]);
+
+        $handler = new XoopsImageSetHandler($database);
+        $imageSet = $handler->get(4);
+
+        $this->assertInstanceOf(XoopsImageSet::class, $imageSet);
+        $this->assertSame('Classic', $imageSet->getVar('imgset_name'));
+        $this->assertFalse($imageSet->isNew());
+    }
+
+    public function testInsertCreatesNewSet(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(21);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_imgset'))
+            ->willReturn(true);
+
+        $handler = new XoopsImageSetHandler($database);
+        $imageSet = $handler->create();
+        $imageSet->setVar('imgset_name', 'Modern');
+        $imageSet->setVar('imgset_refid', 3);
+
+        $this->assertTrue($handler->insert($imageSet));
+        $this->assertSame(21, $imageSet->getVar('imgset_id'));
+    }
+
+    public function testInsertUpdatesExistingSet(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_imgset SET imgset_name ='))
+            ->willReturn(true);
+
+        $handler = new XoopsImageSetHandler($database);
+        $imageSet = $handler->create(false);
+        $imageSet->setNew(false);
+        $imageSet->setVar('imgset_id', 6);
+        $imageSet->setVar('imgset_name', 'Updated');
+        $imageSet->setVar('imgset_refid', 4);
+
+        $this->assertTrue($handler->insert($imageSet));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsImageSetHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesSet(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ['DELETE FROM pref_imgset WHERE imgset_id = 6'],
+                ['DELETE FROM pref_imgset_tplset_link WHERE imgset_id = 6']
+            )
+            ->willReturn(true);
+
+        $handler = new XoopsImageSetHandler($database);
+        $imageSet = $handler->create(false);
+        $imageSet->setVar('imgset_id', 6);
+
+        $this->assertTrue($handler->delete($imageSet));
+    }
+
+    public function testGetObjectsReturnsResults(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT DISTINCT i.* FROM pref_imgset i LEFT JOIN pref_imgset_tplset_link l ON l.imgset_id=i.imgset_id WHERE (imgset_id > 0)', 5, 1)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'imgset_id' => 1,
+                'imgset_name' => 'Modern',
+                'imgset_refid' => 2,
+            ],
+            false
+        );
+
+        $handler = new XoopsImageSetHandler($database);
+        $criteria = new Criteria('imgset_id', 0, '>');
+        $criteria->setLimit(5);
+        $criteria->setStart(1);
+
+        $sets = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $sets);
+        $this->assertArrayHasKey(1, $sets);
+        $this->assertSame('Modern', $sets[1]->getVar('imgset_name'));
+    }
+
+    public function testLinkAndUnlinkThemeset(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ['DELETE FROM pref_imgset_tplset_link WHERE imgset_id = 3 AND tplset_name = \'default\''],
+                ['INSERT INTO pref_imgset_tplset_link (imgset_id, tplset_name) VALUES (3, \'default\')']
+            )
+            ->willReturn(true);
+
+        $handler = new XoopsImageSetHandler($database);
+
+        $this->assertTrue($handler->linkThemeset(3, 'default'));
+    }
+
+    public function testLinkThemesetRejectsInvalidInput(): void
+    {
+        $handler = new XoopsImageSetHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->linkThemeset(0, ''));
+    }
+
+    public function testUnlinkThemeset(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_imgset_tplset_link WHERE imgset_id = 3 AND tplset_name = \'legacy\'')
+            ->willReturn(true);
+
+        $handler = new XoopsImageSetHandler($database);
+
+        $this->assertTrue($handler->unlinkThemeset(3, 'legacy'));
+    }
+
+    public function testUnlinkThemesetRejectsInvalidInput(): void
+    {
+        $handler = new XoopsImageSetHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->unlinkThemeset(0, ''));
+    }
+
+    public function testGetListReturnsIdToNameMapping(): void
+    {
+        $setA = new XoopsImageSet();
+        $setA->setVar('imgset_id', 1);
+        $setA->setVar('imgset_name', 'Default');
+        $setB = new XoopsImageSet();
+        $setB->setVar('imgset_id', 2);
+        $setB->setVar('imgset_name', 'Custom');
+
+        $handler = $this->getMockBuilder(XoopsImageSetHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->method('getObjects')->willReturn([
+            1 => $setA,
+            2 => $setB,
+        ]);
+
+        $this->assertSame([
+            1 => 'Default',
+            2 => 'Custom',
+        ], $handler->getList(5, 'default'));
+    }
+}

--- a/tests/unit/XoopsImageTest.php
+++ b/tests/unit/XoopsImageTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/image.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsImageTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $image = new XoopsImage();
+
+        $this->assertNull($image->getVar('image_id'));
+        $this->assertNull($image->getVar('image_name'));
+        $this->assertNull($image->getVar('image_nicename'));
+        $this->assertNull($image->getVar('image_mimetype'));
+        $this->assertNull($image->getVar('image_created'));
+        $this->assertSame(1, $image->getVar('image_display'));
+        $this->assertSame(0, $image->getVar('image_weight'));
+        $this->assertNull($image->getVar('image_body'));
+        $this->assertSame(0, $image->getVar('imgcat_id'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $image = new XoopsImage();
+        $image->setVar('image_id', 7);
+        $image->setVar('image_name', 'logo.png');
+        $image->setVar('image_nicename', 'Logo');
+        $image->setVar('image_mimetype', 'image/png');
+        $image->setVar('image_created', 123);
+        $image->setVar('image_display', 0);
+        $image->setVar('image_weight', 3);
+        $image->setVar('image_body', 'bin');
+        $image->setVar('imgcat_id', 2);
+
+        $this->assertSame(7, $image->id());
+        $this->assertSame(7, $image->image_id());
+        $this->assertSame('logo.png', $image->image_name());
+        $this->assertSame('Logo', $image->image_nicename());
+        $this->assertSame('image/png', $image->image_mimetype());
+        $this->assertSame(123, $image->image_created());
+        $this->assertSame(0, $image->image_display());
+        $this->assertSame(3, $image->image_weight());
+        $this->assertSame('bin', $image->image_body());
+        $this->assertSame(2, $image->imgcat_id());
+    }
+}
+
+trait ImageDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsImageHandlerTest extends TestCase
+{
+    use ImageDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingImage(): void
+    {
+        $handler = new XoopsImageHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsImage::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesImageWithBody(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT i.*, b.image_body FROM pref_image i LEFT JOIN pref_imagebody b ON b.image_id=i.image_id WHERE i.image_id=5')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'image_id'        => 5,
+            'image_name'      => 'file.png',
+            'image_nicename'  => 'File',
+            'image_mimetype'  => 'image/png',
+            'image_created'   => 123,
+            'image_display'   => 1,
+            'image_weight'    => 0,
+            'image_body'      => 'data',
+            'imgcat_id'       => 9,
+        ]);
+
+        $handler = new XoopsImageHandler($database);
+        $image   = $handler->get(5);
+
+        $this->assertInstanceOf(XoopsImage::class, $image);
+        $this->assertSame('file.png', $image->getVar('image_name'));
+        $this->assertFalse($image->isNew());
+    }
+
+    public function testInsertCreatesNewImage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(11);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                [$this->stringContains('INSERT INTO pref_image')],
+                [$this->stringContains('INSERT INTO pref_imagebody')]
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsImageHandler($database);
+
+        $image = $handler->create();
+        $image->setVar('image_name', 'new.png');
+        $image->setVar('image_nicename', 'New');
+        $image->setVar('image_mimetype', 'image/png');
+        $image->setVar('image_display', 1);
+        $image->setVar('image_weight', 0);
+        $image->setVar('image_body', 'abc');
+        $image->setVar('imgcat_id', 1);
+
+        $this->assertTrue($handler->insert($image));
+        $this->assertSame(11, $image->getVar('image_id'));
+    }
+
+    public function testInsertUpdatesExistingImage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                [$this->stringContains('UPDATE pref_image SET')],
+                [$this->stringContains('UPDATE pref_imagebody SET')]
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsImageHandler($database);
+
+        $image = $handler->create(false);
+        $image->setNew(false);
+        $image->setVar('image_id', 4);
+        $image->setVar('image_name', 'update.png');
+        $image->setVar('image_nicename', 'Update');
+        $image->setVar('image_display', 1);
+        $image->setVar('image_weight', 2);
+        $image->setVar('image_body', 'def');
+        $image->setVar('imgcat_id', 3);
+
+        $this->assertTrue($handler->insert($image));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsImageHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesImageAndBody(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ['DELETE FROM pref_image WHERE image_id = 8'],
+                ['DELETE FROM pref_imagebody WHERE image_id = 8']
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsImageHandler($database);
+
+        $image = $handler->create(false);
+        $image->setVar('image_id', 8);
+
+        $this->assertTrue($handler->delete($image));
+    }
+
+    public function testGetObjectsReturnsImagesWithCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT i.*, b.image_body FROM pref_image i LEFT JOIN pref_imagebody b ON b.image_id=i.image_id WHERE (image_id > 0) ORDER BY image_weight ASC', 5, 2)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'image_id'        => 1,
+                'image_name'      => 'one.png',
+                'image_nicename'  => 'One',
+                'image_mimetype'  => 'image/png',
+                'image_display'   => 1,
+                'image_weight'    => 0,
+                'imgcat_id'       => 1,
+                'image_body'      => 'body',
+            ],
+            false
+        );
+
+        $handler  = new XoopsImageHandler($database);
+        $criteria = new Criteria('image_id', 0, '>');
+        $criteria->setLimit(5);
+        $criteria->setStart(2);
+
+        $images = $handler->getObjects($criteria, true, true);
+
+        $this->assertCount(1, $images);
+        $this->assertArrayHasKey(1, $images);
+        $this->assertSame('One', $images[1]->getVar('image_nicename'));
+    }
+
+    public function testGetCountReturnsValue(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(*) FROM pref_image WHERE (imgcat_id = 2)')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([3]);
+
+        $handler  = new XoopsImageHandler($database);
+        $criteria = new Criteria('imgcat_id', 2);
+
+        $this->assertSame(3, $handler->getCount($criteria));
+    }
+
+    public function testGetListReturnsNameToNicenameMapping(): void
+    {
+        $imageA = new XoopsImage();
+        $imageA->setVar('image_name', 'a');
+        $imageA->setVar('image_nicename', 'Alpha');
+        $imageB = new XoopsImage();
+        $imageB->setVar('image_name', 'b');
+        $imageB->setVar('image_nicename', 'Beta');
+
+        $handler = $this->getMockBuilder(XoopsImageHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->method('getObjects')->willReturn([$imageA, $imageB]);
+
+        $list = $handler->getList(1, 1);
+
+        $this->assertSame(['a' => 'Alpha', 'b' => 'Beta'], $list);
+    }
+}

--- a/tests/unit/XoopsImagecategoryTest.php
+++ b/tests/unit/XoopsImagecategoryTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/imagecategory.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsImagecategoryTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $category = new XoopsImagecategory();
+
+        $this->assertNull($category->getVar('imgcat_id'));
+        $this->assertNull($category->getVar('imgcat_name'));
+        $this->assertSame(1, $category->getVar('imgcat_display'));
+        $this->assertSame(0, $category->getVar('imgcat_weight'));
+        $this->assertSame(0, $category->getVar('imgcat_maxsize'));
+        $this->assertSame(0, $category->getVar('imgcat_maxwidth'));
+        $this->assertSame(0, $category->getVar('imgcat_maxheight'));
+        $this->assertNull($category->getVar('imgcat_type'));
+        $this->assertNull($category->getVar('imgcat_storetype'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $category = new XoopsImagecategory();
+        $category->setVar('imgcat_id', 5);
+        $category->setVar('imgcat_name', 'Icons');
+        $category->setVar('imgcat_display', 0);
+        $category->setVar('imgcat_weight', 2);
+        $category->setVar('imgcat_maxsize', 1024);
+        $category->setVar('imgcat_maxwidth', 80);
+        $category->setVar('imgcat_maxheight', 60);
+        $category->setVar('imgcat_type', 'C');
+        $category->setVar('imgcat_storetype', 'db');
+
+        $this->assertSame(5, $category->id());
+        $this->assertSame(5, $category->imgcat_id());
+        $this->assertSame('Icons', $category->imgcat_name());
+        $this->assertSame(0, $category->imgcat_display());
+        $this->assertSame(2, $category->imgcat_weight());
+        $this->assertSame(1024, $category->imgcat_maxsize());
+        $this->assertSame(80, $category->imgcat_maxwidth());
+        $this->assertSame(60, $category->imgcat_maxheight());
+        $this->assertSame('C', $category->imgcat_type());
+        $this->assertSame('db', $category->imgcat_storetype());
+    }
+
+    public function testImageCountHelpers(): void
+    {
+        $category = new XoopsImagecategory();
+        $category->setImageCount(7);
+
+        $this->assertSame(7, $category->getImageCount());
+    }
+}
+
+trait ImageCategoryDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsImagecategoryHandlerTest extends TestCase
+{
+    use ImageCategoryDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingCategory(): void
+    {
+        $handler = new XoopsImagecategoryHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsImagecategory::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesCategoryFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_imagecategory WHERE imgcat_id=3')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'imgcat_id'        => 3,
+            'imgcat_name'      => 'Banners',
+            'imgcat_display'   => 1,
+            'imgcat_weight'    => 0,
+            'imgcat_maxsize'   => 2000,
+            'imgcat_maxwidth'  => 400,
+            'imgcat_maxheight' => 300,
+            'imgcat_type'      => 'A',
+            'imgcat_storetype' => 'db',
+        ]);
+
+        $handler  = new XoopsImagecategoryHandler($database);
+        $category = $handler->get(3);
+
+        $this->assertInstanceOf(XoopsImagecategory::class, $category);
+        $this->assertSame('Banners', $category->getVar('imgcat_name'));
+        $this->assertFalse($category->isNew());
+    }
+
+    public function testInsertCreatesNewCategory(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(15);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->callback(static function ($sql) {
+                return str_contains($sql, 'INSERT INTO pref_imagecategory')
+                    && str_contains($sql, "'Icons'")
+                    && str_contains($sql, 'imgcat_display')
+                    && str_contains($sql, 'imgcat_weight');
+            }))
+            ->willReturn(true);
+
+        $handler  = new XoopsImagecategoryHandler($database);
+        $category = $handler->create();
+        $category->setVar('imgcat_name', 'Icons');
+        $category->setVar('imgcat_display', 1);
+        $category->setVar('imgcat_weight', 5);
+        $category->setVar('imgcat_maxsize', 1024);
+        $category->setVar('imgcat_maxwidth', 80);
+        $category->setVar('imgcat_maxheight', 60);
+        $category->setVar('imgcat_type', 'C');
+        $category->setVar('imgcat_storetype', 'db');
+
+        $this->assertTrue($handler->insert($category));
+        $this->assertSame(15, $category->getVar('imgcat_id'));
+    }
+
+    public function testInsertUpdatesExistingCategory(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_imagecategory SET imgcat_name ='))
+            ->willReturn(true);
+
+        $handler  = new XoopsImagecategoryHandler($database);
+        $category = $handler->create(false);
+        $category->setNew(false);
+        $category->setVar('imgcat_id', 9);
+        $category->setVar('imgcat_name', 'Updated');
+        $category->setVar('imgcat_display', 0);
+        $category->setVar('imgcat_weight', 2);
+        $category->setVar('imgcat_maxsize', 0);
+        $category->setVar('imgcat_maxwidth', 0);
+        $category->setVar('imgcat_maxheight', 0);
+        $category->setVar('imgcat_type', 'S');
+        $category->setVar('imgcat_storetype', 'db');
+
+        $this->assertTrue($handler->insert($category));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsImagecategoryHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesCategory(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_imagecategory WHERE imgcat_id = 4')
+            ->willReturn(true);
+
+        $handler  = new XoopsImagecategoryHandler($database);
+        $category = $handler->create(false);
+        $category->setVar('imgcat_id', 4);
+
+        $this->assertTrue($handler->delete($category));
+    }
+
+    public function testGetObjectsBuildsCriteriaAndReturnsCategories(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT DISTINCT c.* FROM pref_imagecategory c LEFT JOIN pref_group_permission l ON l.gperm_itemid=c.imgcat_id WHERE (l.gperm_name = 'imgcat_read' OR l.gperm_name = 'imgcat_write') AND (imgcat_display = 1) ORDER BY imgcat_weight, imgcat_id ASC", 3, 2)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'imgcat_id'        => 1,
+                'imgcat_name'      => 'Avatars',
+                'imgcat_display'   => 1,
+                'imgcat_weight'    => 0,
+                'imgcat_maxsize'   => 0,
+                'imgcat_maxwidth'  => 0,
+                'imgcat_maxheight' => 0,
+                'imgcat_type'      => 'C',
+                'imgcat_storetype' => 'db',
+            ],
+            [
+                'imgcat_id'        => 2,
+                'imgcat_name'      => 'Icons',
+                'imgcat_display'   => 1,
+                'imgcat_weight'    => 1,
+                'imgcat_maxsize'   => 0,
+                'imgcat_maxwidth'  => 0,
+                'imgcat_maxheight' => 0,
+                'imgcat_type'      => 'C',
+                'imgcat_storetype' => 'file',
+            ],
+            false
+        );
+
+        $handler  = new XoopsImagecategoryHandler($database);
+        $criteria = new Criteria('imgcat_display', 1);
+        $criteria->setLimit(3);
+        $criteria->setStart(2);
+
+        $categories = $handler->getObjects($criteria);
+
+        $this->assertCount(2, $categories);
+        $this->assertSame('Avatars', $categories[0]->getVar('imgcat_name'));
+        $this->assertSame('Icons', $categories[1]->getVar('imgcat_name'));
+    }
+
+    public function testGetCountUsesCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT COUNT(*) FROM pref_imagecategory i LEFT JOIN pref_group_permission l ON l.gperm_itemid=i.imgcat_id WHERE (l.gperm_name = 'imgcat_read' OR l.gperm_name = 'imgcat_write') AND (imgcat_display = 1)")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([4]);
+
+        $handler  = new XoopsImagecategoryHandler($database);
+        $criteria = new Criteria('imgcat_display', 1);
+
+        $this->assertSame(4, $handler->getCount($criteria));
+    }
+
+    public function testGetListBuildsCriteriaAndReturnsNames(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler  = $this->getMockBuilder(XoopsImagecategoryHandler::class)
+            ->onlyMethods(['getObjects'])
+            ->setConstructorArgs([$database])
+            ->getMock();
+
+        $categoryOne = new XoopsImagecategory();
+        $categoryOne->assignVar('imgcat_id', 1);
+        $categoryOne->assignVar('imgcat_name', 'Icons');
+
+        $categoryTwo = new XoopsImagecategory();
+        $categoryTwo->assignVar('imgcat_id', 2);
+        $categoryTwo->assignVar('imgcat_name', 'Banners');
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(CriteriaCompo::class), true)
+            ->willReturn([
+                1 => $categoryOne,
+                2 => $categoryTwo,
+            ]);
+
+        $groups = [1, 2];
+        $list   = $handler->getList($groups, 'imgcat_write', 1, 'db');
+
+        $this->assertSame([
+            1 => 'Icons',
+            2 => 'Banners',
+        ], $list);
+    }
+}

--- a/tests/unit/XoopsImagesetimgTest.php
+++ b/tests/unit/XoopsImagesetimgTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/imagesetimg.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsImagesetimgTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $image = new XoopsImagesetimg();
+
+        $this->assertNull($image->getVar('imgsetimg_id'));
+        $this->assertNull($image->getVar('imgsetimg_file'));
+        $this->assertNull($image->getVar('imgsetimg_body'));
+        $this->assertNull($image->getVar('imgsetimg_imgset'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $image = new XoopsImagesetimg();
+        $image->setVar('imgsetimg_id', 12);
+        $image->setVar('imgsetimg_file', 'logo.png');
+        $image->setVar('imgsetimg_body', 'binary-data');
+        $image->setVar('imgsetimg_imgset', 7);
+
+        $this->assertSame(12, $image->id());
+        $this->assertSame(12, $image->imgsetimg_id());
+        $this->assertSame('logo.png', $image->imgsetimg_file());
+        $this->assertSame('binary-data', $image->imgsetimg_body());
+        $this->assertSame(7, $image->imgsetimg_imgset());
+    }
+}
+
+trait ImagesetimgDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsImagesetimgHandlerTest extends TestCase
+{
+    use ImagesetimgDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingImage(): void
+    {
+        $handler = new XoopsImagesetimgHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsImagesetimg::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesImageFromDatabase(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_imgsetimg WHERE imgsetimg_id=5')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'imgsetimg_id' => 5,
+            'imgsetimg_file' => 'icon.gif',
+            'imgsetimg_body' => 'binary',
+            'imgsetimg_imgset' => 2,
+        ]);
+
+        $handler = new XoopsImagesetimgHandler($database);
+        $image = $handler->get(5);
+
+        $this->assertInstanceOf(XoopsImagesetimg::class, $image);
+        $this->assertSame('icon.gif', $image->getVar('imgsetimg_file'));
+        $this->assertFalse($image->isNew());
+    }
+
+    public function testInsertCreatesNewImage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(30);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_imgsetimg'))
+            ->willReturn(true);
+
+        $handler = new XoopsImagesetimgHandler($database);
+        $image = $handler->create();
+        $image->setVar('imgsetimg_file', 'background.jpg');
+        $image->setVar('imgsetimg_body', 'data');
+        $image->setVar('imgsetimg_imgset', 8);
+
+        $this->assertTrue($handler->insert($image));
+        $this->assertSame(30, $image->getVar('imgsetimg_id'));
+    }
+
+    public function testInsertUpdatesExistingImage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with($this->stringContains('UPDATE pref_imgsetimg SET imgsetimg_file ='))
+            ->willReturn(true);
+
+        $handler = new XoopsImagesetimgHandler($database);
+        $image = $handler->create(false);
+        $image->setNew(false);
+        $image->setVar('imgsetimg_id', 9);
+        $image->setVar('imgsetimg_file', 'updated.gif');
+        $image->setVar('imgsetimg_body', 'content');
+        $image->setVar('imgsetimg_imgset', 4);
+
+        $this->assertTrue($handler->insert($image));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsImagesetimgHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesImage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_imgsetimg WHERE imgsetimg_id = 10')
+            ->willReturn(true);
+
+        $handler = new XoopsImagesetimgHandler($database);
+        $image = $handler->create(false);
+        $image->setVar('imgsetimg_id', 10);
+
+        $this->assertTrue($handler->delete($image));
+    }
+
+    public function testGetObjectsReturnsResults(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT DISTINCT i.* FROM pref_imgsetimg i LEFT JOIN pref_imgset_tplset_link l ON l.imgset_id=i.imgsetimg_imgset LEFT JOIN pref_imgset s ON s.imgset_id=l.imgset_id WHERE(imgsetimg_imgset > 0) ORDER BY imgsetimg_id ASC', 3, 2)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'imgsetimg_id' => 1,
+                'imgsetimg_file' => 'logo.png',
+                'imgsetimg_body' => 'content',
+                'imgsetimg_imgset' => 3,
+            ],
+            false
+        );
+
+        $handler = new XoopsImagesetimgHandler($database);
+        $criteria = new Criteria('imgsetimg_imgset', 0, '>');
+        $criteria->setLimit(3);
+        $criteria->setStart(2);
+
+        $images = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $images);
+        $this->assertArrayHasKey(1, $images);
+        $this->assertSame('logo.png', $images[1]->getVar('imgsetimg_file'));
+    }
+
+    public function testGetCountReturnsNumberOfImages(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT COUNT(i.imgsetimg_id) FROM pref_imgsetimg i LEFT JOIN pref_imgset_tplset_link l ON l.imgset_id=i.imgsetimg_imgset')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([5]);
+
+        $handler = new XoopsImagesetimgHandler($database);
+
+        $this->assertSame(5, $handler->getCount());
+    }
+
+    public function testGetByImagesetDelegatesToGetObjects(): void
+    {
+        $handler = $this->getMockBuilder(XoopsImagesetimgHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $expected = ['result'];
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(Criteria::class), false)
+            ->willReturn($expected);
+
+        $this->assertSame($expected, $handler->getByImageset(4));
+    }
+
+    public function testImageExistsUsesCount(): void
+    {
+        $handler = $this->getMockBuilder(XoopsImagesetimgHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getCount'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getCount')
+            ->with($this->isInstanceOf(CriteriaCompo::class))
+            ->willReturn(2);
+
+        $this->assertTrue($handler->imageExists('logo.png', 7));
+    }
+}

--- a/tests/unit/XoopsLoadTest.php
+++ b/tests/unit/XoopsLoadTest.php
@@ -1,0 +1,113 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class XoopsLoadTest extends TestCase
+{
+    private string $rootPath;
+
+    protected function setUp(): void
+    {
+        $this->rootPath = sys_get_temp_dir() . '/xoops_load_' . uniqid();
+        mkdir($this->rootPath . '/class/logger', 0777, true);
+        mkdir($this->rootPath . '/Frameworks', 0777, true);
+        mkdir($this->rootPath . '/modules', 0777, true);
+
+        if (!defined('XOOPS_ROOT_PATH')) {
+            define('XOOPS_ROOT_PATH', $this->rootPath);
+        }
+
+        require_once __DIR__ . '/../../htdocs/class/xoopsload.php';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->rootPath);
+    }
+
+    public function testLoadReturnsTrueForExistingClass(): void
+    {
+        $this->assertFalse(class_exists('ExistingClass', false));
+        class_exists('ExistingClass') || eval('class ExistingClass {}');
+
+        $this->assertTrue(XoopsLoad::load('ExistingClass'));
+    }
+
+    public function testLoadMapsDeprecatedNamesAndLogsMessage(): void
+    {
+        $logger = new class {
+            public array $messages = [];
+            public function addDeprecated($message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+        $GLOBALS['xoopsLogger'] = $logger;
+
+        file_put_contents($this->rootPath . '/class/uploader.php', "<?php\nclass xoopsmediauploader {}\n");
+
+        $this->assertTrue(XoopsLoad::load('uploader'));
+        $this->assertSame(["xoops_load('uploader') is deprecated, use xoops_load('xoopsmediauploader')"], $logger->messages);
+    }
+
+    public function testLoadCoreCallsAutoloadWhenDeclared(): void
+    {
+        $file = $this->rootPath . '/class/logger/xoopslogger.php';
+        file_put_contents($file, <<<'LOGGER'
+<?php
+class xoopslogger
+{
+    public static $autoloadCalled = false;
+    public static function __autoload()
+    {
+        self::$autoloadCalled = true;
+    }
+}
+LOGGER
+        );
+
+        $this->assertTrue(XoopsLoad::load('xoopslogger'));
+        $this->assertTrue(xoopslogger::$autoloadCalled);
+    }
+
+    public function testLoadFrameworkReturnsLoadedClassName(): void
+    {
+        mkdir($this->rootPath . '/Frameworks/foo', 0777, true);
+        file_put_contents($this->rootPath . '/Frameworks/foo/xoopsfoo.php', "<?php\nclass XoopsFoo {}\n");
+
+        $this->assertSame('XoopsFoo', XoopsLoad::load('foo', 'framework'));
+    }
+
+    public function testLoadModuleLoadsClassFromModuleDirectory(): void
+    {
+        mkdir($this->rootPath . '/modules/demo/class', 0777, true);
+        file_put_contents($this->rootPath . '/modules/demo/class/sample.php', "<?php\nclass DemoSample {}\n");
+
+        $this->assertTrue(XoopsLoad::load('sample', 'demo'));
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getRealPath());
+            } else {
+                unlink($item->getRealPath());
+            }
+        }
+
+        @rmdir($directory);
+    }
+}

--- a/tests/unit/XoopsLocalAbstractTest.php
+++ b/tests/unit/XoopsLocalAbstractTest.php
@@ -1,0 +1,182 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class XoopsLocalAbstractTest extends TestCase
+{
+    private function ensureDependenciesLoaded(): void
+    {
+        if (!defined('XOOPS_ROOT_PATH')) {
+            define('XOOPS_ROOT_PATH', sys_get_temp_dir());
+        }
+        if (!defined('_CHARSET')) {
+            define('_CHARSET', 'UTF-8');
+        }
+
+        if (!function_exists('xoops_getUserTimestamp')) {
+            function xoops_getUserTimestamp($time, $timeoffset = 0)
+            {
+                return (int)$time + (float)$timeoffset * 3600;
+            }
+        }
+
+        require_once __DIR__ . '/../../htdocs/class/xoopslocal.php';
+    }
+
+    private function defineTimeConstants(): void
+    {
+        $constants = [
+            '_TIMEFORMAT_DESC' => 'Time format description',
+            '_SHORTDATESTRING' => 'm/d/y',
+            '_MEDIUMDATESTRING' => 'M d, Y',
+            '_DATESTRING' => 'Y-m-d H:i:s',
+            '_TODAY' => 'Today',
+            '_YESTERDAY' => 'Yesterday',
+            '_YEARMONTHDAY' => 'Y-m-d',
+            '_MONTHDAY' => 'm-d',
+            '_ELAPSE' => '%s ago',
+            '_DAYS' => '%d days',
+            '_DAY' => 'a day',
+            '_HOURS' => '%d hours',
+            '_HOUR' => 'an hour',
+            '_MINUTES' => '%d minutes',
+            '_MINUTE' => 'a minute',
+            '_SECONDS' => '%d seconds',
+            '_SECOND' => 'a second',
+        ];
+
+        foreach ($constants as $name => $value) {
+            if (!defined($name)) {
+                define($name, $value);
+            }
+        }
+    }
+
+    public function testSubstrTrimsWithMarkerWhenNotMultibyte(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->ensureDependenciesLoaded();
+
+        $result = XoopsLocalAbstract::substr('hello world', 0, 5, '...');
+        $this->assertSame('he...', $result);
+    }
+
+    public function testSubstrUsesMbFunctionsWhenAvailable(): void
+    {
+        if (!function_exists('mb_internal_encoding') || !function_exists('mb_strcut') || !function_exists('mb_strlen')) {
+            $this->markTestSkipped('Multibyte string functions not available');
+        }
+
+        define('XOOPS_USE_MULTIBYTES', true);
+        $this->ensureDependenciesLoaded();
+
+        $text = '你好世界';
+        $result = XoopsLocalAbstract::substr($text, 0, 6, '...');
+
+        $this->assertStringEndsWith('...', $result);
+        $this->assertNotSame($text, $result);
+    }
+
+    public function testConvertEncodingReturnsOriginalWhenEmpty(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->ensureDependenciesLoaded();
+
+        $this->assertSame('', XoopsLocalAbstract::convert_encoding(''));
+    }
+
+    public function testConvertEncodingUsesMultibyteConversion(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', true);
+        $this->ensureDependenciesLoaded();
+
+        $latin1 = "\xe9"; // "é" in ISO-8859-1
+        $converted = XoopsLocalAbstract::convert_encoding($latin1, 'UTF-8', 'ISO-8859-1');
+
+        $this->assertSame('é', $converted);
+    }
+
+    public function testConvertEncodingFallsBackToOriginalOnFailure(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', true);
+        $this->ensureDependenciesLoaded();
+
+        $text = 'unchanged';
+        $this->assertSame($text, XoopsLocalAbstract::convert_encoding($text, 'utf-8', 'invalid-charset'));
+    }
+
+    public function testTrimDelegatesToPhpTrim(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->ensureDependenciesLoaded();
+
+        $this->assertSame('value', XoopsLocalAbstract::trim("  value  \n"));
+    }
+
+    public function testGetTimeFormatDescReturnsConstant(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->defineTimeConstants();
+        $this->ensureDependenciesLoaded();
+
+        $this->assertSame(_TIMEFORMAT_DESC, XoopsLocalAbstract::getTimeFormatDesc());
+    }
+
+    public function testFormatTimestampRssUsesGmdate(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->defineTimeConstants();
+        $this->ensureDependenciesLoaded();
+
+        $GLOBALS['xoopsConfig'] = ['server_TZ' => 0, 'default_TZ' => '0'];
+
+        $this->assertSame('Thu, 01 Jan 1970 00:00:00 +0000', XoopsLocalAbstract::formatTimestamp(0, 'rss'));
+    }
+
+    public function testFormatTimestampElapseDescribesElapsedMinutes(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->defineTimeConstants();
+        $this->ensureDependenciesLoaded();
+
+        $GLOBALS['xoopsConfig'] = ['server_TZ' => 0, 'default_TZ' => '0'];
+        $time = time() - 120;
+
+        $this->assertSame('2 minutes ago', XoopsLocalAbstract::formatTimestamp($time, 'e'));
+    }
+
+    public function testFormatTimestampCustomReturnsTodayLabel(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->defineTimeConstants();
+        $this->ensureDependenciesLoaded();
+
+        $GLOBALS['xoopsConfig'] = ['server_TZ' => 0, 'default_TZ' => '0'];
+        $now = time();
+
+        $this->assertSame('Today', XoopsLocalAbstract::formatTimestamp($now, 'c'));
+    }
+
+    public function testNumberAndMoneyFormatReturnInput(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->ensureDependenciesLoaded();
+
+        $instance = new XoopsLocalAbstract();
+        $this->assertSame(1234, $instance->number_format(1234));
+        $this->assertSame(12.34, $instance->money_format('%i', 12.34));
+    }
+
+    public function testCallDelegatesToExistingFunctionOrReturnsNull(): void
+    {
+        define('XOOPS_USE_MULTIBYTES', false);
+        $this->ensureDependenciesLoaded();
+
+        $instance = new XoopsLocalAbstract();
+        $this->assertSame('lower', $instance->strtolower('LOWER'));
+        $this->assertNull($instance->nonexistent_function('value'));
+    }
+}

--- a/tests/unit/XoopsLoggerTest.php
+++ b/tests/unit/XoopsLoggerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/logger/xoopslogger.php';
+
+if (!defined('_XOOPS_FATAL_MESSAGE')) {
+    define('_XOOPS_FATAL_MESSAGE', 'Fatal: %s');
+}
+if (!defined('_XOOPS_FATAL_BACKTRACE')) {
+    define('_XOOPS_FATAL_BACKTRACE', 'Backtrace');
+}
+if (!defined('_LOGGER_INCLUDED_FILES')) {
+    define('_LOGGER_INCLUDED_FILES', 'Included');
+}
+if (!defined('_LOGGER_FILES')) {
+    define('_LOGGER_FILES', 'Files: %d');
+}
+if (!defined('_LOGGER_MEM_ESTIMATED')) {
+    define('_LOGGER_MEM_ESTIMATED', 'Estimated: %s');
+}
+if (!defined('_LOGGER_MEM_USAGE')) {
+    define('_LOGGER_MEM_USAGE', 'Memory');
+}
+if (!defined('_LOGGER_DEBUG')) {
+    define('_LOGGER_DEBUG', 'Debug');
+}
+if (!defined('_LANGCODE')) {
+    define('_LANGCODE', 'en');
+}
+if (!defined('_CHARSET')) {
+    define('_CHARSET', 'utf-8');
+}
+if (!defined('_CLOSE')) {
+    define('_CLOSE', 'Close');
+}
+if (!defined('_LOGGER_NONE')) {
+    define('_LOGGER_NONE', 'None');
+}
+if (!defined('_LOGGER_ALL')) {
+    define('_LOGGER_ALL', 'All');
+}
+if (!defined('_LOGGER_ERRORS')) {
+    define('_LOGGER_ERRORS', 'Errors');
+}
+if (!defined('_LOGGER_E_USER_NOTICE')) {
+    define('_LOGGER_E_USER_NOTICE', 'User notice');
+}
+if (!defined('_LOGGER_E_USER_WARNING')) {
+    define('_LOGGER_E_USER_WARNING', 'User warning');
+}
+if (!defined('_LOGGER_E_USER_ERROR')) {
+    define('_LOGGER_E_USER_ERROR', 'User error');
+}
+if (!defined('_LOGGER_E_NOTICE')) {
+    define('_LOGGER_E_NOTICE', 'Notice');
+}
+if (!defined('_LOGGER_E_WARNING')) {
+    define('_LOGGER_E_WARNING', 'Warning');
+}
+if (!defined('_LOGGER_UNKNOWN')) {
+    define('_LOGGER_UNKNOWN', 'Unknown');
+}
+if (!defined('_LOGGER_FILELINE')) {
+    define('_LOGGER_FILELINE', '%s in %s (%s)');
+}
+if (!defined('_LOGGER_DEPRECATED')) {
+    define('_LOGGER_DEPRECATED', 'Deprecated');
+}
+if (!defined('_LOGGER_TIMERS')) {
+    define('_LOGGER_TIMERS', 'Timers');
+}
+if (!defined('_LOGGER_TIME')) {
+    define('_LOGGER_TIME', 'Time');
+}
+if (!defined('_LOGGER_QUERIES')) {
+    define('_LOGGER_QUERIES', 'Queries');
+}
+if (!defined('_LOGGER_BLOCKS')) {
+    define('_LOGGER_BLOCKS', 'Blocks');
+}
+if (!defined('_LOGGER_EXTRA')) {
+    define('_LOGGER_EXTRA', 'Extra');
+}
+if (!defined('_LOGGER_CAPTION')) {
+    define('_LOGGER_CAPTION', 'Caption');
+}
+if (!defined('_LOGGER_SEPARATOR')) {
+    define('_LOGGER_SEPARATOR', 'Separator');
+}
+if (!defined('_LOGGER_TYPE')) {
+    define('_LOGGER_TYPE', 'Type');
+}
+if (!defined('_XOOPS_SIDEBLOCK_LEFT')) {
+    define('_XOOPS_SIDEBLOCK_LEFT', 0);
+}
+if (!defined('_XOOPS_SIDEBLOCK_RIGHT')) {
+    define('_XOOPS_SIDEBLOCK_RIGHT', 0);
+}
+if (!defined('_XOOPS_CENTERBLOCK_LEFT')) {
+    define('_XOOPS_CENTERBLOCK_LEFT', 0);
+}
+if (!defined('_XOOPS_CENTERBLOCK_RIGHT')) {
+    define('_XOOPS_CENTERBLOCK_RIGHT', 0);
+}
+if (!defined('_XOOPS_CENTERBLOCK_CENTER')) {
+    define('_XOOPS_CENTERBLOCK_CENTER', 0);
+}
+if (!defined('_XOOPS_LOGGER_OBJECT')) {
+    define('_XOOPS_LOGGER_OBJECT', 'obj');
+}
+if (!defined('_XOOPS_LOGGER_INCLUDE_FILES')) {
+    define('_XOOPS_LOGGER_INCLUDE_FILES', 'include');
+}
+if (!defined('XOOPS_DB_PREFIX')) {
+    define('XOOPS_DB_PREFIX', 'pref');
+}
+if (!defined('XOOPS_DB_NAME')) {
+    define('XOOPS_DB_NAME', 'dbname');
+}
+
+class XoopsLoggerTest extends TestCase
+{
+    /** @var callable|null */
+    private $originalErrorHandler;
+    /** @var callable|null */
+    private $originalExceptionHandler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalErrorHandler = set_error_handler(function () {
+        });
+        set_error_handler($this->originalErrorHandler);
+        $this->originalExceptionHandler = set_exception_handler(function () {
+        });
+        set_exception_handler($this->originalExceptionHandler);
+    }
+
+    protected function tearDown(): void
+    {
+        set_error_handler($this->originalErrorHandler);
+        set_exception_handler($this->originalExceptionHandler);
+        unset($GLOBALS['xoopsLogger']);
+        parent::tearDown();
+    }
+
+    public function testSingletonRegistersHandlers(): void
+    {
+        $logger = XoopsLogger::getInstance();
+
+        $previousHandler = set_error_handler($this->originalErrorHandler);
+        $this->assertSame('XoopsErrorHandler_HandleError', $previousHandler);
+        set_error_handler($this->originalErrorHandler);
+
+        $previousException = set_exception_handler($this->originalExceptionHandler);
+        $this->assertSame([$logger, 'handleException'], $previousException);
+        set_exception_handler($this->originalExceptionHandler);
+
+        $this->assertSame($logger, XoopsLogger::getInstance());
+    }
+
+    public function testLoggingStorageAndTimers(): void
+    {
+        $logger = new XoopsLogger();
+        $GLOBALS['xoopsLogger'] = $logger;
+
+        $logger->addQuery('SELECT *', 'oops', 5, 0.5);
+        $logger->addBlock('block', true, 30);
+        $logger->addExtra('note', 'message');
+        $logger->addDeprecated('deprecated call');
+
+        $this->assertCount(1, $logger->queries);
+        $this->assertSame('SELECT *', $logger->queries[0]['sql']);
+        $this->assertCount(1, $logger->blocks);
+        $this->assertSame('block', $logger->blocks[0]['name']);
+        $this->assertCount(1, $logger->extra);
+        $this->assertSame('note', $logger->extra[0]['name']);
+        $this->assertCount(1, $logger->deprecated);
+        $this->assertStringContainsString('deprecated call', $logger->deprecated[0]);
+        $this->assertStringContainsString('trace:', $logger->deprecated[0]);
+
+        $logger->startTime('t');
+        usleep(1000);
+        $logger->stopTime('t');
+
+        $elapsed = $logger->dumpTime('t');
+        $this->assertGreaterThan(0, $elapsed);
+
+        $logger->dumpTime('t', true);
+        $this->assertArrayNotHasKey('t', $logger->logstart);
+    }
+
+    public function testTriggerErrorSanitizesPath(): void
+    {
+        $logger = new XoopsLogger();
+        $GLOBALS['xoopsLogger'] = $logger;
+
+        $logger->triggerError(5, 'Issue %s', XOOPS_ROOT_PATH . '/file.php', 123, E_USER_WARNING);
+
+        $this->assertCount(1, $logger->deprecated);
+        $this->assertCount(1, $logger->errors);
+        $error = $logger->errors[0];
+        $this->assertSame(E_USER_WARNING, $error['errno']);
+        $this->assertSame('Issue 5', $error['errstr']);
+        $this->assertSame('/file.php', $error['errfile']);
+        $this->assertSame(123, $error['errline']);
+    }
+
+    public function testHandleExceptionUsesSanitizedMessage(): void
+    {
+        $logger = new class extends XoopsLogger {
+            public array $handled = [];
+            public function handleError($errno, $errstr, $errfile, $errline, $trace = null)
+            {
+                $this->handled = func_get_args();
+            }
+            public function exposeSanitizePath($path)
+            {
+                return $this->sanitizePath($path);
+            }
+        };
+
+        $GLOBALS['xoopsLogger'] = $logger;
+        $exception = new Exception('pref_table error in dbname.table');
+        $logger->handleException($exception);
+
+        $this->assertSame(E_USER_ERROR, $logger->handled[0]);
+        $this->assertSame('Exception: table error in table', $logger->handled[1]);
+        $this->assertSame($exception->getLine(), $logger->handled[3]);
+
+        $sanitized = $logger->exposeSanitizePath(XOOPS_ROOT_PATH . '/dir/file.php');
+        $this->assertSame('/dir/file.php', $sanitized);
+    }
+}

--- a/tests/unit/XoopsMailerTest.php
+++ b/tests/unit/XoopsMailerTest.php
@@ -1,0 +1,281 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+/**
+ * Stub for resolving XoopsMultiMailer include path.
+ */
+class XoopsPathStub
+{
+    /** @var string */
+    public $stubPath;
+
+    public function path($file)
+    {
+        if ($file === 'class/mail/xoopsmultimailer.php') {
+            return $this->stubPath;
+        }
+
+        return $file;
+    }
+}
+
+class XoopsMailerTest extends TestCase
+{
+    /** @var string */
+    private $mailerStub;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mailerStub = sys_get_temp_dir() . '/xoopsmailer_stub.php';
+        file_put_contents(
+            $this->mailerStub,
+            <<<'PHP'
+<?php
+namespace PHPMailer\PHPMailer {
+    class Exception extends \Exception {}
+}
+
+class XoopsMultiMailer
+{
+    public $isHtmlFlag;
+    public $addresses = [];
+    public $headers = [];
+    public $Subject;
+    public $Body;
+    public $CharSet;
+    public $Encoding;
+    public $FromName;
+    public $Sender;
+    public $From;
+    public $sendReturn = true;
+    public $ErrorInfo = 'mailer error';
+    public $sendException;
+
+    public function isHTML($value)
+    {
+        $this->isHtmlFlag = $value;
+    }
+
+    public function clearAllRecipients()
+    {
+        $this->addresses = [];
+    }
+
+    public function addAddress($email)
+    {
+        $this->addresses[] = $email;
+    }
+
+    public function clearCustomHeaders()
+    {
+        $this->headers = [];
+    }
+
+    public function addCustomHeader($header)
+    {
+        $this->headers[] = $header;
+    }
+
+    public function send()
+    {
+        if ($this->sendException) {
+            throw new \PHPMailer\PHPMailer\Exception($this->sendException);
+        }
+
+        return $this->sendReturn;
+    }
+}
+PHP
+        );
+
+        $pathStub            = new XoopsPathStub();
+        $pathStub->stubPath  = $this->mailerStub;
+        $GLOBALS['xoops']    = $pathStub;
+        $GLOBALS['xoopsConfig'] = [
+            'adminmail' => 'admin@example.com',
+            'sitename'  => 'Test Site',
+            'language'  => 'english',
+        ];
+
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'http://example.com');
+        }
+
+        foreach ([
+                     '_MAIL_MSGBODY'   => 'message body missing',
+                     '_MAIL_FAILOPTPL' => 'missing template',
+                     '_MAIL_SENDMAILNG'=> 'send failure to %s',
+                     '_MAIL_MAILGOOD'  => 'good send to %s',
+                     '_ERRORS'         => 'Errors',
+                 ] as $constant => $value) {
+            if (!defined($constant)) {
+                define($constant, $value);
+            }
+        }
+
+        require_once XOOPS_ROOT_PATH . '/class/xoopsmailer.php';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->mailerStub);
+        parent::tearDown();
+    }
+
+    public function testConstructorResetsDefaults(): void
+    {
+        $mailer = new XoopsMailer();
+
+        $this->assertSame('', $mailer->fromEmail);
+        $this->assertSame('', $mailer->fromName);
+        $this->assertNull($mailer->fromUser);
+        $this->assertSame([], $mailer->toEmails);
+        $this->assertSame([], $mailer->headers);
+        $this->assertSame('', $mailer->subject);
+        $this->assertSame('', $mailer->body);
+        $this->assertFalse($mailer->isMail);
+        $this->assertFalse($mailer->isPM);
+        $this->assertSame("\n", $mailer->LE);
+        $this->assertSame('iso-8859-1', $mailer->charSet);
+        $this->assertSame('8bit', $mailer->encoding);
+    }
+
+    public function testSetHtmlDelegatesToMultimailer(): void
+    {
+        $mailer                = new XoopsMailer();
+        $mailer->setHTML(false);
+
+        $this->assertFalse($mailer->multimailer->isHtmlFlag);
+    }
+
+    public function testSetTemplateDirUsesModuleDirnameWhenNull(): void
+    {
+        $module = $this->getMockBuilder(stdClass::class)
+            ->setMethods(['getVar'])
+            ->getMock();
+        $module->expects($this->once())
+            ->method('getVar')
+            ->with('dirname', 'n')
+            ->willReturn('moddir');
+        $GLOBALS['xoopsModule'] = $module;
+
+        $mailer = new XoopsMailer();
+        $mailer->setTemplateDir();
+
+        $this->assertSame('moddir', $mailer->templatedir);
+
+        $mailer->setTemplateDir('path\\to\\tpl');
+        $this->assertSame('path/to/tpl', $mailer->templatedir);
+    }
+
+    public function testGetTemplatePathFallsBackToEnglish(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/xoopsmailer_tpl/';
+        $tplPath = $tempDir . 'english/mail_template/sample.tpl';
+        if (!is_dir(dirname($tplPath))) {
+            mkdir(dirname($tplPath), 0777, true);
+        }
+        file_put_contents($tplPath, 'template body');
+
+        $mailer = new XoopsMailer();
+        $mailer->setTemplateDir($tempDir);
+        $mailer->setTemplate('sample.tpl');
+        $GLOBALS['xoopsConfig']['language'] = 'french';
+
+        $this->assertSame($tplPath, $mailer->getTemplatePath());
+    }
+
+    public function testSendReturnsFalseWhenMissingBodyAndTemplate(): void
+    {
+        $mailer = new XoopsMailer();
+
+        $this->assertFalse($mailer->send(true));
+        $this->assertSame(['message body missing'], $mailer->errors);
+    }
+
+    public function testSendLoadsTemplateAndReplacesTags(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/xoopsmailer_tpl2/';
+        $tplPath = $tempDir . 'english/mail_template/sample.tpl';
+        if (!is_dir(dirname($tplPath))) {
+            mkdir(dirname($tplPath), 0777, true);
+        }
+        file_put_contents($tplPath, 'Hello {NAME}');
+
+        $mailer = new class extends XoopsMailer {
+            public $sent = [];
+            public $sendReturn = true;
+
+            public function sendMail($email, $subject, $body, $headers)
+            {
+                $this->sent[] = compact('email', 'subject', 'body', 'headers');
+
+                return $this->sendReturn;
+            }
+        };
+        $mailer->setTemplateDir($tempDir);
+        $mailer->setTemplate('sample.tpl');
+        $mailer->setSubject('Welcome {NAME}');
+        $mailer->assign('name', 'Tester');
+        $mailer->setToEmails('user@example.com');
+
+        $this->assertTrue($mailer->send(true));
+        $this->assertSame(
+            [
+                [
+                    'email'   => 'user@example.com',
+                    'subject' => 'Welcome Tester',
+                    'body'    => "Hello Tester\n",
+                    'headers' => '',
+                ],
+            ],
+            $mailer->sent
+        );
+        $this->assertSame(['good send to user@example.com'], $mailer->success);
+    }
+
+    public function testSendMailAddsErrorOnFailure(): void
+    {
+        $mailer              = new XoopsMailer();
+        $mailer->fromName    = 'Sender Name';
+        $mailer->fromEmail   = 'sender@example.com';
+        $mailer->headers     = ['X-Test: 1'];
+        $mailer->multimailer->sendReturn = false;
+        $mailer->multimailer->ErrorInfo  = 'fail reason';
+
+        $this->assertFalse($mailer->sendMail('dest@example.com', 'Subject', 'Body', 'Headers'));
+        $this->assertSame(['fail reason'], $mailer->errors);
+    }
+
+    public function testSendMailCatchesMailerException(): void
+    {
+        $mailer                     = new XoopsMailer();
+        $mailer->multimailer->sendException = 'boom';
+
+        $this->assertFalse($mailer->sendMail('dest@example.com', 'Subject', 'Body', 'Headers'));
+        $this->assertSame(['boom'], $mailer->errors);
+    }
+
+    public function testAssignCollectsTags(): void
+    {
+        $mailer = new XoopsMailer();
+        $mailer->assign('token', 'value');
+        $mailer->assign(['item' => 'v2']);
+
+        $this->assertSame(['TOKEN' => 'value', 'ITEM' => 'v2'], $mailer->assignedTags);
+    }
+
+    public function testGetErrorsReturnsHtml(): void
+    {
+        $mailer = new XoopsMailer();
+        $mailer->errors = ['one', 'two'];
+
+        $this->assertSame('<h4>Errors</h4>one<br>two<br>', $mailer->getErrors());
+        $this->assertSame(['one', 'two'], $mailer->getErrors(false));
+    }
+}
+

--- a/tests/unit/XoopsMediaUploaderTest.php
+++ b/tests/unit/XoopsMediaUploaderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Xmf {
+    if (!class_exists('Xmf\\Request')) {
+        class Request
+        {
+            public static $files = [];
+
+            public static function reset(): void
+            {
+                self::$files = [];
+            }
+
+            public static function hasVar($key, $type)
+            {
+                return $type === 'FILES' && array_key_exists($key, self::$files);
+            }
+
+            public static function getArray($key, $default = [], $type = 'GET')
+            {
+                if ($type === 'FILES' && array_key_exists($key, self::$files)) {
+                    return self::$files[$key];
+                }
+
+                return $default;
+            }
+        }
+    }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/init_new.php';
+
+    class XoopsPathStub
+    {
+        public function path($file)
+        {
+            return XOOPS_ROOT_PATH . '/' . ltrim($file, '/');
+        }
+    }
+
+    require_once XOOPS_ROOT_PATH . '/class/uploader.php';
+
+    class TestMediaUploader extends XoopsMediaUploader
+    {
+        public $copyCalled = false;
+
+        public function _copyFile($chmod)
+        {
+            $matched = [];
+            if (!preg_match('/\.([a-zA-Z0-9]+)$/', $this->mediaName, $matched)) {
+                $this->setErrors(_ER_UP_INVALIDFILENAME);
+
+                return false;
+            }
+
+            if (isset($this->targetFileName)) {
+                $this->savedFileName = $this->targetFileName;
+            } elseif (isset($this->prefix)) {
+                $this->savedFileName = uniqid($this->prefix, false) . '.' . strtolower($matched[1]);
+            } else {
+                $this->savedFileName = strtolower($this->mediaName);
+            }
+
+            $this->savedFileName    = iconv('UTF-8', 'ASCII//TRANSLIT', $this->savedFileName);
+            $this->savedFileName    = preg_replace('!\s+!', '_', $this->savedFileName);
+            $this->savedFileName    = preg_replace('/[^a-zA-Z0-9\._-]/', '', $this->savedFileName);
+            $this->savedDestination = $this->uploadDir . '/' . $this->savedFileName;
+            $this->copyCalled       = true;
+
+            if (!copy($this->mediaTmpName, $this->savedDestination)) {
+                $this->setErrors(sprintf(_ER_UP_FAILEDSAVEFILE, $this->savedDestination));
+
+                return false;
+            }
+
+            if (false === chmod($this->savedDestination, $chmod)) {
+                $this->setErrors(_ER_UP_MODE_NOT_CHANGED);
+            }
+
+            return true;
+        }
+    }
+
+    class XoopsMediaUploaderTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            parent::setUp();
+            \Xmf\Request::reset();
+            $GLOBALS['xoops']                  = new XoopsPathStub();
+            $GLOBALS['xoopsConfig']['language'] = 'english';
+        }
+
+        public function testConstructorSetsLimitsAndReferencesAllowedTypes(): void
+        {
+            $allowed   = ['application/octet-stream'];
+            $uploader  = new XoopsMediaUploader(sys_get_temp_dir(), $allowed, 2048, 80, 120, true);
+            $allowed[] = 'text/plain';
+
+            $this->assertSame(2048, $uploader->maxFileSize);
+            $this->assertSame(80, $uploader->maxWidth);
+            $this->assertSame(120, $uploader->maxHeight);
+            $this->assertTrue($uploader->randomFilename);
+            $this->assertContains('text/plain', $uploader->allowedMimeTypes, 'Allowed types should be referenced');
+        }
+
+        public function testCountMediaReportsMissingFile(): void
+        {
+            $uploader = new XoopsMediaUploader(sys_get_temp_dir(), ['image/png']);
+
+            $this->assertFalse($uploader->countMedia('missing'));
+            $this->assertContains(_ER_UP_FILENOTFOUND, $uploader->getErrors(false));
+        }
+
+        public function testCountMediaReturnsFileCount(): void
+        {
+            \Xmf\Request::$files = [
+                'upload' => [
+                    'name' => ['one.png', 'two.png'],
+                ],
+            ];
+
+            $uploader = new XoopsMediaUploader(sys_get_temp_dir(), ['image/png']);
+
+            $this->assertSame(2, $uploader->countMedia('upload'));
+        }
+
+        public function testFetchMediaFailsWhenMimeMapMissing(): void
+        {
+            $uploader               = new XoopsMediaUploader(sys_get_temp_dir(), ['image/png']);
+            $uploader->extensionToMime = [];
+
+            $this->assertFalse($uploader->fetchMedia('upload'));
+            $this->assertContains(_ER_UP_MIMETYPELOAD, $uploader->getErrors(false));
+        }
+
+        public function testFetchMediaRequiresIndexForMultipleUpload(): void
+        {
+            \Xmf\Request::$files = [
+                'upload' => [
+                    'name' => ['one.png', 'two.png'],
+                ],
+            ];
+
+            $uploader = new XoopsMediaUploader(sys_get_temp_dir(), ['image/png']);
+
+            $this->assertFalse($uploader->fetchMedia('upload'));
+            $this->assertContains(_ER_UP_INDEXNOTSET, $uploader->getErrors(false));
+        }
+
+        public function testUploadValidatesAndCopiesFile(): void
+        {
+            $uploadDir = sys_get_temp_dir() . '/xoops_upload_' . uniqid('', true);
+            mkdir($uploadDir);
+            $tmpFile = tempnam(sys_get_temp_dir(), 'media');
+            file_put_contents($tmpFile, 'payload');
+
+            $uploader                = new TestMediaUploader($uploadDir, ['application/octet-stream'], 512);
+            $uploader->mediaName     = 'avatar.php.png';
+            $uploader->mediaType     = 'application/octet-stream';
+            $uploader->mediaRealType = 'application/octet-stream';
+            $uploader->mediaTmpName  = $tmpFile;
+            $uploader->mediaSize     = 32;
+            $uploader->prefix        = 'pref';
+            $uploader->checkImageType = false;
+
+            $this->assertTrue($uploader->upload());
+            $this->assertTrue($uploader->copyCalled);
+            $this->assertStringStartsWith('pref', $uploader->savedFileName);
+            $this->assertStringEndsWith('.png', $uploader->savedFileName);
+            $this->assertFileExists($uploader->savedDestination);
+
+            unlink($uploader->savedDestination);
+            rmdir($uploadDir);
+        }
+    }
+}

--- a/tests/unit/XoopsMemberHandlerTest.php
+++ b/tests/unit/XoopsMemberHandlerTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/member.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+trait MemberDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsMemberHandlerTest extends TestCase
+{
+    use MemberDatabaseMockTrait;
+
+    private function injectHandler(object $target, string $property, object $handler): void
+    {
+        $ref = new ReflectionProperty($target, $property);
+        $ref->setAccessible(true);
+        $ref->setValue($target, $handler);
+    }
+
+    public function testConstructorInitializesHandlers(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $this->assertInstanceOf(XoopsGroupHandler::class, $this->getPropertyValue($handler, 'groupHandler'));
+        $this->assertInstanceOf(XoopsUserHandler::class, $this->getPropertyValue($handler, 'userHandler'));
+        $this->assertInstanceOf(XoopsMembershipHandler::class, $this->getPropertyValue($handler, 'membershipHandler'));
+    }
+
+    public function testCreateAndGetForwardToHandlers(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $groupHandler = $this->createMock(XoopsGroupHandler::class);
+        $groupHandler->expects($this->once())->method('create')->willReturn(new XoopsGroup());
+        $groupHandler->expects($this->once())->method('get')->with(12)->willReturn(new XoopsGroup());
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())->method('create')->willReturn(new XoopsUser());
+
+        $this->injectHandler($handler, 'groupHandler', $groupHandler);
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $this->assertInstanceOf(XoopsGroup::class, $handler->createGroup());
+        $this->assertInstanceOf(XoopsUser::class, $handler->createUser());
+        $this->assertInstanceOf(XoopsGroup::class, $handler->getGroup(12));
+    }
+
+    public function testGetUserCachesResult(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $user = new XoopsUser();
+        $user->setVar('uid', 7);
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())->method('get')->with(7)->willReturn($user);
+
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $first = $handler->getUser(7);
+        $second = $handler->getUser(7);
+
+        $this->assertSame($user, $first);
+        $this->assertSame($first, $second);
+    }
+
+    public function testDeleteGroupAndUserDelegateToHandlers(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $group = new XoopsGroup();
+        $group->setVar('groupid', 3);
+        $user = new XoopsUser();
+        $user->setVar('uid', 5);
+
+        $membershipHandler = $this->createMock(XoopsMembershipHandler::class);
+        $membershipHandler->expects($this->exactly(2))->method('deleteAll')
+            ->with($this->isInstanceOf(CriteriaElement::class))
+            ->willReturn(true);
+
+        $groupHandler = $this->createMock(XoopsGroupHandler::class);
+        $groupHandler->expects($this->once())->method('delete')->with($group)->willReturn(true);
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())->method('delete')->with($user)->willReturn(true);
+
+        $this->injectHandler($handler, 'membershipHandler', $membershipHandler);
+        $this->injectHandler($handler, 'groupHandler', $groupHandler);
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $this->assertTrue($handler->deleteGroup($group));
+        $this->assertTrue($handler->deleteUser($user));
+    }
+
+    public function testInsertAndUpdateHelpers(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $group = new XoopsGroup();
+        $user = new XoopsUser();
+
+        $groupHandler = $this->createMock(XoopsGroupHandler::class);
+        $groupHandler->expects($this->once())->method('insert')->with($group)->willReturn(true);
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->exactly(2))->method('insert')->willReturn(true);
+        $userHandler->expects($this->once())->method('updateAll')->with('level', 2, null)->willReturn(true);
+
+        $this->injectHandler($handler, 'groupHandler', $groupHandler);
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $this->assertTrue($handler->insertGroup($group));
+        $this->assertTrue($handler->insertUser($user));
+        $this->assertTrue($handler->updateUserByField($user, 'email', 'me@example.com'));
+        $this->assertTrue($handler->updateUsersByField('level', 2));
+    }
+
+    public function testListsAreBuiltFromHandlers(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $group1 = new XoopsGroup();
+        $group1->setVar('groupid', 1);
+        $group1->setVar('name', 'Admins');
+        $group2 = new XoopsGroup();
+        $group2->setVar('groupid', 2);
+        $group2->setVar('name', 'Users');
+
+        $user1 = new XoopsUser();
+        $user1->setVar('uid', 11);
+        $user1->setVar('uname', 'alice');
+        $user2 = new XoopsUser();
+        $user2->setVar('uid', 12);
+        $user2->setVar('uname', 'bob');
+
+        $groupHandler = $this->createMock(XoopsGroupHandler::class);
+        $groupHandler->expects($this->once())->method('getObjects')->with(null, true)->willReturn([
+            1 => $group1,
+            2 => $group2,
+        ]);
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())->method('getObjects')->with(null, true)->willReturn([
+            11 => $user1,
+            12 => $user2,
+        ]);
+
+        $this->injectHandler($handler, 'groupHandler', $groupHandler);
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $this->assertSame([1 => 'Admins', 2 => 'Users'], $handler->getGroupList());
+        $this->assertSame([11 => 'alice', 12 => 'bob'], $handler->getUserList());
+    }
+
+    public function testAddUserToGroupCreatesMembership(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $membership = new XoopsMembership();
+        $membershipHandler = $this->createMock(XoopsMembershipHandler::class);
+        $membershipHandler->expects($this->once())->method('create')->willReturn($membership);
+        $membershipHandler->expects($this->once())->method('insert')->with($membership)->willReturn(true);
+
+        $this->injectHandler($handler, 'membershipHandler', $membershipHandler);
+
+        $result = $handler->addUserToGroup(4, 9);
+
+        $this->assertInstanceOf(XoopsMembership::class, $result);
+        $this->assertSame(4, $result->getVar('groupid'));
+        $this->assertSame(9, $result->getVar('uid'));
+    }
+
+    public function testRemoveUsersFromGroupBuildsCriteria(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $membershipHandler = $this->createMock(XoopsMembershipHandler::class);
+        $membershipHandler->expects($this->once())
+            ->method('deleteAll')
+            ->with($this->callback(function ($criteria) {
+                return $criteria instanceof CriteriaCompo
+                    && str_contains($criteria->render(), 'groupid')
+                    && str_contains($criteria->render(), 'uid IN (5,6)');
+            }))
+            ->willReturn(true);
+
+        $this->injectHandler($handler, 'membershipHandler', $membershipHandler);
+
+        $this->assertTrue($handler->removeUsersFromGroup(3, [5, 6]));
+    }
+
+    public function testGetUsersAndGroupsByLink(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $membershipHandler = $this->createMock(XoopsMembershipHandler::class);
+        $membershipHandler->expects($this->once())->method('getUsersByGroup')->with(2, 0, 0)->willReturn([7, 8]);
+        $membershipHandler->expects($this->once())->method('getGroupsByUser')->with(10)->willReturn([2, 3]);
+
+        $user1 = new XoopsUser();
+        $user1->setVar('uid', 7);
+        $user2 = new XoopsUser();
+        $user2->setVar('uid', 8);
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(Criteria::class), true)
+            ->willReturn([7 => $user1, 8 => $user2]);
+
+        $group1 = new XoopsGroup();
+        $group1->setVar('groupid', 2);
+        $group2 = new XoopsGroup();
+        $group2->setVar('groupid', 3);
+        $groupHandler = $this->createMock(XoopsGroupHandler::class);
+        $groupHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(Criteria::class), true)
+            ->willReturn([2 => $group1, 3 => $group2]);
+
+        $this->injectHandler($handler, 'membershipHandler', $membershipHandler);
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+        $this->injectHandler($handler, 'groupHandler', $groupHandler);
+
+        $users = $handler->getUsersByGroup(2, true);
+        $groups = $handler->getGroupsByUser(10, true);
+
+        $this->assertSame([$user1, $user2], $users);
+        $this->assertSame([$group1, $group2], $groups);
+    }
+
+    public function testLoginUserValidatesPassword(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $password = 'secret123';
+        $user = new XoopsUser();
+        $user->setVar('uid', 15);
+        $user->setVar('uname', 'tester');
+        $user->setVar('pass', password_hash($password, PASSWORD_DEFAULT));
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(Criteria::class), false)
+            ->willReturn([$user]);
+
+        $userHandler->expects($this->never())->method('insert');
+
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $loggedIn = $handler->loginUser('tester', $password);
+        $this->assertSame($user, $loggedIn);
+    }
+
+    public function testLoginUserFailsWhenNotUnique(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->isInstanceOf(Criteria::class), false)
+            ->willReturn([]);
+
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+
+        $this->assertFalse($handler->loginUser('tester', 'anything'));
+    }
+
+    public function testActivateUserAndCounts(): void
+    {
+        $db = $this->createDatabaseMock();
+        $handler = new XoopsMemberHandler($db);
+
+        $user = new XoopsUser();
+        $user->setVar('uid', 22);
+        $user->setVar('level', 0);
+        $user->setVar('pass', 'legacy');
+
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())->method('insert')->with($user, true)->willReturn(true);
+        $userHandler->expects($this->once())->method('getCount')->with(null)->willReturn(4);
+
+        $membershipHandler = $this->createMock(XoopsMembershipHandler::class);
+        $membershipHandler->expects($this->once())
+            ->method('getCount')
+            ->with($this->isInstanceOf(Criteria::class))
+            ->willReturn(2);
+
+        $this->injectHandler($handler, 'userHandler', $userHandler);
+        $this->injectHandler($handler, 'membershipHandler', $membershipHandler);
+
+        $this->assertTrue($handler->activateUser($user));
+        $this->assertSame(4, $handler->getUserCount());
+        $this->assertSame(2, $handler->getUserCountByGroup(1));
+    }
+
+    private function getPropertyValue(object $target, string $property)
+    {
+        $ref = new ReflectionProperty($target, $property);
+        $ref->setAccessible(true);
+        return $ref->getValue($target);
+    }
+}

--- a/tests/unit/XoopsModelTest.php
+++ b/tests/unit/XoopsModelTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/model/xoopsmodel.php';
+require_once XOOPS_ROOT_PATH . '/class/model/read.php';
+require_once XOOPS_ROOT_PATH . '/class/model/stats.php';
+require_once XOOPS_ROOT_PATH . '/class/model/joint.php';
+require_once XOOPS_ROOT_PATH . '/class/model/sync.php';
+require_once XOOPS_ROOT_PATH . '/class/model/write.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+if (!class_exists('MyTextSanitizer')) {
+    class MyTextSanitizer
+    {
+        public static function getInstance()
+        {
+            return new self();
+        }
+
+        public function htmlSpecialChars($value)
+        {
+            return htmlspecialchars($value, ENT_QUOTES);
+        }
+
+        public function censorString($value)
+        {
+            return $value;
+        }
+    }
+}
+
+class DummyPersistableHandler extends XoopsPersistableObjectHandler
+{
+    public $db;
+
+    public function __construct($db)
+    {
+        $this->db          = $db;
+        $this->table       = 'pref_table';
+        $this->keyName     = 'id';
+        $this->identifierName = 'name';
+        $this->table_link  = 'pref_link';
+        $this->field_link  = 'link_id';
+        $this->field_object = 'object_id';
+    }
+
+    public function create($isNew = true)
+    {
+        return new ModelObjectStub();
+    }
+}
+
+class ModelObjectStub
+{
+    public $cleanVars = [];
+    private $vars = [];
+
+    public function __construct(array $vars = [])
+    {
+        $this->vars = $vars;
+    }
+
+    public function getVars()
+    {
+        return $this->vars;
+    }
+
+    public function assignVars($vars): void
+    {
+        $this->vars = $vars;
+    }
+
+    public function getValues($keys)
+    {
+        return array_intersect_key($this->vars, array_flip($keys));
+    }
+}
+
+class XoopsModelTest extends TestCase
+{
+    public function testFactorySingleton(): void
+    {
+        $first  = XoopsModelFactory::getInstance();
+        $second = XoopsModelFactory::getInstance();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testFactoryLoadsHandlerAndSetsVars(): void
+    {
+        $db = $this->createMock(stdClass::class);
+        $handler = new DummyPersistableHandler($db);
+
+        $model = XoopsModelFactory::loadHandler($handler, 'read', ['extra' => 'value']);
+
+        $this->assertInstanceOf(XoopsModelRead::class, $model);
+        $this->assertSame($handler, $model->handler);
+        $this->assertSame('value', $model->extra);
+    }
+
+    public function testAbstractSetHandlerRejectsInvalid(): void
+    {
+        $abstract = new XoopsModelAbstract();
+
+        $this->assertFalse($abstract->setHandler(new stdClass()));
+    }
+
+    public function testReadGetIdsReturnsValues(): void
+    {
+        $db = $this->createMock(stdClass::class);
+        $db->method('query')->willReturn('result');
+        $db->method('isResultSet')->willReturn(true);
+        $db->method('fetchArray')->willReturnOnConsecutiveCalls(['id' => 7], false);
+
+        $handler      = new DummyPersistableHandler($db);
+        $handler->keyName = 'id';
+        $model        = new XoopsModelRead(null, $handler);
+
+        $ids = $model->getIds();
+        $this->assertSame([7], $ids);
+    }
+
+    public function testStatsGetCountWithGrouping(): void
+    {
+        $db = $this->createMock(stdClass::class);
+        $db->method('query')->willReturn('result');
+        $db->method('isResultSet')->willReturn(true);
+        $db->method('fetchRow')->willReturnOnConsecutiveCalls(['cat', 3], false);
+
+        $handler = new DummyPersistableHandler($db);
+        $criteria = $this->createMock(CriteriaElement::class);
+        $criteria->groupby = 'cat';
+        $criteria->method('renderWhere')->willReturn('WHERE 1=1');
+        $criteria->method('getGroupby')->willReturn(' GROUP BY cat');
+
+        $model = new XoopsModelStats(null, $handler);
+
+        $counts = $model->getCount($criteria);
+        $this->assertSame(['cat' => 3], $counts);
+    }
+
+    public function testJointValidateLinksWarnsOnMissing(): void
+    {
+        $this->expectWarning();
+        $db = $this->createMock(stdClass::class);
+        $handler = new DummyPersistableHandler($db);
+        $handler->table_link = '';
+
+        $model = new XoopsModelJoint(null, $handler);
+
+        $this->assertNull($model->getByLink());
+    }
+
+    public function testJointGetByLinkReturnsObjects(): void
+    {
+        $db = $this->createMock(stdClass::class);
+        $db->method('query')->willReturn('result');
+        $db->method('isResultSet')->willReturn(true);
+        $db->method('fetchArray')->willReturnOnConsecutiveCalls([
+            'id' => 5,
+            'name' => 'first',
+            'link_id' => 9,
+        ], false);
+
+        $handler = new DummyPersistableHandler($db);
+        $model   = new XoopsModelJoint(null, $handler);
+
+        $objects = $model->getByLink();
+        $this->assertArrayHasKey(5, $objects);
+        $this->assertSame('first', $objects[5]->getValues(['name'])['name']);
+    }
+
+    public function testSyncCleanOrphanChoosesSqlForVersion(): void
+    {
+        $db        = $this->createMock(stdClass::class);
+        $db->conn  = '4.2.0';
+        $db->expects($this->once())->method('exec')->with($this->stringContains('DELETE FROM `pref_table`'))
+            ->willReturn(true);
+
+        $handler = new DummyPersistableHandler($db);
+        $model   = new XoopsModelSync(null, $handler);
+
+        $this->assertTrue($model->cleanOrphan());
+    }
+
+    public function testWriteCleanVarsPopulatesCleanVars(): void
+    {
+        $db = $this->createMock(stdClass::class);
+        $db->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+
+        $handler = new DummyPersistableHandler($db);
+        $object  = new ModelObjectStub([
+            'title' => [
+                'changed' => true,
+                'value' => 'hello',
+                'data_type' => XOBJ_DTYPE_TXTBOX,
+                'required' => false,
+                'maxlength' => 255,
+            ],
+        ]);
+
+        $model = new XoopsModelWrite(null, $handler);
+        $this->assertTrue($model->cleanVars($object));
+        $this->assertSame(['title' => 'hello'], $object->cleanVars);
+    }
+}

--- a/tests/unit/XoopsModuleTest.php
+++ b/tests/unit/XoopsModuleTest.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/module.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsModuleTest extends TestCase
+{
+    private $previousLogger;
+    private array $messages;
+
+    protected function setUp(): void
+    {
+        $this->previousLogger   = $GLOBALS['xoopsLogger'] ?? null;
+        $this->messages         = [];
+        $GLOBALS['xoopsLogger'] = new class {
+            public array $messages = [];
+
+            public function addDeprecated($message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+        $GLOBALS['xoopsLogger']->messages =& $this->messages;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['xoopsLogger'] = $this->previousLogger;
+    }
+
+    public function testConstructorInitializesVars(): void
+    {
+        $module = new XoopsModule();
+
+        $this->assertNull($module->getVar('mid'));
+        $this->assertNull($module->getVar('name'));
+        $this->assertNull($module->getVar('version'));
+        $this->assertNull($module->getVar('last_update'));
+        $this->assertSame(0, $module->getVar('weight'));
+        $this->assertSame(1, $module->getVar('isactive'));
+        $this->assertNull($module->getVar('dirname'));
+        $this->assertSame(0, $module->getVar('hasmain'));
+        $this->assertSame(0, $module->getVar('hasadmin'));
+        $this->assertSame(0, $module->getVar('hassearch'));
+        $this->assertSame(0, $module->getVar('hasconfig'));
+        $this->assertSame(0, $module->getVar('hascomments'));
+        $this->assertSame(0, $module->getVar('hasnotification'));
+    }
+
+    public function testLoadInfoAsVarSetsFlagsFromModinfo(): void
+    {
+        $module           = new class extends XoopsModule {
+            public function setFakeInfo(array $info): void
+            {
+                $this->modinfo = $info;
+            }
+        };
+        $module->setFakeInfo([
+            'name'            => 'Example',
+            'version'         => '1.2.3',
+            'dirname'         => 'sample',
+            'hasMain'         => 1,
+            'hasAdmin'        => 0,
+            'hasSearch'       => 1,
+            'config'          => ['opt'],
+            'hasComments'     => 0,
+            'hasNotification' => 1,
+        ]);
+
+        $module->loadInfoAsVar('sample');
+
+        $this->assertSame('Example', $module->getVar('name'));
+        $this->assertSame('1.2.3', $module->getVar('version'));
+        $this->assertSame('sample', $module->getVar('dirname'));
+        $this->assertSame(1, $module->getVar('hasmain'));
+        $this->assertSame(0, $module->getVar('hasadmin'));
+        $this->assertSame(1, $module->getVar('hassearch'));
+        $this->assertSame(1, $module->getVar('hasconfig'));
+        $this->assertSame(0, $module->getVar('hascomments'));
+        $this->assertSame(1, $module->getVar('hasnotification'));
+    }
+
+    public function testMessageHelpersTrimAndReturnMessages(): void
+    {
+        $module = new XoopsModule();
+        $module->setMessage(' first ');
+        $module->setMessage("second\n");
+
+        $this->assertSame(['first', 'second'], $module->getMessages());
+    }
+
+    public function testSetInfoAndGetInfo(): void
+    {
+        $module = new XoopsModule();
+        $module->setInfo('', ['name' => 'full']);
+        $module->setInfo('version', '1.0');
+
+        $this->assertSame('1.0', $module->getInfo('version'));
+        $this->assertSame(['name' => 'full', 'version' => '1.0'], $module->getInfo());
+        $this->assertFalse($module->getInfo('missing'));
+    }
+
+    public function testStatusAndVersionCompare(): void
+    {
+        $module = new XoopsModule();
+        $module->setVar('version', '1.0-beta');
+
+        $this->assertSame('beta', $module->getStatus());
+        $this->assertTrue($module->versionCompare('1.1-stable', '1.0-stable', '>'));
+        $this->assertFalse($module->versionCompare('1.0', '1.0-stable', '>'));
+    }
+
+    public function testLinkHelpers(): void
+    {
+        $module = new XoopsModule();
+        $module->setVar('dirname', 'testmod');
+        $module->setVar('name', 'Module');
+        $module->setVar('hasmain', 1);
+        $module->setInfo('sub', [
+            ['id' => 1, 'name' => 'Sub', 'url' => 'page.php', 'icon' => 'icon.png'],
+            ['id' => 2, 'name' => 'Second', 'url' => 'next.php'],
+        ]);
+
+        $this->assertStringContainsString('/modules/testmod/', $module->mainLink());
+        $subs = $module->subLink();
+        $this->assertCount(2, $subs);
+        $this->assertSame('Sub', $subs[0]['name']);
+        $this->assertSame('', $subs[1]['icon']);
+    }
+
+    public function testDeprecatedMethodsLogMessages(): void
+    {
+        $module = new XoopsModule();
+
+        $module->update();
+        $module->insert();
+        $module->executeSQL();
+        $module->insertTemplates();
+        $module->gettemplate('file.tpl');
+        $module->insertBlocks();
+        $module->insertConfigCategories();
+        $module->insertConfig();
+        $module->insertProfileFields();
+        $module->executeScript('type');
+        $module->insertGroupPermissions([], 'type');
+        $module->checkAccess();
+        $module->setMessage('msg');
+        $module->printErrors();
+
+        $this->assertGreaterThanOrEqual(11, \count($this->messages));
+    }
+}
+
+trait ModuleDatabaseMockTrait
+{
+    protected function createDatabaseMock(): XoopsDatabase
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'escape',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsModuleHandlerTest extends TestCase
+{
+    use ModuleDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExisting(): void
+    {
+        $handler = new XoopsModuleHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsModule::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetFetchesAndCachesModule(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_modules');
+        $database->expects($this->once())->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'mid'             => 3,
+            'name'            => 'Module',
+            'version'         => '1.0',
+            'last_update'     => 0,
+            'weight'          => 0,
+            'isactive'        => 1,
+            'dirname'         => 'mod',
+            'hasmain'         => 1,
+            'hasadmin'        => 0,
+            'hassearch'       => 0,
+            'hasconfig'       => 0,
+            'hascomments'     => 0,
+            'hasnotification' => 0,
+        ]);
+
+        $handler = new XoopsModuleHandler($database);
+        $module  = $handler->get(3);
+        $this->assertInstanceOf(XoopsModule::class, $module);
+        $this->assertFalse($module->isNew());
+        $this->assertSame('Module', $module->getVar('name'));
+
+        $this->assertSame($module, $handler->get(3));
+    }
+
+    public function testGetByDirnameUsesPreparedStatement(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_modules');
+        $database->method('escape')->willReturnArgument(0);
+
+        $result = 'result';
+        $statement = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['bind_param', 'execute', 'get_result'])
+            ->getMock();
+        $statement->expects($this->once())->method('bind_param')->with('s', 'mod');
+        $statement->expects($this->once())->method('execute')->willReturn(true);
+        $statement->expects($this->once())->method('get_result')->willReturn($result);
+
+        $database->conn = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['prepare'])
+            ->getMock();
+        $database->conn->expects($this->once())->method('prepare')->with($this->stringContains('WHERE dirname = ?'))
+            ->willReturn($statement);
+
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'mid'             => 7,
+            'name'            => 'Dir Module',
+            'version'         => '2.0',
+            'last_update'     => 0,
+            'weight'          => 0,
+            'isactive'        => 1,
+            'dirname'         => 'mod',
+            'hasmain'         => 1,
+            'hasadmin'        => 0,
+            'hassearch'       => 0,
+            'hasconfig'       => 0,
+            'hascomments'     => 0,
+            'hasnotification' => 0,
+        ]);
+
+        $handler = new XoopsModuleHandler($database);
+        $module  = $handler->getByDirname('mod');
+
+        $this->assertInstanceOf(XoopsModule::class, $module);
+        $this->assertSame(7, $module->getVar('mid'));
+        $this->assertSame($module, $handler->getByDirname('mod'));
+    }
+
+    public function testInsertCreatesNewModule(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_modules');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(42);
+        $database->expects($this->once())->method('exec')->with($this->stringContains('INSERT INTO pref_modules'))->willReturn(true);
+
+        $handler = new XoopsModuleHandler($database);
+        $module  = $handler->create();
+        $module->setVar('name', 'Module');
+        $module->setVar('version', '1.0');
+        $module->setVar('dirname', 'mod');
+        $module->setVar('weight', 2);
+        $module->setVar('hasmain', 1);
+        $module->setVar('hasadmin', 0);
+        $module->setVar('hassearch', 0);
+        $module->setVar('hasconfig', 1);
+        $module->setVar('hascomments', 0);
+        $module->setVar('hasnotification', 0);
+
+        $this->assertTrue($handler->insert($module));
+        $this->assertSame(42, $module->getVar('mid'));
+    }
+
+    public function testInsertUpdatesExistingModule(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_modules');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())->method('exec')->with($this->stringContains('UPDATE pref_modules SET'))->willReturn(true);
+
+        $handler = new XoopsModuleHandler($database);
+        $module  = $handler->create(false);
+        $module->setVar('mid', 5);
+        $module->setVar('name', 'Module');
+        $module->setVar('version', '1.1');
+        $module->setVar('dirname', 'mod');
+        $module->setVar('weight', 2);
+        $module->setVar('hasmain', 1);
+        $module->setVar('hasadmin', 0);
+        $module->setVar('hassearch', 0);
+        $module->setVar('hasconfig', 1);
+        $module->setVar('hascomments', 0);
+        $module->setVar('hasnotification', 0);
+
+        $this->assertTrue($handler->insert($module));
+    }
+
+    public function testDeleteRemovesCaches(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->expects($this->exactly(3))->method('exec')->willReturn(true);
+        $database->expects($this->once())->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(false);
+
+        $handler = new XoopsModuleHandler($database);
+        $module  = $handler->create(false);
+        $module->assignVar('mid', 9);
+        $module->assignVar('dirname', 'mod');
+
+        $handler->_cachedModule_dirname['mod'] = $module;
+        $handler->_cachedModule_mid[9]         = $module;
+
+        $this->assertTrue($handler->delete($module));
+        $this->assertArrayNotHasKey('mod', $handler->_cachedModule_dirname);
+        $this->assertArrayNotHasKey(9, $handler->_cachedModule_mid);
+    }
+
+    public function testGetObjectsLoadsModules(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->expects($this->once())->method('query')->with($this->stringContains('SELECT * FROM pref'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'mid'             => 1,
+                'name'            => 'One',
+                'version'         => '1.0',
+                'last_update'     => 0,
+                'weight'          => 0,
+                'isactive'        => 1,
+                'dirname'         => 'one',
+                'hasmain'         => 1,
+                'hasadmin'        => 0,
+                'hassearch'       => 0,
+                'hasconfig'       => 0,
+                'hascomments'     => 0,
+                'hasnotification' => 0,
+            ],
+            false
+        );
+
+        $criteria = $this->getMockBuilder(CriteriaElement::class)
+            ->onlyMethods(['renderWhere', 'getOrder', 'getLimit', 'getStart'])
+            ->getMockForAbstractClass();
+        $criteria->method('renderWhere')->willReturn('WHERE 1=1');
+        $criteria->method('getOrder')->willReturn('ASC');
+        $criteria->method('getLimit')->willReturn(5);
+        $criteria->method('getStart')->willReturn(0);
+
+        $handler = new XoopsModuleHandler($database);
+        $objects = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $objects);
+        $this->assertInstanceOf(XoopsModule::class, $objects[1]);
+        $this->assertSame('One', $objects[1]->getVar('name'));
+    }
+}

--- a/tests/unit/XoopsMultiMailerTest.php
+++ b/tests/unit/XoopsMultiMailerTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/init_new.php';
+}
+
+namespace PHPMailer\PHPMailer {
+    if (!class_exists(__NAMESPACE__ . '\\PHPMailer')) {
+        class PHPMailer
+        {
+            public $exceptions;
+            public $CharSet;
+            public $Sender;
+            public $From;
+            public $Mailer;
+            public $SMTPAuth;
+            public $Host;
+            public $Username;
+            public $Password;
+            public $Sendmail;
+            public $language;
+            public $setLanguageArgs;
+            public $ErrorInfo;
+
+            public function __construct($exceptions = false)
+            {
+                $this->exceptions = $exceptions;
+            }
+
+            public function setLanguage($langcode, $path = '')
+            {
+                $this->setLanguageArgs = [$langcode, $path];
+                $this->language        = [$langcode, $path];
+
+                return true;
+            }
+
+            public function setError($message)
+            {
+                $this->ErrorInfo = $message;
+            }
+        }
+    }
+
+    if (!class_exists(__NAMESPACE__ . '\\Exception')) {
+        class Exception extends \Exception
+        {
+        }
+    }
+}
+
+namespace Xmf\Mail {
+    class SendmailRunner
+    {
+        public static $deliveries = [];
+        public static $throwMessage = null;
+
+        public function deliver($path, $message, $from)
+        {
+            if (null !== self::$throwMessage) {
+                throw new \RuntimeException(self::$throwMessage);
+            }
+
+            self::$deliveries[] = compact('path', 'message', 'from');
+        }
+    }
+}
+
+namespace {
+    use Xmf\Mail\SendmailRunner;
+
+    class ConfigHandlerStub
+    {
+        private $config;
+
+        public function __construct(array $config)
+        {
+            $this->config = $config;
+        }
+
+        public function getConfigsByCat($category)
+        {
+            return $this->config;
+        }
+    }
+
+    if (!function_exists('xoops_getHandler')) {
+        function xoops_getHandler($name)
+        {
+            return $GLOBALS['xoopsConfigHandler'];
+        }
+    }
+
+    if (!defined('XOOPS_CONF_MAILER')) {
+        define('XOOPS_CONF_MAILER', 5);
+    }
+
+    if (!defined('_CHARSET')) {
+        define('_CHARSET', 'UTF-8');
+    }
+
+    /**
+     * @runTestsInSeparateProcesses
+     */
+    class XoopsMultiMailerTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            parent::setUp();
+
+            SendmailRunner::$deliveries   = [];
+            SendmailRunner::$throwMessage = null;
+
+            $GLOBALS['xoopsConfig'] = [
+                'adminmail' => 'admin@example.com',
+                'language'  => 'unknown',
+            ];
+
+            $GLOBALS['xoopsConfigHandler'] = new ConfigHandlerStub([
+                'from'         => 'from@example.com',
+                'mailmethod'   => 'smtpauth',
+                'smtphost'     => ['smtp.example.com'],
+                'smtpuser'     => 'smtp-user',
+                'smtppass'     => 'smtp-pass',
+                'sendmailpath' => '/custom/sendmail',
+            ]);
+
+            if (!class_exists('XoopsMultiMailer', false)) {
+                require_once XOOPS_ROOT_PATH . '/class/mail/xoopsmultimailer.php';
+            }
+        }
+
+        protected function tearDown(): void
+        {
+            parent::tearDown();
+            unset($GLOBALS['xoopsConfig'], $GLOBALS['xoopsConfigHandler']);
+        }
+
+        public function testConstructorAppliesSmtpConfiguration(): void
+        {
+            $mailer = new \XoopsMultiMailer();
+
+            $this->assertSame('from@example.com', $mailer->From);
+            $this->assertSame('from@example.com', $mailer->Sender);
+            $this->assertSame('smtp', $mailer->Mailer);
+            $this->assertTrue($mailer->SMTPAuth);
+            $this->assertSame('smtp.example.com', $mailer->Host);
+            $this->assertSame('smtp-user', $mailer->Username);
+            $this->assertSame('smtp-pass', $mailer->Password);
+            $this->assertSame('utf-8', $mailer->CharSet);
+            $this->assertSame(['en', XOOPS_ROOT_PATH . '/class/mail/phpmailer/language/'], $mailer->setLanguageArgs);
+        }
+
+        public function testConstructorFallsBackToAdminMailAndSendmail(): void
+        {
+            $GLOBALS['xoopsConfig'] = [
+                'adminmail' => 'admin@example.com',
+                'language'  => 'unknown',
+            ];
+
+            $GLOBALS['xoopsConfigHandler'] = new ConfigHandlerStub([
+                'from'         => '',
+                'mailmethod'   => 'sendmail',
+                'smtphost'     => ['smtp.other'],
+                'smtpuser'     => 'user2',
+                'smtppass'     => 'pass2',
+                'sendmailpath' => '/usr/bin/sendmail',
+            ]);
+
+            $mailer = new \XoopsMultiMailer();
+
+            $this->assertSame('admin@example.com', $mailer->From);
+            $this->assertSame('admin@example.com', $mailer->Sender);
+            $this->assertSame('sendmail', $mailer->Mailer);
+            $this->assertFalse($mailer->SMTPAuth);
+            $this->assertSame('/usr/bin/sendmail', $mailer->Sendmail);
+            $this->assertSame('smtp.other', $mailer->Host);
+        }
+
+        public function testSendmailSendDeliversMessage(): void
+        {
+            $mailer             = new class extends \XoopsMultiMailer {
+                public function callSendmail($header, $body)
+                {
+                    return $this->sendmailSend($header, $body);
+                }
+            };
+            $mailer->Sendmail   = '/bin/sendmail';
+            $mailer->Sender     = 'sender@example.com';
+            $mailer->From       = 'from@example.com';
+
+            $result = $mailer->callSendmail("Subject: Hi\r\n", 'Body content');
+
+            $this->assertTrue($result);
+            $this->assertSame([
+                [
+                    'path'    => '/bin/sendmail',
+                    'message' => "Subject: Hi\n\nBody content",
+                    'from'    => 'sender@example.com',
+                ],
+            ], SendmailRunner::$deliveries);
+        }
+
+        public function testSendmailSendCapturesRuntimeError(): void
+        {
+            SendmailRunner::$throwMessage = 'send failure';
+
+            $mailer           = new class extends \XoopsMultiMailer {
+                public function callSendmail($header, $body)
+                {
+                    return $this->sendmailSend($header, $body);
+                }
+            };
+            $mailer->exceptions = false;
+            $mailer->Sendmail   = '/bin/sendmail';
+
+            $this->assertFalse($mailer->callSendmail('H', 'B'));
+            $this->assertSame('send failure', $mailer->ErrorInfo);
+        }
+
+        public function testSendmailSendThrowsWhenExceptionsEnabled(): void
+        {
+            SendmailRunner::$throwMessage = 'send explode';
+
+            $mailer = new class extends \XoopsMultiMailer {
+                public function callSendmail($header, $body)
+                {
+                    return $this->sendmailSend($header, $body);
+                }
+            };
+
+            $this->expectException(\PHPMailer\PHPMailer\Exception::class);
+            $this->expectExceptionMessage('send explode');
+            $mailer->callSendmail('H', 'B');
+        }
+    }
+}

--- a/tests/unit/XoopsMySQLDatabaseTest.php
+++ b/tests/unit/XoopsMySQLDatabaseTest.php
@@ -1,0 +1,168 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('DummyLogger', false)) {
+    class DummyLogger
+    {
+        public array $queries = [];
+        public array $extra = [];
+
+        public function startTime($name)
+        {
+        }
+
+        public function stopTime($name)
+        {
+        }
+
+        public function dumpTime($name, $decimals = false)
+        {
+            return 0;
+        }
+
+        public function addQuery($sql, $error, $errno, $time)
+        {
+            $this->queries[] = [$sql, $error, $errno, $time];
+        }
+
+        public function addExtra($channel, $message)
+        {
+            $this->extra[] = [$channel, $message];
+        }
+    }
+}
+
+if (!defined('XOOPS_ROOT_PATH')) {
+    define('XOOPS_ROOT_PATH', __DIR__);
+}
+if (!defined('XOOPS_DB_PREFIX')) {
+    define('XOOPS_DB_PREFIX', 'xoops');
+}
+if (!defined('XOOPS_DB_HOST')) {
+    define('XOOPS_DB_HOST', 'localhost');
+}
+if (!defined('XOOPS_DB_USER')) {
+    define('XOOPS_DB_USER', 'root');
+}
+if (!defined('XOOPS_DB_PASS')) {
+    define('XOOPS_DB_PASS', '');
+}
+if (!defined('XOOPS_DB_NAME')) {
+    define('XOOPS_DB_NAME', 'xoops');
+}
+if (!defined('XOOPS_DB_PCONNECT')) {
+    define('XOOPS_DB_PCONNECT', 0);
+}
+
+$GLOBALS['xoopsConfig'] = [];
+
+require_once XOOPS_ROOT_PATH . '/../../htdocs/class/database/database.php';
+require_once XOOPS_ROOT_PATH . '/../../htdocs/class/database/mysqldatabase.php';
+
+class MySQLProxyDouble extends XoopsMySQLDatabaseProxy
+{
+    public array $calls = [];
+    public $returnValue = true;
+
+    public function queryF($sql, $limit = 0, $start = 0)
+    {
+        $this->calls[] = [$sql, $limit, $start];
+        return $this->returnValue;
+    }
+}
+
+class MySQLSafeDouble extends XoopsMySQLDatabaseSafe
+{
+    public function setConnection($conn)
+    {
+        $this->conn = $conn;
+    }
+
+    public function setLogger($logger)
+    {
+        $this->logger = $logger;
+    }
+}
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class XoopsMySQLDatabaseTest extends TestCase
+{
+    public function testProxyBlocksNonSelectWhenWebChangesNotAllowed(): void
+    {
+        $proxy = new MySQLProxyDouble();
+        $proxy->allowWebChanges = false;
+
+        $message = null;
+        set_error_handler(static function ($errno, $errstr) use (&$message) {
+            $message = $errstr;
+            return true;
+        });
+        $result = $proxy->query('UPDATE table SET x=1');
+        restore_error_handler();
+
+        $this->assertFalse($result);
+        $this->assertSame('Database updates are not allowed during processing of a GET request', $message);
+        $this->assertSame([], $proxy->calls);
+    }
+
+    public function testProxyUsesQueryFWithPagination(): void
+    {
+        $proxy = new MySQLProxyDouble();
+        $proxy->allowWebChanges = true;
+
+        $result = $proxy->query('SELECT * FROM table', 5, -3);
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $proxy->calls);
+        $this->assertSame(['SELECT * FROM table', 5, 0], $proxy->calls[0]);
+    }
+
+    public function testProxyUsesQueryFWithoutLimit(): void
+    {
+        $proxy = new MySQLProxyDouble();
+        $proxy->allowWebChanges = true;
+
+        $result = $proxy->query('SELECT * FROM table');
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $proxy->calls);
+        $this->assertSame(['SELECT * FROM table', 0, 0], $proxy->calls[0]);
+    }
+
+    public function testSafeDelegatesWithNullLimitWhenZero(): void
+    {
+        $logger = new DummyLogger();
+        $safe = new MySQLSafeDouble();
+        $safe->setLogger($logger);
+        $safe->setConnection(mysqli_init());
+
+        set_error_handler(static function () {
+            return true;
+        });
+        $safe->query('SELECT * FROM table', 0, 10);
+        restore_error_handler();
+
+        $this->assertCount(1, $logger->queries);
+        $this->assertSame('SELECT * FROM table', $logger->queries[0][0]);
+    }
+
+    public function testSafeAppendsLimitAndOffset(): void
+    {
+        $logger = new DummyLogger();
+        $safe = new MySQLSafeDouble();
+        $safe->setLogger($logger);
+        $safe->setConnection(mysqli_init());
+
+        set_error_handler(static function () {
+            return true;
+        });
+        $safe->query('SELECT * FROM table', 2, 3);
+        restore_error_handler();
+
+        $this->assertCount(1, $logger->queries);
+        $this->assertSame('SELECT * FROM table LIMIT 2 OFFSET 3', $logger->queries[0][0]);
+    }
+}

--- a/tests/unit/XoopsNotificationTest.php
+++ b/tests/unit/XoopsNotificationTest.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/notification.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria/compo.php';
+
+class XoopsNotificationTest extends TestCase
+{
+    public function testConstructorInitializesVars(): void
+    {
+        $notification = new XoopsNotification();
+
+        $this->assertNull($notification->getVar('not_id'));
+        $this->assertNull($notification->getVar('not_modid'));
+        $this->assertNull($notification->getVar('not_category'));
+        $this->assertSame(0, $notification->getVar('not_itemid'));
+        $this->assertNull($notification->getVar('not_event'));
+        $this->assertSame(0, $notification->getVar('not_uid'));
+        $this->assertSame(0, $notification->getVar('not_mode'));
+    }
+
+    public function testAccessorMethodsReturnValues(): void
+    {
+        $notification = new XoopsNotification();
+        $notification->setVar('not_id', 5);
+        $notification->setVar('not_modid', 7);
+        $notification->setVar('not_category', 'cat');
+        $notification->setVar('not_itemid', 11);
+        $notification->setVar('not_event', 'event');
+        $notification->setVar('not_uid', 13);
+        $notification->setVar('not_mode', 3);
+
+        $this->assertSame(5, $notification->id());
+        $this->assertSame(5, $notification->not_id());
+        $this->assertSame(7, $notification->not_modid());
+        $this->assertSame('cat', $notification->not_category());
+        $this->assertSame(11, $notification->not_itemid());
+        $this->assertSame('event', $notification->not_event());
+        $this->assertSame(13, $notification->not_uid());
+        $this->assertSame(3, $notification->not_mode());
+    }
+
+    public function testNotifyUserSkipsInactiveUser(): void
+    {
+        $notification = new XoopsNotification();
+        $notification->setVar('not_uid', 99);
+
+        $memberHandler = new class {
+            public function getUser($uid)
+            {
+                return new class {
+                    public function isActive()
+                    {
+                        return false;
+                    }
+                };
+            }
+        };
+        $GLOBALS['notification_test_member_handler'] = $memberHandler;
+
+        $this->assertTrue($notification->notifyUser('dir', 'template', 'subject', []));
+    }
+}
+
+trait NotificationDatabaseMockTrait
+{
+    protected function createDatabaseMock(): XoopsDatabase
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'genId',
+                'getInsertId',
+                'quote',
+                'escape',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsNotificationHandlerTest extends TestCase
+{
+    use NotificationDatabaseMockTrait;
+
+    public function testCreateReturnsNotification(): void
+    {
+        $handler = new XoopsNotificationHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsNotification::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetReturnsNotificationWhenFound(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_xoopsnotifications');
+        $database->expects($this->once())->method('query')->with($this->stringContains('WHERE not_id=5'))->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'not_id'       => 5,
+            'not_modid'    => 3,
+            'not_category' => 'cat',
+            'not_itemid'   => 9,
+            'not_event'    => 'event',
+            'not_uid'      => 17,
+            'not_mode'     => 1,
+        ]);
+
+        $handler      = new XoopsNotificationHandler($database);
+        $notification = $handler->get(5);
+        $this->assertInstanceOf(XoopsNotification::class, $notification);
+        $this->assertSame(3, $notification->getVar('not_modid'));
+        $this->assertFalse($notification->isNew());
+    }
+
+    public function testInsertCreatesNewNotification(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->method('genId')->willReturn(0);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->method('exec')->with($this->stringContains('INSERT INTO pref'))->willReturn(true);
+        $database->method('getInsertId')->willReturn(10);
+
+        $handler      = new XoopsNotificationHandler($database);
+        $notification = $handler->create();
+        $notification->setVar('not_modid', 2);
+        $notification->setVar('not_itemid', 3);
+        $notification->setVar('not_category', 'cat');
+        $notification->setVar('not_uid', 5);
+        $notification->setVar('not_event', 'event');
+        $notification->setVar('not_mode', 1);
+
+        $this->assertTrue($handler->insert($notification));
+        $this->assertSame(10, $notification->getVar('not_id'));
+    }
+
+    public function testInsertUpdatesExistingNotification(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->method('exec')->with($this->stringContains('UPDATE pref'))->willReturn(true);
+
+        $handler      = new XoopsNotificationHandler($database);
+        $notification = $handler->create(false);
+        $notification->assignVar('not_id', 4);
+        $notification->setVar('not_modid', 2);
+        $notification->setVar('not_itemid', 3);
+        $notification->setVar('not_category', 'cat');
+        $notification->setVar('not_uid', 5);
+        $notification->setVar('not_event', 'event');
+        $notification->setVar('not_mode', 2);
+
+        $this->assertTrue($handler->insert($notification));
+    }
+
+    public function testDeleteRemovesNotification(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->expects($this->once())->method('exec')->with($this->stringContains('DELETE FROM pref'))
+            ->willReturn(true);
+
+        $handler      = new XoopsNotificationHandler($database);
+        $notification = $handler->create(false);
+        $notification->assignVar('not_id', 6);
+
+        $this->assertTrue($handler->delete($notification));
+    }
+
+    public function testGetObjectsReturnsNotifications(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->expects($this->once())->method('query')->with($this->stringContains('SELECT * FROM pref'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'not_id'       => 1,
+                'not_modid'    => 2,
+                'not_category' => 'cat',
+                'not_itemid'   => 3,
+                'not_event'    => 'event',
+                'not_uid'      => 4,
+                'not_mode'     => 1,
+            ],
+            false
+        );
+
+        $criteria = $this->getMockBuilder(CriteriaElement::class)
+            ->onlyMethods(['renderWhere', 'getSort', 'getOrder', 'getLimit', 'getStart'])
+            ->getMockForAbstractClass();
+        $criteria->method('renderWhere')->willReturn('WHERE 1=1');
+        $criteria->method('getSort')->willReturn('not_id');
+        $criteria->method('getOrder')->willReturn('ASC');
+        $criteria->method('getLimit')->willReturn(5);
+        $criteria->method('getStart')->willReturn(0);
+
+        $handler = new XoopsNotificationHandler($database);
+        $objects = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $objects);
+        $this->assertArrayHasKey(1, $objects);
+        $this->assertSame(2, $objects[1]->getVar('not_modid'));
+    }
+
+    public function testGetCountReturnsNumberOfNotifications(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->expects($this->once())->method('query')->with($this->stringContains('COUNT(*)'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([7]);
+
+        $handler  = new XoopsNotificationHandler($database);
+        $criteria = $this->getMockBuilder(CriteriaElement::class)
+            ->onlyMethods(['renderWhere', 'getGroupby'])
+            ->getMockForAbstractClass();
+        $criteria->method('renderWhere')->willReturn('WHERE not_uid = 1');
+        $criteria->method('getGroupby')->willReturn('');
+
+        $this->assertSame(7, $handler->getCount($criteria));
+    }
+
+    public function testDeleteAllClearsRecords(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref');
+        $database->expects($this->once())->method('exec')->with($this->stringContains('DELETE FROM pref'))
+            ->willReturn(true);
+
+        $handler  = new XoopsNotificationHandler($database);
+        $criteria = $this->getMockBuilder(CriteriaElement::class)
+            ->onlyMethods(['renderWhere'])
+            ->getMockForAbstractClass();
+        $criteria->method('renderWhere')->willReturn('WHERE not_uid = 1');
+
+        $this->assertTrue($handler->deleteAll($criteria));
+    }
+
+    public function testGetNotificationReturnsSingleMatch(): void
+    {
+        $notification = new XoopsNotification();
+        $handler      = new class($this->createDatabaseMock(), $notification) extends XoopsNotificationHandler {
+            private $notification;
+
+            public function __construct($db, $notification)
+            {
+                parent::__construct($db);
+                $this->notification = $notification;
+            }
+
+            public function getObjects(?CriteriaElement $criteria = null, $id_as_key = false)
+            {
+                return [$this->notification];
+            }
+        };
+
+        $result = $handler->getNotification(1, 'cat', 2, 'event', 3);
+
+        $this->assertSame($notification, $result);
+    }
+
+    public function testIsSubscribedDelegatesToCount(): void
+    {
+        $handler = $this->getMockBuilder(XoopsNotificationHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getCount'])
+            ->getMock();
+        $handler->expects($this->once())->method('getCount')->with($this->callback(function ($criteria) {
+            return $criteria instanceof CriteriaCompo;
+        }))->willReturn(2);
+
+        $this->assertSame(2, $handler->isSubscribed('cat', 1, 'event', 2, 3));
+    }
+
+    public function testSubscribeUpdatesExistingNotification(): void
+    {
+        $existing = new XoopsNotification();
+        $existing->setVar('not_mode', 0);
+
+        $handler = new class($this->createDatabaseMock(), $existing) extends XoopsNotificationHandler {
+            public array $updated = [];
+
+            private $existing;
+
+            public function __construct($db, $existing)
+            {
+                parent::__construct($db);
+                $this->existing = $existing;
+            }
+
+            public function &getNotification($module_id, $category, $item_id, $event, $user_id)
+            {
+                return $this->existing;
+            }
+
+            public function updateByField(XoopsNotification $notification, $field_name, $field_value)
+            {
+                $this->updated[] = [$field_name, $field_value];
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($handler->subscribe('cat', 1, 'event', 2, 3, 4));
+        $this->assertSame([['not_mode', 2]], $handler->updated);
+    }
+
+    public function testSubscribeInsertsWhenNotFound(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsNotificationHandler {
+            public array $inserted = [];
+
+            public function &getNotification($module_id, $category, $item_id, $event, $user_id)
+            {
+                $inst = false;
+
+                return $inst;
+            }
+
+            public function insert(XoopsObject $object)
+            {
+                $this->inserted[] = $object;
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($handler->subscribe('cat', 1, ['first', 'second'], 2, 3, 4));
+        $this->assertCount(2, $handler->inserted);
+        foreach ($handler->inserted as $object) {
+            $this->assertInstanceOf(XoopsNotification::class, $object);
+            $this->assertSame(3, $object->getVar('not_modid'));
+        }
+    }
+
+    public function testGetByUserUsesCriteria(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsNotificationHandler {
+            public $capturedCriteria;
+
+            public function getObjects(?CriteriaElement $criteria = null, $id_as_key = false)
+            {
+                $this->capturedCriteria = $criteria;
+
+                return ['item'];
+            }
+        };
+
+        $result = $handler->getByUser(12);
+
+        $this->assertSame('item', $result[0]);
+        $this->assertInstanceOf(Criteria::class, $handler->capturedCriteria);
+        $this->assertSame(12, $handler->capturedCriteria->value);
+    }
+
+    public function testGetSubscribedEventsReturnsEventList(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsNotificationHandler {
+            public function getObjects(?CriteriaElement $criteria = null, $id_as_key = false)
+            {
+                $one = new XoopsNotification();
+                $one->setVar('not_event', 'first');
+                $two = new XoopsNotification();
+                $two->setVar('not_event', 'second');
+
+                return [1 => $one, 2 => $two];
+            }
+        };
+
+        $events = $handler->getSubscribedEvents('cat', 1, 2, 3);
+
+        $this->assertSame(['first', 'second'], $events);
+    }
+
+    public function testGetByItemIdReturnsObjects(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsNotificationHandler {
+            public $capturedCriteria;
+
+            public function getObjects(?CriteriaElement $criteria = null, $id_as_key = false)
+            {
+                $this->capturedCriteria = $criteria;
+
+                return ['item'];
+            }
+        };
+
+        $result = $handler->getByItemId(1, 2, 'DESC', 3);
+
+        $this->assertSame(['item'], $result);
+        $this->assertInstanceOf(CriteriaCompo::class, $handler->capturedCriteria);
+    }
+
+    public function testTriggerEventsDelegatesToTriggerEvent(): void
+    {
+        $handler = $this->getMockBuilder(XoopsNotificationHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['triggerEvent'])
+            ->getMock();
+        $handler->expects($this->exactly(2))->method('triggerEvent')
+            ->withConsecutive(
+                ['cat', 1, 'first', [], [], null, null],
+                ['cat', 1, 'second', [], [], null, null]
+            );
+
+        $handler->triggerEvents('cat', 1, ['first', 'second']);
+    }
+
+    public function testUnsubscribeHelpersCallDeleteAll(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsNotificationHandler {
+            public array $criteria = [];
+
+            public function deleteAll(?CriteriaElement $criteria = null)
+            {
+                $this->criteria[] = $criteria;
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($handler->unsubscribeByUser(5));
+        $this->assertTrue($handler->unsubscribe('cat', 1, ['evt'], 2, 3));
+        $this->assertTrue($handler->unsubscribeByModule(7));
+        $this->assertTrue($handler->unsubscribeByItem(7, 'cat', 10));
+        $this->assertCount(4, $handler->criteria);
+    }
+
+    public function testDoLoginMaintenanceUpdatesWaitingNotifications(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsNotificationHandler {
+            public array $inserted = [];
+
+            public function getObjects(?CriteriaElement $criteria = null, $id_as_key = false)
+            {
+                $waiting = new XoopsNotification();
+                $waiting->setVar('not_mode', XOOPS_NOTIFICATION_MODE_WAITFORLOGIN);
+
+                return [1 => $waiting];
+            }
+
+            public function insert(XoopsObject $notification)
+            {
+                $this->inserted[] = $notification;
+
+                return true;
+            }
+        };
+
+        $handler->doLoginMaintenance(3);
+
+        $this->assertCount(1, $handler->inserted);
+        $this->assertSame(XOOPS_NOTIFICATION_MODE_SENDONCETHENWAIT, $handler->inserted[0]->getVar('not_mode'));
+    }
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return $GLOBALS['notification_test_' . $name . '_handler'] ?? null;
+    }
+}
+
+if (!function_exists('xoops_getMailer')) {
+    function xoops_getMailer()
+    {
+        return $GLOBALS['notification_test_mailer'] ?? null;
+    }
+}

--- a/tests/unit/XoopsObjectHandlersTest.php
+++ b/tests/unit/XoopsObjectHandlersTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/object.php';
+require_once XOOPS_ROOT_PATH . '/class/database/database.php';
+require_once XOOPS_ROOT_PATH . '/class/module.textsanitizer.php';
+
+class XoopsObjectTest extends TestCase
+{
+    public function testNewAndDirtyFlagsToggle(): void
+    {
+        $object = new XoopsObject();
+
+        $this->assertFalse($object->isNew());
+        $object->setNew();
+        $this->assertTrue($object->isNew());
+        $object->unsetNew();
+        $this->assertFalse($object->isNew());
+
+        $this->assertFalse($object->isDirty());
+        $object->setDirty();
+        $this->assertTrue($object->isDirty());
+        $object->unsetDirty();
+        $this->assertFalse($object->isDirty());
+    }
+
+    public function testInitAndSetVarMarksChange(): void
+    {
+        $object = new XoopsObject();
+        $object->initVar('int_field', XOBJ_DTYPE_INT, 1, true, 8, 'options');
+
+        $this->assertArrayHasKey('int_field', $object->vars);
+        $this->assertSame(1, $object->vars['int_field']['value']);
+        $this->assertFalse($object->isDirty());
+
+        $object->setVar('int_field', 5, true);
+
+        $this->assertTrue($object->vars['int_field']['changed']);
+        $this->assertTrue($object->vars['int_field']['not_gpc']);
+        $this->assertSame(5, $object->vars['int_field']['value']);
+        $this->assertTrue($object->isDirty());
+    }
+
+    public function testDestroyVarsResetsChangeFlags(): void
+    {
+        $object = new XoopsObject();
+        $object->initVar('to_unset', XOBJ_DTYPE_INT, 2);
+        $object->setVar('to_unset', 3);
+
+        $this->assertTrue($object->vars['to_unset']['changed']);
+
+        $this->assertTrue($object->destroyVars('to_unset'));
+        $this->assertNull($object->vars['to_unset']['changed']);
+    }
+
+    public function testGetVarCastsIntegerValues(): void
+    {
+        $object = new XoopsObject();
+        $object->initVar('int_value', XOBJ_DTYPE_INT, '7');
+
+        $this->assertSame(7, $object->getVar('int_value'));
+    }
+}
+
+class XoopsObjectHandlerTest extends TestCase
+{
+    public function testConstructorStoresDatabaseReference(): void
+    {
+        $database = $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $handler = new XoopsObjectHandler($database);
+
+        $this->assertSame($database, $handler->db);
+    }
+}
+
+class XoopsPersistableObjectHandlerTest extends TestCase
+{
+    public function testCreateAndGetReturnNewObjects(): void
+    {
+        $database = $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $handler = new TestPersistableObjectHandler($database);
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(TestPersistableObject::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+
+        $fromNull = $handler->get(null);
+        $this->assertInstanceOf(TestPersistableObject::class, $fromNull);
+        $this->assertTrue($fromNull->isNew());
+    }
+
+    public function testInsertDelegatesToWriteHandler(): void
+    {
+        $database = $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $handler = new TestPersistableObjectHandler($database);
+        $object  = $handler->create();
+
+        $writeHandler = new class {
+            public array $captured = [];
+
+            public function insert($object, $force)
+            {
+                $this->captured = [$object, $force];
+
+                return 'saved';
+            }
+        };
+
+        $handler->registerHandler('write', $writeHandler);
+
+        $this->assertSame('saved', $handler->insert($object, false));
+        $this->assertSame([$object, false], $writeHandler->captured);
+    }
+
+    public function testMagicCallDelegatesToCustomHandlers(): void
+    {
+        $database = $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $handler = new TestPersistableObjectHandler($database);
+        $handler->handler = new class {
+            public function customMethod($value)
+            {
+                return strtoupper($value);
+            }
+        };
+
+        $this->assertSame('VALUE', $handler->customMethod('value'));
+
+        $handler->handler = null;
+        $handler->handlers = ['read' => null];
+
+        $handler->registerHandler('read', new class {
+            public function customMethod($value)
+            {
+                return $value . '_from_read';
+            }
+        });
+
+        $this->assertSame('alt_from_read', $handler->customMethod('alt'));
+    }
+}
+
+class TestPersistableObjectHandler extends XoopsPersistableObjectHandler
+{
+    /** @var array<string, object> */
+    private $handlerMap = [];
+
+    public function __construct(XoopsDatabase $db)
+    {
+        $this->db        = $db;
+        $this->table     = 'unit_table';
+        $this->keyName   = 'id';
+        $this->className = TestPersistableObject::class;
+    }
+
+    public function registerHandler(string $name, object $handler): void
+    {
+        $this->handlerMap[$name] = $handler;
+    }
+
+    public function loadHandler($name, $args = null)
+    {
+        return $this->handlerMap[$name];
+    }
+}
+
+class TestPersistableObject extends XoopsObject
+{
+}

--- a/tests/unit/XoopsObjectTreeTest.php
+++ b/tests/unit/XoopsObjectTreeTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/tree.php';
+
+class DummyTreeObject
+{
+    private $vars;
+
+    public function __construct($id, $parentId, $name, $rootId = null)
+    {
+        $this->vars = [
+            'id'     => $id,
+            'parent' => $parentId,
+            'name'   => $name,
+            'root'   => $rootId,
+        ];
+    }
+
+    public function getVar($key)
+    {
+        return $this->vars[$key];
+    }
+}
+
+class LoggerTreeStub
+{
+    public $deprecated = [];
+    public $extra = [];
+
+    public function addDeprecated($message)
+    {
+        $this->deprecated[] = $message;
+    }
+
+    public function addExtra($channel, $message)
+    {
+        $this->extra[] = [$channel, $message];
+    }
+}
+
+class SelectTreeStub
+{
+    public $name;
+    public $caption;
+    public $selected;
+    public $extra = '';
+    public $options = [];
+
+    public function __construct($caption, $name, $selected)
+    {
+        $this->caption  = $caption;
+        $this->name     = $name;
+        $this->selected = $selected;
+    }
+
+    public function setExtra($extra)
+    {
+        $this->extra = $extra;
+    }
+
+    public function addOption($value, $name)
+    {
+        $this->options[$value] = $name;
+    }
+}
+
+if (!function_exists('xoops_load')) {
+    function xoops_load($name)
+    {
+        if ($name === 'xoopsformselect' && !class_exists('XoopsFormSelect')) {
+            class_alias(SelectTreeStub::class, 'XoopsFormSelect');
+        }
+    }
+}
+
+class XoopsObjectTreeTest extends TestCase
+{
+    /** @var LoggerTreeStub */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->logger            = new LoggerTreeStub();
+        $GLOBALS['xoopsLogger']  = $this->logger;
+    }
+
+    private function buildTree(): XoopsObjectTree
+    {
+        $objects = [
+            new DummyTreeObject(1, 0, 'root', 1),
+            new DummyTreeObject(2, 1, 'child', 1),
+            new DummyTreeObject(3, 1, 'child2', 1),
+            new DummyTreeObject(4, 2, 'grandchild', 1),
+        ];
+
+        return new XoopsObjectTree($objects, 'id', 'parent', 'root');
+    }
+
+    public function testTreeConstructionAndRetrieval(): void
+    {
+        $tree = $this->buildTree();
+        $data = $tree->getTree();
+
+        $this->assertArrayHasKey(1, $data);
+        $this->assertSame(1, $data[1]['obj']->getVar('id'));
+        $this->assertSame(0, $data[1]['parent']);
+        $this->assertSame([2, 3], $data[1]['child']);
+        $this->assertSame(1, $data[1]['root']);
+    }
+
+    public function testGetByKeyAndChildren(): void
+    {
+        $tree = $this->buildTree();
+
+        $this->assertSame(2, $tree->getByKey(2)->getVar('id'));
+        $firstChildren = $tree->getFirstChild(1);
+        $this->assertSame([2, 3], array_keys($firstChildren));
+        $this->assertSame('child2', $firstChildren[3]->getVar('name'));
+
+        $allChildren = $tree->getAllChild(1);
+        $this->assertEqualsCanonicalizing([2, 3, 4], array_keys($allChildren));
+        $this->assertSame('grandchild', $allChildren[4]->getVar('name'));
+    }
+
+    public function testGetAllParentReturnsAncestors(): void
+    {
+        $tree    = $this->buildTree();
+        $parents = $tree->getAllParent(4);
+
+        $this->assertSame('child', $parents[1]->getVar('name'));
+        $this->assertSame('root', $parents[2]->getVar('name'));
+    }
+
+    public function testMakeSelBoxBuildsMarkupAndLogsDeprecation(): void
+    {
+        $tree   = $this->buildTree();
+        $output = $tree->makeSelBox('tree', 'name', '-', 2, true, 1, 'class="sel"');
+
+        $this->assertStringContainsString('<select name="tree" id="tree" class="sel">', $output);
+        $this->assertStringContainsString('<option value="0"></option>', $output);
+        $this->assertStringContainsString('<option value="1">root</option>', $output);
+        $this->assertStringContainsString('<option value="2" selected>-child</option>', $output);
+        $this->assertStringContainsString('<option value="4">--grandchild</option>', $output);
+        $this->assertNotEmpty($this->logger->deprecated);
+    }
+
+    public function testMakeSelectElementAddsOptions(): void
+    {
+        $tree    = $this->buildTree();
+        $element = $tree->makeSelectElement('tree', 'name', '*', 3, true, 1, 'data-test', 'Tree');
+
+        $this->assertInstanceOf(SelectTreeStub::class, $element);
+        $this->assertSame('Tree', $element->caption);
+        $this->assertSame('tree', $element->name);
+        $this->assertSame('data-test', $element->extra);
+        $this->assertSame('root', $element->options[1]);
+        $this->assertSame('-child2', $element->options[3]);
+        $this->assertArrayHasKey('0', $element->options);
+    }
+
+    public function testMagicGetLogsDeprecatedTreeAndExtra(): void
+    {
+        $tree = $this->buildTree();
+
+        $treeData = $tree->_tree;
+        $this->assertSame($tree->getTree(), $treeData);
+        $this->assertNotEmpty($this->logger->deprecated);
+
+        $unknown = $tree->undefined;
+        $this->assertNull($unknown);
+        $this->assertNotEmpty($this->logger->extra);
+    }
+}

--- a/tests/unit/XoopsOnlineHandlerTest.php
+++ b/tests/unit/XoopsOnlineHandlerTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/online.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria/compo.php';
+
+class XoopsOnlineHandlerTest extends TestCase
+{
+    public function testConstructorSetsTablePrefix(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->with('online')->willReturn('pref_online');
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertSame('pref_online', $handler->table);
+    }
+
+    public function testWriteUpdatesExistingRecord(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->once())->method('queryF')->with($this->stringContains('WHERE online_uid=5'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([1]);
+        $database->expects($this->once())->method('exec')->with($this->stringContains('UPDATE pref_online'))
+            ->willReturn(true);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertTrue($handler->write(5, 'user', 123, 9, '127.0.0.1'));
+    }
+
+    public function testWriteInsertsNewGuestRecord(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->once())->method('queryF')
+            ->with($this->stringContains('online_uid=0 AND online_ip'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([0]);
+        $database->expects($this->once())->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_online'))
+            ->willReturn(true);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertTrue($handler->write(0, 'guest', 123, 1, '8.8.8.8'));
+    }
+
+    public function testWriteCleansGuestRowWhenUserSignsIn(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->once())->method('queryF')
+            ->with($this->stringContains('WHERE online_uid=7'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([0]);
+        $database->expects($this->exactly(2))->method('exec')->withConsecutive(
+            [$this->stringContains('DELETE FROM pref_online WHERE online_uid = 0')],
+            [$this->stringContains('INSERT INTO pref_online')]
+        )->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertTrue($handler->write(7, 'member', 200, 3, '10.0.0.1'));
+    }
+
+    public function testDestroyRemovesUserEntries(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->expects($this->once())->method('exec')
+            ->with($this->stringContains('DELETE FROM pref_online WHERE online_uid = 11'))
+            ->willReturn(true);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertTrue($handler->destroy(11));
+    }
+
+    public function testGcDeletesExpiredEntries(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->expects($this->once())->method('exec')
+            ->with($this->stringContains('online_updated < '));
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $handler->gc(100);
+    }
+
+    public function testGetAllReturnsOnlineRows(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->expects($this->once())->method('query')->with($this->stringContains('SELECT * FROM pref_online'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(['id' => 1], ['id' => 2], false);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertSame([
+            ['id' => 1],
+            ['id' => 2],
+        ], $handler->getAll());
+    }
+
+    public function testGetAllAppliesCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->expects($this->once())->method('query')
+            ->with($this->stringContains('WHERE (`online_uid` = 3)'), 5, 2)
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturn(false);
+
+        $criteria = new CriteriaCompo();
+        $criteria->add(new Criteria('online_uid', 3));
+        $criteria->setLimit(5);
+        $criteria->setStart(2);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertSame([], $handler->getAll($criteria));
+    }
+
+    public function testGetCountReturnsRowCount(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->expects($this->once())->method('query')->with($this->stringContains('SELECT COUNT(*) FROM pref_online'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([4]);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertSame(4, $handler->getCount());
+    }
+
+    public function testGetCountReturnsZeroWhenQueryFails(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_online');
+        $database->method('isResultSet')->willReturn(false);
+        $database->expects($this->once())->method('query')->with($this->stringContains('SELECT COUNT(*) FROM pref_online'))
+            ->willReturn(false);
+
+        $handler = new XoopsOnlineHandler($database);
+
+        $this->assertSame(0, $handler->getCount());
+    }
+
+    private function createDatabaseMock(): XoopsDatabase
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'quote',
+                'queryF',
+                'isResultSet',
+                'fetchRow',
+                'exec',
+                'query',
+                'fetchArray',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsPageNavTest.php
+++ b/tests/unit/XoopsPageNavTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xmf {
+    if (!class_exists('Xmf\\Request')) {
+        class Request
+        {
+            public static array $values = [];
+
+            public static function reset(): void
+            {
+                self::$values = [];
+            }
+
+            public static function getString($name, $default = '', $type = 'GET')
+            {
+                return self::$values[$type][$name] ?? $default;
+            }
+        }
+    }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use Xmf\Request;
+
+    require_once __DIR__ . '/init_new.php';
+
+    if (!class_exists('XoopsTpl')) {
+        class XoopsTpl
+        {
+            public static array $lastAssigned = [];
+            public array $assigned = [];
+
+            public function assign($key, $value): void
+            {
+                $this->assigned[$key] = $value;
+            }
+
+            public function fetch($template)
+            {
+                self::$lastAssigned = $this->assigned;
+
+                return 'TPL:' . $template;
+            }
+        }
+    }
+
+    require_once XOOPS_ROOT_PATH . '/class/pagenav.php';
+
+    class StubXoopsPath
+    {
+        private string $path;
+
+        public function __construct(string $path)
+        {
+            $this->path = $path;
+        }
+
+        public function path($file): string
+        {
+            return $this->path;
+        }
+    }
+
+    class XoopsPageNavTest extends TestCase
+    {
+        private string $stubInclude;
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+            $this->stubInclude = sys_get_temp_dir() . '/xoops_pagenav_stub.php';
+            file_put_contents($this->stubInclude, "<?php\n");
+            $GLOBALS['xoops']   = new StubXoopsPath($this->stubInclude);
+            $GLOBALS['xoTheme'] = (object) [];
+            Request::reset();
+            XoopsTpl::$lastAssigned = [];
+        }
+
+        protected function tearDown(): void
+        {
+            unset($GLOBALS['xoops'], $GLOBALS['xoTheme']);
+            @unlink($this->stubInclude);
+            parent::tearDown();
+        }
+
+        public function testConstructorBuildsUrlAndExtra(): void
+        {
+            Request::$values['SERVER']['PHP_SELF'] = '/index.php';
+
+            $nav = new \XoopsPageNav(100, 10, 30, 'offset', 'foo=bar');
+
+            $this->assertSame(100, $nav->total);
+            $this->assertSame(10, $nav->perpage);
+            $this->assertSame(30, $nav->current);
+            $this->assertSame('&amp;foo=bar', $nav->extra);
+            $this->assertSame('/index.php?offset=', $nav->url);
+        }
+
+        public function testRenderNavAssignsNavigationData(): void
+        {
+            Request::$values['SERVER']['PHP_SELF'] = '/list.php';
+            $nav = new \XoopsPageNav(50, 10, 10);
+
+            $output = $nav->renderNav();
+
+            $this->assertSame('TPL:db:system_pagenav.tpl', $output);
+            $assigned = XoopsTpl::$lastAssigned;
+            $this->assertSame('Nav', $assigned['pageNavType']);
+            $navigation = $assigned['pageNavigation'];
+            $this->assertSame('/list.php?start=0', $navigation[0]['url']);
+            $this->assertSame('first', $navigation[0]['option']);
+            $this->assertSame(2, $navigation[1]['value']);
+            $this->assertSame('selected', $navigation[1]['option']);
+            $this->assertSame('/list.php?start=20', $navigation[count($navigation) - 1]['url']);
+            $this->assertSame('last', $navigation[count($navigation) - 1]['option']);
+        }
+
+        public function testRenderSelectIncludesButtonWhenRequested(): void
+        {
+            Request::$values['SERVER']['PHP_SELF'] = '/page.php';
+            $nav = new \XoopsPageNav(40, 10, 0);
+
+            $output = $nav->renderSelect(true);
+
+            $this->assertSame('TPL:db:system_pagenav.tpl', $output);
+            $assigned = XoopsTpl::$lastAssigned;
+            $this->assertSame('Select', $assigned['pageNavType']);
+            $this->assertTrue($assigned['pageNavigation']['button']);
+            $this->assertStringContainsString('selected>', $assigned['pageNavigation']['select']);
+            $this->assertStringContainsString('/page.php?start=0', $assigned['pageNavigation']['select']);
+        }
+
+        public function testRenderImageNavUsesEmptyMarkersAtEdges(): void
+        {
+            Request::$values['SERVER']['PHP_SELF'] = '/images.php';
+            $nav = new \XoopsPageNav(20, 10, 0);
+
+            $output = $nav->renderImageNav();
+
+            $this->assertSame('TPL:db:system_pagenav.tpl', $output);
+            $assigned = XoopsTpl::$lastAssigned;
+            $this->assertSame('Image', $assigned['pageNavType']);
+            $navigation = $assigned['pageNavigation'];
+            $this->assertSame('firstempty', $navigation[0]['option']);
+            $this->assertSame('selected', $navigation[1]['option']);
+            $this->assertSame('last', $navigation[count($navigation) - 1]['option']);
+        }
+
+        public function testRenderMethodsReturnEmptyWhenSinglePage(): void
+        {
+            Request::$values['SERVER']['PHP_SELF'] = '/single.php';
+            $nav = new \XoopsPageNav(5, 10, 0);
+
+            $this->assertSame('', $nav->renderNav());
+            $this->assertSame('', $nav->renderSelect());
+            $this->assertSame('', $nav->renderImageNav());
+        }
+    }
+}

--- a/tests/unit/XoopsPreloadTest.php
+++ b/tests/unit/XoopsPreloadTest.php
@@ -1,0 +1,127 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('XoopsLoad', false)) {
+    class XoopsLoad
+    {
+        public static $loaded = [];
+
+        public static function load($name)
+        {
+            self::$loaded[] = $name;
+            return true;
+        }
+    }
+}
+
+if (!class_exists('XoopsLists', false)) {
+    class XoopsLists
+    {
+        public static $files = [];
+
+        public static function getFileListAsArray($dir)
+        {
+            return self::$files ?: [];
+        }
+    }
+}
+
+if (!class_exists('XoopsCache', false)) {
+    class XoopsCache
+    {
+        public static $data = [];
+
+        public static function read($name)
+        {
+            return self::$data[$name] ?? false;
+        }
+    }
+}
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class XoopsPreloadTest extends TestCase
+{
+    private $rootPath;
+
+    protected function setUp()
+    {
+        $this->rootPath = sys_get_temp_dir() . '/xoops_preload_' . uniqid('', true);
+        mkdir($this->rootPath . '/modules/mod1/preloads', 0777, true);
+    }
+
+    private function writePreloadFile($className = 'Mod1CustomPreload')
+    {
+        $template = <<<'PHPFILE'
+<?php
+class %s
+{
+    public static $events = array();
+    public static function eventTest($args)
+    {
+        self::$events[] = $args;
+    }
+}
+PHPFILE;
+        file_put_contents($this->rootPath . '/modules/mod1/preloads/custom.php', sprintf($template, $className));
+    }
+
+    private function includePreload()
+    {
+        if (!defined('XOOPS_ROOT_PATH')) {
+            define('XOOPS_ROOT_PATH', $this->rootPath);
+        }
+
+        XoopsLists::$files = ['custom.php'];
+        XoopsCache::$data['system_modules_active'] = ['mod1'];
+
+        require_once __DIR__ . '/../../htdocs/class/preload.php';
+    }
+
+    public function testSingletonBuildsPreloadList()
+    {
+        $this->writePreloadFile();
+        $this->includePreload();
+
+        $instance = XoopsPreload::getInstance();
+
+        $this->assertSame($instance, XoopsPreload::getInstance(), 'getInstance should return singleton');
+        $this->assertSame([
+            ['module' => 'mod1', 'file' => 'custom'],
+        ], $instance->_preloads);
+    }
+
+    public function testEventsRegisteredAndTriggered()
+    {
+        $this->writePreloadFile();
+        $this->includePreload();
+
+        $instance = XoopsPreload::getInstance();
+        $this->assertArrayHasKey('test', $instance->_events);
+        $this->assertSame('Mod1CustomPreload', $instance->_events['test'][0]['class_name']);
+
+        $instance->triggerEvent('test', ['foo' => 'bar']);
+
+        $this->assertSame([
+            ['foo' => 'bar'],
+        ], Mod1CustomPreload::$events);
+    }
+
+    public function testIgnoresMissingModules()
+    {
+        if (!defined('XOOPS_ROOT_PATH')) {
+            define('XOOPS_ROOT_PATH', $this->rootPath);
+        }
+
+        XoopsCache::$data['system_modules_active'] = [];
+        XoopsLists::$files = [];
+
+        require_once __DIR__ . '/../../htdocs/class/preload.php';
+
+        $instance = XoopsPreload::getInstance();
+        $this->assertSame([], $instance->_preloads);
+        $this->assertSame([], $instance->_events);
+    }
+}

--- a/tests/unit/XoopsPrivmessageTest.php
+++ b/tests/unit/XoopsPrivmessageTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/privmessage.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria/compo.php';
+
+class XoopsPrivmessageTest extends TestCase
+{
+    public function testConstructorInitializesVars(): void
+    {
+        $message = new XoopsPrivmessage();
+
+        $this->assertNull($message->getVar('msg_id'));
+        $this->assertNull($message->getVar('msg_image'));
+        $this->assertNull($message->getVar('subject'));
+        $this->assertNull($message->getVar('from_userid'));
+        $this->assertNull($message->getVar('to_userid'));
+        $this->assertNull($message->getVar('msg_time'));
+        $this->assertNull($message->getVar('msg_text'));
+        $this->assertSame(0, $message->getVar('read_msg'));
+    }
+
+    public function testAccessorMethodsReturnValues(): void
+    {
+        $message = new XoopsPrivmessage();
+        $message->setVar('msg_id', 10);
+        $message->setVar('msg_image', 'icon.png');
+        $message->setVar('subject', 'Hello');
+        $message->setVar('from_userid', 5);
+        $message->setVar('to_userid', 7);
+        $message->setVar('msg_time', 123456789);
+        $message->setVar('msg_text', 'Body');
+        $message->setVar('read_msg', 1);
+
+        $this->assertSame(10, $message->id());
+        $this->assertSame(10, $message->msg_id());
+        $this->assertSame('icon.png', $message->msg_image());
+        $this->assertSame('Hello', $message->subject());
+        $this->assertSame(5, $message->from_userid());
+        $this->assertSame(7, $message->to_userid());
+        $this->assertSame(123456789, $message->msg_time());
+        $this->assertSame('Body', $message->msg_text());
+        $this->assertSame(1, $message->read_msg());
+    }
+}
+
+trait PrivmessageDatabaseMockTrait
+{
+    protected function createDatabaseMock(): XoopsDatabase
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'queryF',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'genId',
+                'getInsertId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsPrivmessageHandlerTest extends TestCase
+{
+    use PrivmessageDatabaseMockTrait;
+
+    public function testCreateReturnsPrivmessage(): void
+    {
+        $handler = new XoopsPrivmessageHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsPrivmessage::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetReturnsMessageWhenFound(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->with($this->stringContains('WHERE msg_id=5'))->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'msg_id'       => 5,
+            'msg_image'    => 'icon.png',
+            'subject'      => 'Hello',
+            'from_userid'  => 11,
+            'to_userid'    => 13,
+            'msg_time'     => 123456,
+            'msg_text'     => 'Message body',
+            'read_msg'     => 1,
+        ]);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $message = $handler->get(5);
+
+        $this->assertInstanceOf(XoopsPrivmessage::class, $message);
+        $this->assertSame(5, $message->getVar('msg_id'));
+        $this->assertSame('Message body', $message->getVar('msg_text'));
+    }
+
+    public function testGetReturnsFalseWhenNoResult(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(false);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $this->assertFalse($handler->get(99));
+    }
+
+    public function testInsertRejectsInvalidType(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler  = new XoopsPrivmessageHandler($database);
+
+        $this->assertFalse($handler->insert(new XoopsObject()));
+    }
+
+    public function testInsertInsertsNewMessage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->method('quote')->willReturnCallback(static function ($value) {
+            return "'{$value}'";
+        });
+        $database->method('genId')->willReturn(123);
+        $database->expects($this->once())->method('query')->with($this->stringContains('INSERT INTO pref_priv_msgs'))->willReturn(true);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $message = new XoopsPrivmessage();
+        $message->setVar('msg_image', 'icon.png');
+        $message->setVar('subject', 'Hello');
+        $message->setVar('from_userid', 5);
+        $message->setVar('to_userid', 7);
+        $message->setVar('msg_text', 'Body text');
+
+        $result = $handler->insert($message);
+
+        $this->assertTrue($result);
+        $this->assertSame(123, $message->getVar('msg_id'));
+    }
+
+    public function testInsertUpdatesExistingMessage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->method('quote')->willReturnCallback(static function ($value) {
+            return "'{$value}'";
+        });
+        $database->expects($this->once())->method('query')->with($this->stringContains('UPDATE pref_priv_msgs'))->willReturn(true);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $message = new XoopsPrivmessage();
+        $message->setVar('msg_id', 9);
+        $message->setVar('msg_image', 'icon.png');
+        $message->setVar('subject', 'Updated');
+        $message->setVar('from_userid', 5);
+        $message->setVar('to_userid', 7);
+        $message->setVar('msg_text', 'Updated text');
+        $message->setVar('read_msg', 1);
+        $message->unsetNew();
+        $message->setDirty();
+
+        $this->assertTrue($handler->insert($message));
+    }
+
+    public function testDeleteRemovesMessage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->with($this->stringContains('DELETE FROM pref_priv_msgs'))
+            ->willReturn(true);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $message = new XoopsPrivmessage();
+        $message->setVar('msg_id', 15);
+
+        $this->assertTrue($handler->delete($message));
+    }
+
+    public function testGetObjectsReturnsListWithCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->with($this->stringContains('ORDER BY msg_id ASC'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls([
+            'msg_id'      => 21,
+            'subject'     => 'First',
+            'from_userid' => 1,
+            'to_userid'   => 2,
+            'msg_text'    => 'Hello',
+            'read_msg'    => 0,
+        ], false);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $criteria = new Criteria('msg_id', 21);
+        $criteria->setSort('msg_id');
+        $criteria->setOrder('ASC');
+
+        $messages = $handler->getObjects($criteria, true);
+
+        $this->assertCount(1, $messages);
+        $this->assertArrayHasKey(21, $messages);
+        $this->assertInstanceOf(XoopsPrivmessage::class, $messages[21]);
+    }
+
+    public function testGetObjectsReturnsEmptyWhenNotResultSet(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(false);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $this->assertSame([], $handler->getObjects());
+    }
+
+    public function testGetCountReturnsCount(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([7]);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $this->assertSame(7, $handler->getCount());
+    }
+
+    public function testGetCountReturnsZeroWhenNotResultSet(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('query')->willReturn('result');
+        $database->method('isResultSet')->willReturn(false);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $this->assertSame(0, $handler->getCount(new Criteria('read_msg', 0)));
+    }
+
+    public function testSetReadMarksMessage(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_priv_msgs');
+        $database->expects($this->once())->method('exec')->with($this->stringContains('read_msg = 1 WHERE msg_id = 33'))
+            ->willReturn(true);
+        $handler = new XoopsPrivmessageHandler($database);
+
+        $message = new XoopsPrivmessage();
+        $message->setVar('msg_id', 33);
+
+        $this->assertTrue($handler->setRead($message));
+    }
+}

--- a/tests/unit/XoopsSecurityTest.php
+++ b/tests/unit/XoopsSecurityTest.php
@@ -1,0 +1,102 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('XoopsSecurity')) {
+    require_once dirname(__DIR__, 2) . '/htdocs/class/xoopssecurity.php';
+}
+
+if (!function_exists('xoops_getenv')) {
+    function xoops_getenv($key)
+    {
+        return $_SERVER[$key] ?? '';
+    }
+}
+
+if (!defined('XOOPS_DB_PREFIX')) {
+    define('XOOPS_DB_PREFIX', 'pref');
+}
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'http://example.com');
+}
+
+class XoopsSecurityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        $_SESSION = [];
+        $_REQUEST = [];
+        $_SERVER['HTTP_USER_AGENT'] = 'phpunit-agent';
+        $GLOBALS['xoopsLogger'] = new class {
+            public $extras = [];
+            public function addExtra($name, $msg)
+            {
+                $this->extras[] = [$name, $msg];
+            }
+        };
+    }
+
+    public function testCreateTokenStoresSessionDataAndHashesId()
+    {
+        $security = new XoopsSecurity();
+        $token = $security->createToken(10, 'TOKEN');
+
+        $sessionName = 'TOKEN_SESSION';
+        $this->assertArrayHasKey($sessionName, $_SESSION);
+        $this->assertCount(1, $_SESSION[$sessionName]);
+        $stored = $_SESSION[$sessionName][0];
+
+        $expected = md5($stored['id'] . $_SERVER['HTTP_USER_AGENT'] . XOOPS_DB_PREFIX);
+        $this->assertSame($expected, $token);
+        $this->assertGreaterThanOrEqual(time(), $stored['expire']);
+    }
+
+    public function testValidateTokenClearsWhenValid()
+    {
+        $security = new XoopsSecurity();
+        $token = $security->createToken(10, 'TOKEN');
+
+        $result = $security->validateToken($token, true, 'TOKEN');
+
+        $this->assertTrue($result);
+        $this->assertSame([], $_SESSION['TOKEN_SESSION']);
+        $this->assertContains(['Token Validation', 'Valid token found'], $GLOBALS['xoopsLogger']->extras);
+    }
+
+    public function testValidateTokenExpiredSetsError()
+    {
+        $security = new XoopsSecurity();
+        $_SESSION['TOKEN_SESSION'] = [
+            [
+                'id'     => 'expired',
+                'expire' => time() - 5,
+            ],
+        ];
+        $token = md5('expired' . $_SERVER['HTTP_USER_AGENT'] . XOOPS_DB_PREFIX);
+
+        $result = $security->validateToken($token, true, 'TOKEN');
+
+        $this->assertFalse($result);
+        $errors = $security->getErrors();
+        $this->assertContains('Valid token expired', $errors);
+        $this->assertSame([], $_SESSION['TOKEN_SESSION']);
+    }
+
+    public function testCheckRefererHonorsDocheckFlag()
+    {
+        $security = new XoopsSecurity();
+
+        $_SERVER['HTTP_REFERER'] = '';
+        $this->assertFalse($security->checkReferer(1));
+
+        $_SERVER['HTTP_REFERER'] = XOOPS_URL . '/path';
+        $this->assertTrue($security->checkReferer(1));
+
+        $_SERVER['HTTP_REFERER'] = '';
+        $this->assertTrue($security->checkReferer(0));
+    }
+}

--- a/tests/unit/XoopsSessionHandlerTest.php
+++ b/tests/unit/XoopsSessionHandlerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/session.php';
+
+class XoopsSessionHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $GLOBALS['xoopsConfig'] = [
+            'use_mysession' => true,
+            'session_name' => 'xoops_session',
+            'session_expire' => 10,
+        ];
+
+        if (!defined('XOOPS_PROT')) {
+            define('XOOPS_PROT', 'https://');
+        }
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'https://example.com');
+        }
+        if (!defined('XOOPS_COOKIE_DOMAIN')) {
+            define('XOOPS_COOKIE_DOMAIN', 'example.com');
+        }
+    }
+
+    public function testConstructorSetsCookieParameters(): void
+    {
+        $database = $this->createDatabaseMock();
+
+        $handler = new XoopsSessionHandler($database);
+
+        $params = session_get_cookie_params();
+        $this->assertSame('example.com', $params['domain']);
+        $this->assertSame('/', $params['path']);
+        $this->assertTrue($params['httponly']);
+    }
+
+    public function testOpenReturnsTrue(): void
+    {
+        $handler = new XoopsSessionHandler($this->createDatabaseMock());
+        $this->assertTrue($handler->open('', 'sid'));
+    }
+
+    public function testCloseCallsGcForce(): void
+    {
+        $handler = new class($this->createDatabaseMock()) extends XoopsSessionHandler {
+            public $closed = false;
+            public function gc_force()
+            {
+                $this->closed = true;
+            }
+        };
+
+        $this->assertTrue($handler->close());
+        $this->assertTrue($handler->closed);
+    }
+
+    public function testReadReturnsDataWhenSubnetMatches(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '192.168.1.10';
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_session');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->once())->method('queryF')
+            ->with($this->stringContains('pref_session'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn(['payload', '192.168.1.5']);
+
+        $handler = new XoopsSessionHandler($database);
+
+        $this->assertSame('payload', $handler->read('abc123'));
+    }
+
+    public function testReadReturnsEmptyWhenSubnetDoesNotMatch(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_session');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->once())->method('queryF')
+            ->with($this->stringContains('pref_session'))
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn(['payload', '192.168.1.5']);
+
+        $handler = new XoopsSessionHandler($database);
+
+        $this->assertSame('', $handler->read('abc123'));
+    }
+
+    public function testWritePersistsSessionAndUpdatesCookie(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_session');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->once())->method('exec')
+            ->with($this->stringContains('INSERT INTO pref_session'))
+            ->willReturn(true);
+
+        $handler = new class($database) extends XoopsSessionHandler {
+            public $updatedCookie = false;
+            public function update_cookie($sess_id = null, $expire = null)
+            {
+                $this->updatedCookie = true;
+            }
+        };
+
+        $this->assertTrue($handler->write('abc', 'data'));
+        $this->assertTrue($handler->updatedCookie);
+    }
+
+    public function testDestroyReturnsExecutionResult(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_session');
+        $database->method('quote')->willReturnCallback(static fn($value) => "'{$value}'");
+        $database->expects($this->exactly(2))->method('exec')
+            ->with($this->stringContains('DELETE FROM pref_session'))
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $handler = new XoopsSessionHandler($database);
+
+        $this->assertFalse($handler->destroy('id1'));
+        $this->assertTrue($handler->destroy('id2'));
+    }
+
+    public function testGcReturnsAffectedRows(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_session');
+        $database->expects($this->once())->method('exec')->willReturn(true);
+        $database->method('getAffectedRows')->willReturn(5);
+
+        $handler = new XoopsSessionHandler($database);
+
+        $this->assertSame(5, $handler->gc(100));
+    }
+
+    public function testGcReturnsZeroForEmptyExpire(): void
+    {
+        $handler = new XoopsSessionHandler($this->createDatabaseMock());
+        $this->assertSame(0, $handler->gc(0));
+    }
+
+    public function testGcReturnsFalseOnFailure(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturn('pref_session');
+        $database->expects($this->once())->method('exec')->willReturn(false);
+
+        $handler = new XoopsSessionHandler($database);
+
+        $this->assertFalse($handler->gc(50));
+    }
+
+    public function testRegenerateIdRespectsEnableFlag(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler = new class($database) extends XoopsSessionHandler {
+            public $updatedCookie = false;
+            public function update_cookie($sess_id = null, $expire = null)
+            {
+                $this->updatedCookie = true;
+            }
+        };
+        $handler->enableRegenerateId = false;
+
+        $this->assertTrue($handler->regenerate_id(true));
+        $this->assertTrue($handler->updatedCookie);
+    }
+
+    private function createDatabaseMock(): XoopsDatabase
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'quote',
+                'queryF',
+                'isResultSet',
+                'fetchRow',
+                'exec',
+                'getAffectedRows',
+            ])
+            ->getMock();
+    }
+}

--- a/tests/unit/XoopsSimpleFormTest.php
+++ b/tests/unit/XoopsSimpleFormTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/simpleform.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelement.php';
+
+if (!class_exists('XoopsSecurity')) {
+    class XoopsSecurity
+    {
+        public function createToken($timeout = 0, $name = 'XOOPS_TOKEN')
+        {
+            return 'token';
+        }
+    }
+}
+
+if (!class_exists('DummySimpleFormElement')) {
+    class DummySimpleFormElement extends XoopsFormElement
+    {
+        private bool $hidden;
+        private string $body;
+
+        public function __construct(string $name, string $caption, string $body, bool $hidden = false)
+        {
+            $this->hidden  = $hidden;
+            $this->body    = $body;
+            $this->setName($name);
+            $this->setCaption($caption);
+        }
+
+        public function isContainer()
+        {
+            return false;
+        }
+
+        public function isHidden()
+        {
+            return $this->hidden;
+        }
+
+        public function render()
+        {
+            return $this->body;
+        }
+    }
+}
+
+class XoopsSimpleFormTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['xoopsSecurity'] = new XoopsSecurity();
+    }
+
+    public function testRenderOutputsMinimalFormattedForm(): void
+    {
+        $form = new XoopsSimpleForm('My Title', 'my-form', '/submit.php', 'post', false);
+
+        $visible = new DummySimpleFormElement('visible', 'Visible caption', '<input name="visible" />');
+        $hidden  = new DummySimpleFormElement('hidden', 'Hidden caption', '<input type="hidden" name="hidden" />', true);
+
+        $form->addElement($visible);
+        $form->addElement($hidden);
+
+        $rendered = $form->render();
+
+        $expected  = "My Title\n";
+        $expected .= "<form name='my-form' id='my-form' action='/submit.php' method='post'>\n";
+        $expected .= "<strong>Visible caption</strong><br><input name=\"visible\" /><br>\n";
+        $expected .= "<input type=\"hidden\" name=\"hidden\" />\n";
+        $expected .= "</form>\n";
+
+        $this->assertSame($expected, $rendered);
+    }
+}

--- a/tests/unit/XoopsStoryTest.php
+++ b/tests/unit/XoopsStoryTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsstory.php';
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static $connection;
+
+        public static function getDatabaseConnection()
+        {
+            return static::$connection;
+        }
+    }
+}
+
+if (!class_exists('XoopsLogger')) {
+    class XoopsLogger
+    {
+        public function addDeprecated($message): void {}
+    }
+}
+
+if (!class_exists('MyTextSanitizer')) {
+    class MyTextSanitizer
+    {
+        public array $displayArgs = [];
+        public array $previewArgs = [];
+
+        public static function getInstance()
+        {
+            return new self();
+        }
+
+        public function censorString($text)
+        {
+            return (string) $text;
+        }
+
+        public function htmlSpecialChars($text)
+        {
+            return htmlspecialchars((string) $text, ENT_QUOTES | ENT_HTML5);
+        }
+
+        public function displayTarea($text, $html, $smiley, $xcodes)
+        {
+            $this->displayArgs[] = func_get_args();
+
+            return "display:" . $text;
+        }
+
+        public function previewTarea($text, $html, $smiley, $xcodes)
+        {
+            $this->previewArgs[] = func_get_args();
+
+            return "preview:" . $text;
+        }
+    }
+}
+
+if (!class_exists('XoopsUser')) {
+    class XoopsUser
+    {
+        public static function getUnameFromId($uid)
+        {
+            return 'user-' . $uid;
+        }
+    }
+}
+
+if (!class_exists('XoopsTopic')) {
+    class XoopsTopic
+    {
+        public string $table;
+        public int $topicid;
+
+        public function __construct($table, $topicid)
+        {
+            $this->table   = $table;
+            $this->topicid = (int) $topicid;
+        }
+    }
+}
+
+if (!defined('_DB_QUERY_ERROR')) {
+    define('_DB_QUERY_ERROR', 'Query error: %s');
+}
+
+class StoryTestDatabase
+{
+    public int $nextId      = 0;
+    public int $insertId    = 0;
+    public bool $execResult = true;
+    public $queryResult;
+    public array $fetchArray = [];
+    public array $queries    = [];
+
+    public function genId($seq)
+    {
+        $this->queries[] = 'GENID:' . $seq;
+
+        return $this->nextId;
+    }
+
+    public function exec($sql)
+    {
+        $this->queries[] = $sql;
+
+        return $this->execResult;
+    }
+
+    public function getInsertId()
+    {
+        return $this->insertId;
+    }
+
+    public function query($sql)
+    {
+        $this->queries[] = $sql;
+
+        return $this->queryResult;
+    }
+
+    public function isResultSet($result)
+    {
+        return $result === $this->queryResult && $result !== null;
+    }
+
+    public function fetchArray($result)
+    {
+        return $this->fetchArray;
+    }
+
+    public function escape($text)
+    {
+        return addslashes((string) $text);
+    }
+
+    public function error()
+    {
+        return 'error';
+    }
+}
+
+class XoopsStoryTest extends TestCase
+{
+    private StoryTestDatabase $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db                    = new StoryTestDatabase();
+        XoopsDatabaseFactory::$connection = $this->db;
+        $GLOBALS['xoopsLogger']      = new XoopsLogger();
+        $GLOBALS['xoopsDB']          = $this->db;
+    }
+
+    public function testMakeStoryPopulatesFields(): void
+    {
+        $story = new XoopsStory();
+        $story->table = 'stories';
+        $story->makeStory(['storyid' => 42, 'title' => 'hello', 'topicid' => 9]);
+
+        $this->assertSame(42, $story->storyid);
+        $this->assertSame('hello', $story->title);
+        $this->assertSame(9, $story->topicid);
+    }
+
+    public function testStoreInsertsNewStory(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->table       = 'stories';
+        $story->topicstable = 'topics';
+        $story->uid         = 1;
+        $story->title       = 'Title';
+        $story->hometext    = 'Home';
+        $story->bodytext    = 'Body';
+        $story->hostname    = 'host';
+        $story->topicid     = 3;
+        $story->ihome       = 0;
+        $story->notifypub   = 1;
+        $story->type        = 'news';
+        $story->topicdisplay = 1;
+        $story->topicalign   = 'L';
+        $story->comments     = 0;
+        $story->approved     = true;
+        $story->published    = 123;
+        $this->db->nextId    = 7;
+
+        $newId = $story->store();
+
+        $this->assertSame(7, $newId);
+        $this->assertSame(7, $story->storyid);
+        $this->assertStringContainsString("INSERT INTO stories", $this->db->queries[1]);
+        $this->assertStringContainsString("'Title'", $this->db->queries[1]);
+    }
+
+    public function testStoreUpdatesExistingStory(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->table       = 'stories';
+        $story->storyid     = 5;
+        $story->title       = 'Updated';
+        $story->published   = 10;
+        $story->expired     = 0;
+        $story->nohtml      = 1;
+        $story->nosmiley    = 0;
+        $story->hometext    = 'Home';
+        $story->bodytext    = 'Body';
+        $story->topicid     = 3;
+        $story->ihome       = 0;
+        $story->topicdisplay = 1;
+        $story->topicalign   = 'C';
+        $story->comments     = 2;
+        $story->approved     = false;
+
+        $updatedId = $story->store();
+
+        $this->assertSame(5, $updatedId);
+        $this->assertSame(5, $story->storyid);
+        $this->assertStringContainsString('UPDATE stories SET title', $this->db->queries[0]);
+        $this->assertStringContainsString('WHERE storyid = 5', $this->db->queries[0]);
+    }
+
+    public function testStoreReturnsFalseOnExecFailure(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->table   = 'stories';
+        $story->uid     = 1;
+        $this->db->execResult = false;
+
+        $this->assertFalse($story->store());
+    }
+
+    public function testGetStoryThrowsOnInvalidResult(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->table = 'stories';
+        $this->db->queryResult = null;
+
+        $this->expectException(\RuntimeException::class);
+        $story->getStory(2);
+    }
+
+    public function testGetStoryPopulatesFromDatabase(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->table = 'stories';
+        $this->db->queryResult = new stdClass();
+        $this->db->fetchArray  = ['storyid' => 9, 'title' => 'loaded'];
+
+        $story->getStory(9);
+
+        $this->assertSame(['SELECT * FROM stories WHERE storyid=9'], $this->db->queries);
+        $this->assertSame(9, $story->storyid);
+        $this->assertSame('loaded', $story->title);
+    }
+
+    public function testDeleteAndCounters(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->table   = 'stories';
+        $story->storyid = 4;
+
+        $this->assertTrue($story->delete());
+        $this->assertTrue($story->updateCounter());
+        $this->assertTrue($story->updateComments(5));
+        $this->assertCount(3, $this->db->queries);
+        $this->assertStringContainsString('DELETE FROM stories WHERE storyid = 4', $this->db->queries[0]);
+        $this->assertStringContainsString('UPDATE stories SET counter = counter+1 WHERE storyid = 4', $this->db->queries[1]);
+        $this->assertStringContainsString('UPDATE stories SET comments = 5 WHERE storyid = 4', $this->db->queries[2]);
+    }
+
+    public function testFormattingHelpers(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->title    = '<b>title</b>';
+        $story->hometext = 'home';
+        $story->bodytext = 'body';
+        $story->nohtml   = 1;
+        $story->nosmiley = 1;
+
+        $this->assertSame('&lt;b&gt;title&lt;/b&gt;', $story->title());
+        $this->assertSame('display:home', $story->hometext());
+        $this->assertSame('display:body', $story->bodytext());
+
+        $story->nosmiley = 0;
+        $this->assertSame('preview:home', $story->hometext('Preview'));
+    }
+
+    public function testTopicAndUserHelpers(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->topicstable = 'topics';
+        $story->topicid     = 11;
+        $story->uid         = 8;
+
+        $topic = $story->topic();
+        $this->assertInstanceOf(XoopsTopic::class, $topic);
+        $this->assertSame('topics', $topic->table);
+        $this->assertSame(11, $topic->topicid);
+        $this->assertSame('user-8', $story->uname());
+    }
+
+    public function testTopicalignReturnsTextOrRaw(): void
+    {
+        $story = new XoopsStory();
+        $story->Story();
+        $story->topicalign = 'R';
+
+        $this->assertSame('right', $story->topicalign());
+        $this->assertSame('R', $story->topicalign(false));
+    }
+}

--- a/tests/unit/XoopsTableFormTest.php
+++ b/tests/unit/XoopsTableFormTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/form.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/formelement.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/tableform.php';
+
+if (!defined('NWLINE')) {
+    define('NWLINE', "\n");
+}
+
+if (!class_exists('TableDummyElement')) {
+    class TableDummyElement extends XoopsFormElement
+    {
+        private string $rendered;
+
+        public function __construct(string $name, string $caption = '', string $rendered = '', string $description = '')
+        {
+            $this->setName($name);
+            $this->setCaption($caption);
+            $this->rendered = $rendered ?: '<input name="' . $name . '" />';
+            if ($description !== '') {
+                $this->setDescription($description);
+            }
+        }
+
+        public function isContainer()
+        {
+            return false;
+        }
+
+        public function render()
+        {
+            return $this->rendered;
+        }
+    }
+}
+
+class XoopsTableFormTest extends TestCase
+{
+    public function testRenderRendersTableWithColspanAndHiddenElements(): void
+    {
+        $form = new XoopsTableForm('Table Title', 'tbl', '/submit.php', 'post', false);
+        $first = new TableDummyElement('first', 'First caption', '<input id="first" />', 'First description');
+        $second = new TableDummyElement('second', 'Second caption', '<textarea id="second"></textarea>');
+        $second->setNocolspan(true);
+        $hidden = new TableDummyElement('hid', 'Hidden caption', '<input type="hidden" name="hid" />');
+        $hidden->setHidden();
+
+        $form->addElement($first);
+        $form->addElement($second);
+        $form->addElement($hidden);
+
+        $output = $form->render();
+
+        $this->assertStringContainsString('<form name="tbl" id="tbl" action="/submit.php" method="post">', $output);
+        $this->assertStringContainsString('<table border="0" width="100%">', $output);
+        $this->assertStringContainsString('<td>First caption', $output);
+        $this->assertStringContainsString('<span style="font-weight: normal;">First description</span>', $output);
+        $this->assertStringContainsString('</td><td><input id="first" /></td></tr>', $output);
+        $this->assertStringContainsString('<td colspan="2">Second caption</td></tr><tr valign="top" align="left"><td><textarea id="second"></textarea></td></tr>', $output);
+        $this->assertStringContainsString('<input type="hidden" name="hid" />', $output);
+
+        $tableEndPos = strpos($output, '</table>');
+        $hiddenPos   = strpos($output, '<input type="hidden" name="hid" />');
+        $this->assertNotFalse($tableEndPos);
+        $this->assertNotFalse($hiddenPos);
+        $this->assertGreaterThan($tableEndPos, $hiddenPos);
+    }
+}

--- a/tests/unit/XoopsTarDownloaderTest.php
+++ b/tests/unit/XoopsTarDownloaderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/tardownloader.php';
+
+class TarStub
+{
+    public array $files = [];
+    public int $numFiles = 0;
+    public ?string $lastOutputName = null;
+    public ?bool $lastGzip = null;
+
+    public function addFile($path, $binary = false): void
+    {
+        $this->files[] = ['name' => $path, 'time' => 0, 'binary' => $binary];
+        $this->numFiles = count($this->files);
+    }
+
+    public function toTarOutput($name, $gzip)
+    {
+        $this->lastOutputName = $name;
+        $this->lastGzip      = $gzip;
+
+        return 'tar-output:' . $name . ':' . ($gzip ? 'gzip' : 'plain');
+    }
+}
+
+class XoopsTarDownloaderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!defined('XOOPS_CACHE_PATH')) {
+            define('XOOPS_CACHE_PATH', sys_get_temp_dir() . '/xoops_cache');
+        }
+        if (!is_dir(XOOPS_CACHE_PATH)) {
+            mkdir(XOOPS_CACHE_PATH, 0777, true);
+        }
+
+        if (function_exists('header_remove')) {
+            header_remove();
+        }
+    }
+
+    public function testConstructorSetsDefaults(): void
+    {
+        $downloader = new XoopsTarDownloader();
+
+        $this->assertInstanceOf(tar::class, $downloader->archiver);
+        $this->assertSame('.tar.gz', $downloader->ext);
+        $this->assertSame('application/x-gzip', $downloader->mimetype);
+    }
+
+    public function testAddFileRenamesWhenProvided(): void
+    {
+        $downloader            = new XoopsTarDownloader();
+        $downloader->archiver  = new TarStub();
+
+        $downloader->addFile('/tmp/original.txt', 'renamed.txt');
+
+        $this->assertSame(1, $downloader->archiver->numFiles);
+        $this->assertSame('renamed.txt', $downloader->archiver->files[0]['name']);
+    }
+
+    public function testAddBinaryFileKeepsBinaryFlag(): void
+    {
+        $downloader           = new XoopsTarDownloader();
+        $downloader->archiver = new TarStub();
+
+        $downloader->addBinaryFile('/tmp/binary.bin', 'binary.bin');
+
+        $this->assertTrue($downloader->archiver->files[0]['binary']);
+        $this->assertSame('binary.bin', $downloader->archiver->files[0]['name']);
+    }
+
+    public function testAddFileDataWritesAndReplacesNameAndTime(): void
+    {
+        $downloader           = new XoopsTarDownloader();
+        $downloader->archiver = new TarStub();
+
+        $downloader->addFileData('content', 'archive.txt', 1234);
+
+        $this->assertSame('archive.txt', $downloader->archiver->files[0]['name']);
+        $this->assertSame(1234, $downloader->archiver->files[0]['time']);
+    }
+
+    public function testAddBinaryFileDataMarksBinaryAndTime(): void
+    {
+        $downloader           = new XoopsTarDownloader();
+        $downloader->archiver = new TarStub();
+
+        $downloader->addBinaryFileData("\x00\x01", 'binary.data', 5678);
+
+        $this->assertTrue($downloader->archiver->files[0]['binary']);
+        $this->assertSame('binary.data', $downloader->archiver->files[0]['name']);
+        $this->assertSame(5678, $downloader->archiver->files[0]['time']);
+    }
+
+    public function testDownloadOutputsArchiveAndHeaders(): void
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'UnitTestBrowser/1.0';
+        $downloader                 = new XoopsTarDownloader();
+        $downloader->archiver       = new TarStub();
+
+        ob_start();
+        $downloader->download('package', false);
+        $output = ob_get_clean();
+
+        $this->assertSame('tar-output:package.tar.gz:plain', $output);
+        $this->assertSame('package.tar.gz', $downloader->archiver->lastOutputName);
+        $this->assertFalse($downloader->archiver->lastGzip);
+
+        $headers = headers_list();
+        $this->assertContains('Content-Type: application/x-gzip', $headers);
+        $this->assertContains('Content-Disposition: attachment; filename="package.tar.gz"', $headers);
+        $this->assertContains('Pragma: no-cache', $headers);
+    }
+}

--- a/tests/unit/XoopsThemeCoreTest.php
+++ b/tests/unit/XoopsThemeCoreTest.php
@@ -1,0 +1,476 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'http://example.com');
+}
+if (!defined('XOOPS_UPLOAD_URL')) {
+    define('XOOPS_UPLOAD_URL', XOOPS_URL . '/uploads');
+}
+
+// Basic XOOPS constants used by theme logic
+if (!defined('XOOPS_SIDEBLOCK_LEFT')) {
+    define('XOOPS_SIDEBLOCK_LEFT', 0);
+    define('XOOPS_SIDEBLOCK_RIGHT', 1);
+    define('XOOPS_CENTERBLOCK_LEFT', 2);
+    define('XOOPS_CENTERBLOCK_CENTER', 3);
+    define('XOOPS_CENTERBLOCK_RIGHT', 4);
+    define('XOOPS_CENTERBLOCK_BOTTOMLEFT', 5);
+    define('XOOPS_CENTERBLOCK_BOTTOM', 6);
+    define('XOOPS_CENTERBLOCK_BOTTOMRIGHT', 7);
+    define('XOOPS_FOOTERBLOCK_LEFT', 8);
+    define('XOOPS_FOOTERBLOCK_CENTER', 9);
+    define('XOOPS_FOOTERBLOCK_RIGHT', 10);
+    define('XOOPS_FOOTERBLOCK_ALL', 11);
+}
+if (!defined('XOOPS_BLOCK_VISIBLE')) {
+    define('XOOPS_BLOCK_VISIBLE', 1);
+}
+if (!defined('XOOPS_CONF_SEARCH')) {
+    define('XOOPS_CONF_SEARCH', 5);
+}
+if (!defined('XOOPS_CONF_METAFOOTER')) {
+    define('XOOPS_CONF_METAFOOTER', 6);
+}
+if (!defined('XOOPS_GROUP_ANONYMOUS')) {
+    define('XOOPS_GROUP_ANONYMOUS', 3);
+}
+if (!defined('_XO_ER_FILENOTFOUND')) {
+    define('_XO_ER_FILENOTFOUND', 'FILE_NOT_FOUND');
+}
+
+// Cache/config helpers
+if (!function_exists('xoops_setConfigOption')) {
+    $GLOBALS['xoopsConfigOptions'] = [];
+    function xoops_setConfigOption($name, $value)
+    {
+        $GLOBALS['xoopsConfigOptions'][$name] = $value;
+    }
+}
+if (!function_exists('xoops_getConfigOption')) {
+    function xoops_getConfigOption($name)
+    {
+        return $GLOBALS['xoopsConfigOptions'][$name] ?? null;
+    }
+}
+if (!function_exists('xoops_load')) {
+    function xoops_load($name)
+    {
+        return true;
+    }
+}
+if (!function_exists('xoops_getbanner')) {
+    function xoops_getbanner()
+    {
+        return 'banner';
+    }
+}
+if (!function_exists('xoops_getcss')) {
+    function xoops_getcss($theme)
+    {
+        return "{$theme}/style.css";
+    }
+}
+if (!function_exists('xoops_getHandler')) {
+    class XoopsConfigHandler
+    {
+        public function getConfigsByCat($cat)
+        {
+            return ['enable_search' => 1];
+        }
+
+        public function getConfigs($criteria, $id_as_key = true)
+        {
+            return [
+                new class {
+                    public function getVar($name, $format = 'n')
+                    {
+                        if ('conf_name' === $name) {
+                            return 'meta_description';
+                        }
+                        if ('conf_value' === $name) {
+                            return 'Site description';
+                        }
+
+                        return null;
+                    }
+                },
+            ];
+        }
+    }
+
+    function xoops_getHandler($name)
+    {
+        return new XoopsConfigHandler();
+    }
+}
+
+if (!class_exists('Criteria')) {
+    class Criteria
+    {
+        public function __construct($field, $value = null) {}
+    }
+}
+if (!class_exists('CriteriaCompo')) {
+    class CriteriaCompo
+    {
+        public function __construct($criteria = null) {}
+        public function add($criteria) {}
+    }
+}
+
+if (!class_exists('Xmf\\Request')) {
+    class Request
+    {
+        public static function getString($name, $default = '', $source = 'REQUEST')
+        {
+            return $_SERVER[$name] ?? $default;
+        }
+    }
+    class_alias('Request', 'Xmf\\Request');
+}
+
+class TestLogger
+{
+    public $triggered = [];
+    public $blocks    = [];
+
+    public static function getInstance()
+    {
+        if (!isset($GLOBALS['testLogger'])) {
+            $GLOBALS['testLogger'] = new self();
+        }
+
+        return $GLOBALS['testLogger'];
+    }
+
+    public function triggerError($path, $code, $file, $line, $type)
+    {
+        $this->triggered[] = [$path, $code, $type];
+    }
+
+    public function addBlock($name, $cached = false, $ttl = null)
+    {
+        $this->blocks[] = [$name, $cached, $ttl];
+    }
+
+    public function stopTime($label)
+    {
+        $this->stopped[] = $label;
+    }
+}
+
+class XoopsCache
+{
+    private static $instance;
+    public $data = [];
+
+    public static function getInstance()
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function read($id)
+    {
+        return $this->data[$id] ?? false;
+    }
+
+    public function write($id, $value)
+    {
+        $this->data[$id] = $value;
+    }
+}
+
+class XoopsPreload
+{
+    private static $instance;
+
+    public static function getInstance()
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function triggerEvent($event, $args)
+    {
+        $this->lastEvent = [$event, $args];
+    }
+}
+
+$stubBase = sys_get_temp_dir() . '/xoops_theme_stubs';
+if (!is_dir($stubBase . '/class')) {
+    mkdir($stubBase . '/class', 0777, true);
+}
+file_put_contents(
+    $stubBase . '/class/xoopsblock.php',
+    <<<'PHPBLOCK'
+<?php
+class XoopsBlock
+{
+    public function getAllByGroupModule($groups, $mid, $isStart, $visible)
+    {
+        return [new XoopsBlockStub()];
+    }
+}
+class XoopsBlockStub
+{
+    public function getVar($name, $format = 'n')
+    {
+        $map = [
+            'bid'            => 99,
+            'dirname'        => 'system',
+            'title'          => 'Block title',
+            'weight'         => 2,
+            'last_modified'  => 123,
+            'bcachetime'     => 0,
+            'template'       => 'dummy.tpl',
+            'name'           => 'Dummy block',
+            'side'           => XOOPS_SIDEBLOCK_LEFT,
+        ];
+
+        return $map[$name];
+    }
+
+    public function buildBlock()
+    {
+        return ['data' => 'ok'];
+    }
+}
+PHPBLOCK
+);
+file_put_contents(
+    $stubBase . '/class/template.php',
+    <<<'PHPTPL'
+<?php
+class XoopsTpl
+{
+    public $assigned = [];
+    public $caching = 0;
+    public $cache_lifetime = 0;
+    public $currentTheme;
+    public $compileId;
+
+    public function assignByRef($name, &$value)
+    {
+        $this->assigned[$name] =& $value;
+    }
+
+    public function assign($name, $value = null)
+    {
+        if (is_array($name)) {
+            foreach ($name as $key => $val) {
+                $this->assigned[$key] = $val;
+            }
+        } else {
+            $this->assigned[$name] = $value;
+        }
+    }
+
+    public function setCompileId($id = null)
+    {
+        $this->compileId = $id;
+    }
+
+    public function fetch($tpl, $cacheId = null)
+    {
+        return "tpl:{$tpl}:{$cacheId}";
+    }
+
+    public function isCached($tpl, $cacheId = null)
+    {
+        return false;
+    }
+
+    public function display($tpl)
+    {
+        $this->lastDisplayed = $tpl;
+    }
+
+    public function getTemplateVars($name)
+    {
+        return $this->assigned[$name] ?? '';
+    }
+}
+PHPTPL
+);
+
+$GLOBALS['xoops'] = new class($stubBase)
+{
+    private $base;
+    public function __construct($base)
+    {
+        $this->base = $base;
+    }
+
+    public function path($path)
+    {
+        return $this->base . '/' . $path;
+    }
+
+    public function url($path)
+    {
+        return XOOPS_URL . '/' . $path;
+    }
+};
+
+if (!defined('XOOPS_THEME_PATH')) {
+    define('XOOPS_THEME_PATH', sys_get_temp_dir() . '/xoops_themes');
+}
+if (!defined('XOOPS_THEME_URL')) {
+    define('XOOPS_THEME_URL', XOOPS_URL . '/themes');
+}
+if (!defined('XOOPS_ADMINTHEME_PATH')) {
+    define('XOOPS_ADMINTHEME_PATH', sys_get_temp_dir() . '/xoops_admin_themes');
+}
+if (!defined('XOOPS_ADMINTHEME_URL')) {
+    define('XOOPS_ADMINTHEME_URL', XOOPS_URL . '/adminthemes');
+}
+
+foreach ([XOOPS_THEME_PATH, XOOPS_ADMINTHEME_PATH] as $dir) {
+    if (!is_dir($dir . '/alpha')) {
+        mkdir($dir . '/alpha', 0777, true);
+    }
+    file_put_contents($dir . '/alpha/theme.tpl', '<h1>Theme</h1>');
+}
+
+$GLOBALS['xoopsLogger'] = TestLogger::getInstance();
+
+require_once XOOPS_TU_ROOT_PATH . '/class/xoopskernel.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/theme_blocks.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/theme.php';
+
+class XoopsThemeCoreTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['xoopsConfig'] = [
+            'startpage' => '--',
+            'theme_set' => 'alpha',
+            'banners'   => false,
+            'language'  => 'english',
+            'sitename'  => 'XOOPS',
+            'slogan'    => 'Just test',
+        ];
+        $GLOBALS['xoopsOption'] = [];
+        $GLOBALS['xoopsUser']   = null;
+        $GLOBALS['xoopsUserIsAdmin'] = false;
+        $GLOBALS['xoopsModule'] = null;
+        $_SERVER['REQUEST_URI'] = '/index.php';
+        $_SERVER['SCRIPT_FILENAME'] = XOOPS_ROOT_PATH . '/index.php';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['PATH_TRANSLATED'] = null;
+        $_SESSION = [];
+        $GLOBALS['xoopsConfigOptions'] = ['theme_set_allowed' => ['alpha']];
+        $GLOBALS['testLogger']->triggered = [];
+    }
+
+    public function testKernelPathAndUrlHelpers(): void
+    {
+        $kernel = new xos_kernel_Xoops2();
+
+        $this->assertSame(XOOPS_ROOT_PATH . DS . 'modules', $kernel->path('modules'));
+        $this->assertSame('https://example.com', $kernel->url('https://example.com'));
+
+        $built = $kernel->buildUrl('index.php?foo=bar', ['baz' => 'qux']);
+        $this->assertSame('index.php?foo=bar&baz=qux', $built);
+    }
+
+    public function testKernelPathExistsLogsMissing(): void
+    {
+        $kernel = new xos_kernel_Xoops2();
+        $existing = tempnam(sys_get_temp_dir(), 'xoops');
+
+        $this->assertSame($existing, $kernel->pathExists($existing, E_USER_WARNING));
+
+        unlink($existing);
+        $this->assertFalse($kernel->pathExists($existing, E_USER_WARNING));
+        $this->assertSame($existing, $GLOBALS['testLogger']->triggered[0][0]);
+    }
+
+    public function testKernelThemeSelectAndGzip(): void
+    {
+        $kernel = new xos_kernel_Xoops2();
+        $_POST['xoops_theme_select'] = 'alpha';
+
+        xoops_setConfigOption('gzip_compression', 1);
+        $kernel->themeSelect();
+        $this->assertSame('alpha', xoops_getConfigOption('theme_set'));
+        $this->assertSame('alpha', $_SESSION['xoopsUserTheme']);
+
+        $kernel->gzipCompression();
+        $this->assertSame(0, xoops_getConfigOption('gzip_compression'));
+    }
+
+    public function testPageBuilderRetrievesBlocks(): void
+    {
+        $builder = new xos_logos_PageBuilder();
+        $builder->theme = new class {
+            public $template;
+            public function __construct()
+            {
+                $this->template = new XoopsTpl();
+            }
+        };
+        $builder->xoInit();
+
+        $this->assertArrayHasKey('canvas_left', $builder->blocks);
+        $left = $builder->blocks['canvas_left'];
+        $this->assertArrayHasKey(99, $left);
+        $this->assertSame('tpl:db:dummy.tpl:blk_99', $left[99]['content']);
+    }
+
+    public function testPageBuilderCacheIdGeneratedByTheme(): void
+    {
+        $builder      = new xos_logos_PageBuilder();
+        $builder->theme = new class {
+            public function generateCacheId($id)
+            {
+                return 'prefix-' . $id;
+            }
+        };
+
+        $this->assertSame('prefix-abc', $builder->generateCacheId('abc'));
+    }
+
+    public function testThemeFactoryCreatesFromRequest(): void
+    {
+        $_REQUEST['xoops_theme_select'] = 'alpha';
+        $_SESSION = [];
+        ob_start();
+        $factory = new xos_opal_ThemeFactory();
+        $theme   = $factory->createInstance();
+        ob_end_clean();
+
+        $this->assertInstanceOf(xos_opal_Theme::class, $theme);
+        $this->assertSame('alpha', $theme->folderName);
+        $this->assertSame(XOOPS_THEME_URL . '/alpha', $theme->url);
+        $this->assertSame($theme, $theme->template->assigned['xoTheme']);
+    }
+
+    public function testAdminThemeFactoryOverridesPaths(): void
+    {
+        $_REQUEST['xoops_theme_select'] = 'alpha';
+        ob_start();
+        $factory = new xos_opal_AdminThemeFactory();
+        $theme   = $factory->createInstance();
+        ob_end_clean();
+
+        $this->assertFalse($theme->renderBanner);
+        $this->assertSame(XOOPS_ADMINTHEME_PATH . '/alpha', $theme->path);
+        $this->assertSame(XOOPS_ADMINTHEME_URL . '/alpha', $theme->url);
+        $this->assertSame($theme->path, $theme->template->assigned['theme_path']);
+    }
+}

--- a/tests/unit/XoopsThemeFormTest.php
+++ b/tests/unit/XoopsThemeFormTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/form.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopsform/themeform.php';
+
+if (!class_exists('DummyThemeRenderer')) {
+    class DummyThemeRenderer
+    {
+        public array $calls = [];
+
+        public function addThemeFormBreak($form, $extra, $class): void
+        {
+            $this->calls[] = ['addThemeFormBreak', $form, $extra, $class];
+        }
+
+        public function renderThemeForm($form)
+        {
+            $this->calls[] = ['renderThemeForm', $form];
+
+            return '<rendered:' . $form->getName() . '>';
+        }
+    }
+}
+
+if (!class_exists('XoopsFormRenderer')) {
+    class XoopsFormRenderer
+    {
+        private static $instance;
+        private DummyThemeRenderer $renderer;
+
+        private function __construct()
+        {
+            $this->renderer = new DummyThemeRenderer();
+        }
+
+        public static function getInstance(): self
+        {
+            if (!self::$instance) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        public function get(): DummyThemeRenderer
+        {
+            return $this->renderer;
+        }
+    }
+}
+
+/**
+ * @covers XoopsThemeForm
+ */
+class XoopsThemeFormTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $ref = new ReflectionClass(XoopsFormRenderer::class);
+        $instanceProperty = $ref->getProperty('instance');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue(null);
+    }
+
+    public function testInsertBreakDelegatesToRenderer(): void
+    {
+        $form = new XoopsThemeForm('title', 'theme', '/action.php');
+        $renderer = XoopsFormRenderer::getInstance()->get();
+
+        $form->insertBreak('extra', 'cls');
+
+        $this->assertSame([
+            ['addThemeFormBreak', $form, 'extra', 'cls'],
+        ], $renderer->calls);
+    }
+
+    public function testRenderUsesRendererOutput(): void
+    {
+        $form = new XoopsThemeForm('title', 'theme', '/action.php');
+        $renderer = XoopsFormRenderer::getInstance()->get();
+
+        $output = $form->render();
+
+        $this->assertSame('<rendered:theme>', $output);
+        $this->assertSame([
+            ['renderThemeForm', $form],
+        ], $renderer->calls);
+    }
+}

--- a/tests/unit/XoopsThemeSetParserClassTest.php
+++ b/tests/unit/XoopsThemeSetParserClassTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/xml/themesetparser.php';
+
+if (!class_exists('ThemeSetThemeNameHandler')) {
+    class ThemeSetThemeNameHandler extends XmlTagHandler
+    {
+        public function __construct() {}
+
+        public function getName()
+        {
+            return 'themeset';
+        }
+    }
+}
+
+class XoopsThemeSetParserClassTest extends TestCase
+{
+    public function testConstructorRegistersHandlers(): void
+    {
+        $parser = new XoopsThemeSetParser('');
+
+        $this->assertCount(
+            12,
+            $parser->tagHandlers,
+            'Constructor should register all theme set tag handlers'
+        );
+
+        $expectedClasses = [
+            ThemeSetThemeNameHandler::class,
+            ThemeSetDateCreatedHandler::class,
+            ThemeSetAuthorHandler::class,
+            ThemeSetDescriptionHandler::class,
+            ThemeSetGeneratorHandler::class,
+            ThemeSetNameHandler::class,
+            ThemeSetEmailHandler::class,
+            ThemeSetLinkHandler::class,
+            ThemeSetTemplateHandler::class,
+            ThemeSetImageHandler::class,
+            ThemeSetModuleHandler::class,
+            ThemeSetFileTypeHandler::class,
+            ThemeSetTagHandler::class,
+        ];
+
+        $actualClasses = array_map(function ($handler) {
+            return get_class($handler);
+        }, $parser->tagHandlers);
+
+        foreach ($expectedClasses as $expected) {
+            $this->assertContains($expected, $actualClasses);
+        }
+    }
+
+    public function testThemeSetDataHelpers(): void
+    {
+        $parser = new XoopsThemeSetParser('');
+        $value  = 'XOOPS Modern';
+
+        $parser->setThemeSetData('name', $value);
+
+        $this->assertSame($value, $parser->getThemeSetData('name'));
+        $this->assertArrayHasKey('name', $parser->getThemeSetData());
+        $this->assertFalse($parser->getThemeSetData('missing'));
+    }
+
+    public function testImageDataStoredByReference(): void
+    {
+        $parser = new XoopsThemeSetParser('');
+        $image  = ['name' => 'logo.png'];
+
+        $parser->setImagesData($image);
+        $image['name'] = 'logo-updated.png';
+
+        $images = $parser->getImagesData();
+        $this->assertSame('logo-updated.png', $images[0]['name']);
+    }
+
+    public function testTemplateDataStoredByReference(): void
+    {
+        $parser   = new XoopsThemeSetParser('');
+        $template = ['name' => 'theme.html'];
+
+        $parser->setTemplatesData($template);
+        $template['name'] = 'theme-new.html';
+
+        $templates = $parser->getTemplatesData();
+        $this->assertSame('theme-new.html', $templates[0]['name']);
+    }
+
+    public function testTempArrayAccumulationAndReset(): void
+    {
+        $parser = new XoopsThemeSetParser('');
+
+        $first  = 'first';
+        $second = 'second';
+
+        $parser->setTempArr('value', $first);
+        $parser->setTempArr('value', $second, ',');
+
+        $this->assertSame(['value' => 'first,second'], $parser->getTempArr());
+
+        $parser->resetTempArr();
+        $this->assertSame([], $parser->getTempArr());
+    }
+}

--- a/tests/unit/XoopsTopicTest.php
+++ b/tests/unit/XoopsTopicTest.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopstopic.php';
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static $connection;
+
+        public static function getDatabaseConnection()
+        {
+            return static::$connection;
+        }
+    }
+}
+
+if (!class_exists('XoopsLogger')) {
+    class XoopsLogger
+    {
+        public array $deprecated = [];
+
+        public function addDeprecated($message): void
+        {
+            $this->deprecated[] = $message;
+        }
+    }
+}
+
+if (!class_exists('MyTextSanitizer')) {
+    class MyTextSanitizer
+    {
+        public static function getInstance()
+        {
+            return new self();
+        }
+
+        public function htmlSpecialChars($text)
+        {
+            return htmlspecialchars((string) $text, ENT_QUOTES | ENT_HTML5);
+        }
+    }
+}
+
+if (!class_exists('XoopsTree')) {
+    class XoopsTree
+    {
+        public static array $firstChild      = [];
+        public static array $allChild        = [];
+        public static array $childTree       = [];
+        public static array $selBoxCalls     = [];
+        public static string $nicePathResult = '';
+        public static array $allChildIds     = [];
+
+        public array $records = [];
+
+        public function __construct(public $table, public $id, public $pid)
+        {
+            $this->records[] = [$table, $id, $pid];
+        }
+
+        public function getFirstChild($topicId, $order)
+        {
+            $this->records[] = ['first', $topicId, $order];
+
+            return static::$firstChild;
+        }
+
+        public function getAllChild($topicId, $order)
+        {
+            $this->records[] = ['all', $topicId, $order];
+
+            return static::$allChild;
+        }
+
+        public function getChildTreeArray($topicId, $order)
+        {
+            $this->records[] = ['tree', $topicId, $order];
+
+            return static::$childTree;
+        }
+
+        public function makeMySelBox($title, $order, $selId, $none, $selname, $onchange)
+        {
+            static::$selBoxCalls[] = func_get_args();
+        }
+
+        public function getNicePathFromId($topicId, $title, $funcURL)
+        {
+            $this->records[] = ['nice', $topicId, $title, $funcURL];
+
+            return static::$nicePathResult;
+        }
+
+        public function getAllChildId($topicId, $title)
+        {
+            $this->records[] = ['allid', $topicId, $title];
+
+            return static::$allChildIds;
+        }
+    }
+}
+
+if (!class_exists('XoopsPerms')) {
+    class XoopsPerms
+    {
+        public static function getPermitted($mid, $name, $group)
+        {
+            return [];
+        }
+
+        public function setModuleId($mid): void {}
+
+        public function setName($name): void {}
+
+        public function setItemId($id): void {}
+
+        public function store(): void {}
+
+        public function addGroup($group): void {}
+    }
+}
+
+if (!class_exists('ErrorHandler')) {
+    class ErrorHandler
+    {
+        public static array $errors = [];
+
+        public static function show($code)
+        {
+            static::$errors[] = $code;
+
+            return false;
+        }
+    }
+}
+
+if (!defined('_DB_QUERY_ERROR')) {
+    define('_DB_QUERY_ERROR', 'Query error: %s');
+}
+
+class TopicTestDatabase
+{
+    public int $nextId          = 0;
+    public int $insertId        = 0;
+    public bool $execResult     = true;
+    public $queryResult;
+    public array $fetchArray    = [];
+    public array $fetchArrayQueue = [];
+    public array $fetchRow      = [];
+    public array $queries       = [];
+
+    public function genId($seq)
+    {
+        $this->queries[] = 'GENID:' . $seq;
+
+        return $this->nextId;
+    }
+
+    public function exec($sql)
+    {
+        $this->queries[] = $sql;
+
+        return $this->execResult;
+    }
+
+    public function getInsertId()
+    {
+        return $this->insertId;
+    }
+
+    public function query($sql)
+    {
+        $this->queries[] = $sql;
+
+        return $this->queryResult;
+    }
+
+    public function isResultSet($result)
+    {
+        return $result === $this->queryResult && $result !== null;
+    }
+
+    public function fetchArray($result)
+    {
+        if ($this->fetchArrayQueue !== []) {
+            return array_shift($this->fetchArrayQueue);
+        }
+
+        return $this->fetchArray;
+    }
+
+    public function escape($text)
+    {
+        return addslashes((string) $text);
+    }
+
+    public function error()
+    {
+        return 'error';
+    }
+
+    public function fetchRow($result)
+    {
+        return $this->fetchRow;
+    }
+}
+
+class XoopsTopicTest extends TestCase
+{
+    private TopicTestDatabase $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db                    = new TopicTestDatabase();
+        $this->db->queryResult       = new stdClass();
+        XoopsDatabaseFactory::$connection = $this->db;
+        $GLOBALS['xoopsDB']          = $this->db;
+        $GLOBALS['xoopsLogger']      = new XoopsLogger();
+        XoopsTree::$firstChild       = [];
+        XoopsTree::$allChild         = [];
+        XoopsTree::$childTree        = [];
+        XoopsTree::$selBoxCalls      = [];
+        XoopsTree::$nicePathResult   = '';
+        XoopsTree::$allChildIds      = [];
+    }
+
+    public function testConstructorUsesArrayToPopulate(): void
+    {
+        $topic = new XoopsTopic('topics', ['topic_id' => 5, 'topic_title' => 'Title']);
+
+        $this->assertSame(5, $topic->topic_id);
+        $this->assertSame('Title', $topic->topic_title);
+        $this->assertSame('topics', $topic->table);
+    }
+
+    public function testConstructorLoadsFromDatabaseWhenIdProvided(): void
+    {
+        $this->db->fetchArray = ['topic_id' => 7, 'topic_title' => 'Loaded'];
+        $topic                = new XoopsTopic('topics', 7);
+
+        $this->assertSame(['SELECT * FROM topics WHERE topic_id=7'], $this->db->queries);
+        $this->assertSame(7, $topic->topic_id);
+        $this->assertSame('Loaded', $topic->topic_title);
+    }
+
+    public function testSettersAndAccessors(): void
+    {
+        $topic = new XoopsTopic('topics', 0);
+        $topic->setTopicTitle('<b>Title</b>');
+        $topic->setTopicImgurl('img.png');
+        $topic->setTopicPid(3);
+        $topic->topic_id = 2;
+
+        $this->assertSame(2, $topic->topic_id());
+        $this->assertSame(3, $topic->topic_pid());
+        $this->assertSame('&lt;b&gt;Title&lt;/b&gt;', $topic->topic_title());
+        $this->assertSame('img.png', $topic->topic_imgurl());
+        $this->assertNull($topic->prefix());
+    }
+
+    public function testStoreInsertsNewTopic(): void
+    {
+        $topic              = new XoopsTopic('topics', 0);
+        $topic->topic_title = 'New';
+        $topic->topic_imgurl = 'url';
+        $topic->topic_pid   = 1;
+        $this->db->nextId   = 10;
+
+        $this->assertTrue($topic->store());
+        $this->assertSame(10, $topic->topic_id);
+        $this->assertStringContainsString('INSERT INTO topics', $this->db->queries[1]);
+    }
+
+    public function testStoreUpdatesExistingTopic(): void
+    {
+        $topic              = new XoopsTopic('topics', 0);
+        $topic->topic_id    = 4;
+        $topic->topic_title = 'Update';
+        $topic->topic_imgurl = 'img';
+        $topic->topic_pid   = 2;
+
+        $this->assertTrue($topic->store());
+        $this->assertStringContainsString('UPDATE topics SET topic_pid = 2, topic_imgurl =', $this->db->queries[0]);
+    }
+
+    public function testDeleteIssuesQuery(): void
+    {
+        $topic           = new XoopsTopic('topics', 0);
+        $topic->topic_id = 9;
+
+        $topic->delete();
+        $this->assertStringContainsString('DELETE FROM topics WHERE topic_id = 9', $this->db->queries[0]);
+    }
+
+    public function testTopicExistsCountsMatches(): void
+    {
+        $topic             = new XoopsTopic('topics', 0);
+        $this->db->fetchRow = [2];
+
+        $this->assertTrue($topic->topicExists(1, 'Title'));
+        $this->db->fetchRow = [0];
+        $this->assertFalse($topic->topicExists(1, 'Missing'));
+    }
+
+    public function testGetTopicsListReturnsSanitizedTitles(): void
+    {
+        $topic                    = new XoopsTopic('topics', 0);
+        $this->db->fetchArrayQueue = [
+            ['topic_id' => 1, 'topic_pid' => 0, 'topic_title' => 'First'],
+            ['topic_id' => 2, 'topic_pid' => 1, 'topic_title' => '<Second>'],
+            false,
+        ];
+
+        $list = $topic->getTopicsList();
+
+        $this->assertSame(['title' => 'First', 'pid' => 0], $list[1]);
+        $this->assertSame(['title' => '&lt;Second&gt;', 'pid' => 1], $list[2]);
+    }
+
+    public function testChildTopicHelpersReturnObjects(): void
+    {
+        XoopsTree::$firstChild = [
+            ['topic_id' => 5, 'topic_title' => 'Child'],
+        ];
+        XoopsTree::$allChild = [
+            ['topic_id' => 6, 'topic_title' => 'All'],
+        ];
+        XoopsTree::$childTree = [
+            ['topic_id' => 7, 'topic_title' => 'Tree'],
+        ];
+
+        $topic           = new XoopsTopic('topics', ['topic_id' => 1]);
+        $firstChildren   = $topic->getFirstChildTopics();
+        $allChildren     = $topic->getAllChildTopics();
+        $treeChildren    = $topic->getChildTopicsTreeArray();
+
+        $this->assertSame(5, $firstChildren[0]->topic_id);
+        $this->assertSame('Child', $firstChildren[0]->topic_title);
+        $this->assertSame(6, $allChildren[0]->topic_id);
+        $this->assertSame(7, $treeChildren[0]->topic_id);
+    }
+
+    public function testSelectionAndPathHelpers(): void
+    {
+        XoopsTree::$nicePathResult = 'nice-path';
+        XoopsTree::$allChildIds    = [1, 2, 3];
+
+        $topic           = new XoopsTopic('topics', ['topic_id' => 12]);
+        $topic->makeTopicSelBox(0, -1, 'sel', 'onchange');
+
+        $this->assertSame([
+            ['topic_title', 'topic_title', 12, 0, 'sel', 'onchange'],
+        ], XoopsTree::$selBoxCalls);
+        $this->assertSame('nice-path', $topic->getNiceTopicPathFromId('url'));
+        $this->assertSame([1, 2, 3], $topic->getAllChildTopicsId());
+    }
+}

--- a/tests/unit/XoopsTplClassTest.php
+++ b/tests/unit/XoopsTplClassTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/xoops_lib/vendor/smarty/smarty/libs/Smarty.class.php';
+
+if (!defined('_LANGCODE')) {
+    define('_LANGCODE', 'en');
+}
+if (!defined('_CHARSET')) {
+    define('_CHARSET', 'UTF-8');
+}
+if (!defined('XOOPS_VERSION')) {
+    define('XOOPS_VERSION', '2.5.11');
+}
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'https://example.com');
+}
+if (!defined('XOOPS_UPLOAD_URL')) {
+    define('XOOPS_UPLOAD_URL', XOOPS_URL . '/uploads');
+}
+if (!defined('XOOPS_THEME_PATH')) {
+    define('XOOPS_THEME_PATH', sys_get_temp_dir() . '/xoops_themes');
+}
+
+if (!class_exists(XoopsPreload::class)) {
+    class XoopsPreload
+    {
+        public $events = [];
+        private static $instance;
+
+        public static function getInstance()
+        {
+            if (!isset(self::$instance)) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        public function triggerEvent($name, $args = [])
+        {
+            $this->events[] = [$name, $args];
+        }
+    }
+}
+
+if (!isset($GLOBALS['xoopsLogger'])) {
+    $GLOBALS['xoopsLogger'] = new class () {
+        public $deprecated = [];
+
+        public function addDeprecated($message)
+        {
+            $this->deprecated[] = $message;
+        }
+    };
+}
+
+$GLOBALS['xoopsConfig'] = [
+    'debug_mode'   => 0,
+    'template_set' => 'default',
+    'theme_set'    => 'default',
+];
+
+require_once XOOPS_ROOT_PATH . '/class/template.php';
+
+class XoopsTplClassTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!is_dir(XOOPS_THEME_PATH)) {
+            mkdir(XOOPS_THEME_PATH, 0777, true);
+        }
+    }
+
+    public function testConstructorInitializesSmartySettings(): void
+    {
+        $tpl = new XoopsTpl();
+
+        $this->assertSame('<{', $tpl->left_delimiter);
+        $this->assertSame('}>', $tpl->right_delimiter);
+        $this->assertContains(XOOPS_THEME_PATH, (array) $tpl->template_dir);
+        $this->assertSame(XOOPS_VAR_PATH . '/caches/smarty_cache', $tpl->cache_dir);
+        $this->assertSame(XOOPS_VAR_PATH . '/caches/smarty_compile', $tpl->compile_dir);
+        $this->assertSame(Smarty::COMPILECHECK_ON, $tpl->compile_check);
+        $this->assertContains(XOOPS_ROOT_PATH . '/class/smarty3_plugins', $tpl->plugins_dir);
+
+        $expectedCompileId = substr(md5(XOOPS_URL), 0, 8) . '-system-default-default';
+        $this->assertSame($expectedCompileId, $tpl->compile_id);
+
+        $this->assertSame(XOOPS_URL, $tpl->getTemplateVars('xoops_url'));
+        $this->assertSame(XOOPS_ROOT_PATH, $tpl->getTemplateVars('xoops_rootpath'));
+        $this->assertSame(_LANGCODE, $tpl->getTemplateVars('xoops_langcode'));
+        $this->assertSame(_CHARSET, $tpl->getTemplateVars('xoops_charset'));
+        $this->assertSame(XOOPS_VERSION, $tpl->getTemplateVars('xoops_version'));
+        $this->assertSame(XOOPS_UPLOAD_URL, $tpl->getTemplateVars('xoops_upload_url'));
+
+        $preload = XoopsPreload::getInstance();
+        $this->assertSame([
+            ['core.class.template.new', [$tpl]],
+        ], $preload->events);
+    }
+
+    public function testFetchFromDataUsesTemporaryAssignments(): void
+    {
+        $tpl = new XoopsTpl();
+        $tpl->assign('existing', 'keep');
+
+        $output = $tpl->fetchFromData('Hello <{$name}>', false, ['name' => 'World']);
+
+        $this->assertSame('Hello World', trim($output));
+        $this->assertSame('keep', $tpl->getTemplateVars('existing'));
+    }
+
+    public function testSetCompileIdHonorsParameters(): void
+    {
+        $tpl = new XoopsTpl();
+        $tpl->setCompileId('news', 'theme1', 'tpl1');
+
+        $expected = substr(md5(XOOPS_URL), 0, 8) . '-news-theme1-tpl1';
+        $this->assertSame($expected, $tpl->compile_id);
+    }
+
+    public function testXoopsClearCacheResetsCompileIdAndClearsTemplates(): void
+    {
+        $tpl = new class () extends XoopsTpl {
+            public $clearCalls;
+
+            public function clearCompiledTemplate($tpl_file = null, $compile_id = null, $exp_time = null)
+            {
+                $this->clearCalls[] = [$tpl_file, $compile_id, $exp_time];
+                return true;
+            }
+        };
+
+        $tpl->compile_id = 'original';
+        $tpl->xoopsClearCache('mod', 'themeX', 'tplX');
+
+        $expectedId = substr(md5(XOOPS_URL), 0, 8) . '-mod-tplX-themeX';
+        $this->assertSame($expectedId, $tpl->compile_id);
+        $this->assertSame([[null, $expectedId, null]], $tpl->clearCalls);
+    }
+
+    public function testDeprecatedMethodsLogWarnings(): void
+    {
+        $logger = $GLOBALS['xoopsLogger'];
+        $logger->deprecated = [];
+
+        $tpl = new XoopsTpl();
+        $tpl->xoops_setCaching(2);
+
+        $this->assertSame(2, $tpl->caching);
+        $this->assertNotEmpty($logger->deprecated);
+        $this->assertStringContainsString('xoops_setCaching', $logger->deprecated[0]);
+    }
+}

--- a/tests/unit/XoopsTplfileTest.php
+++ b/tests/unit/XoopsTplfileTest.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/tplfile.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsTplfileTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $tplfile = new XoopsTplfile();
+
+        $this->assertNull($tplfile->getVar('tpl_id'));
+        $this->assertSame(0, $tplfile->getVar('tpl_refid'));
+        $this->assertNull($tplfile->getVar('tpl_tplset'));
+        $this->assertNull($tplfile->getVar('tpl_file'));
+        $this->assertNull($tplfile->getVar('tpl_desc'));
+        $this->assertSame(0, $tplfile->getVar('tpl_lastmodified'));
+        $this->assertSame(0, $tplfile->getVar('tpl_lastimported'));
+        $this->assertNull($tplfile->getVar('tpl_module'));
+        $this->assertNull($tplfile->getVar('tpl_type'));
+        $this->assertNull($tplfile->getVar('tpl_source'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $tplfile = new XoopsTplfile();
+        $tplfile->setVar('tpl_id', 99);
+        $tplfile->setVar('tpl_refid', 3);
+        $tplfile->setVar('tpl_tplset', 'default');
+        $tplfile->setVar('tpl_file', 'index.tpl');
+        $tplfile->setVar('tpl_desc', 'desc');
+        $tplfile->setVar('tpl_lastmodified', 111);
+        $tplfile->setVar('tpl_lastimported', 222);
+        $tplfile->setVar('tpl_module', 'system');
+        $tplfile->setVar('tpl_type', 'block');
+        $tplfile->setVar('tpl_source', '<tpl>');
+
+        $this->assertSame(99, $tplfile->id());
+        $this->assertSame(99, $tplfile->tpl_id());
+        $this->assertSame(3, $tplfile->tpl_refid());
+        $this->assertSame('default', $tplfile->tpl_tplset());
+        $this->assertSame('index.tpl', $tplfile->tpl_file());
+        $this->assertSame('desc', $tplfile->tpl_desc());
+        $this->assertSame(111, $tplfile->tpl_lastmodified());
+        $this->assertSame(222, $tplfile->tpl_lastimported());
+        $this->assertSame('system', $tplfile->tpl_module());
+        $this->assertSame('block', $tplfile->tpl_type());
+        $this->assertSame('<tpl>', $tplfile->tpl_source());
+        $this->assertSame('<tpl>', $tplfile->getSource());
+        $this->assertSame(111, $tplfile->getLastModified());
+    }
+}
+
+trait TplfileDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsTplfileHandlerTest extends TestCase
+{
+    use TplfileDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingTplfile(): void
+    {
+        $handler = new XoopsTplfileHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsTplfile::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesTplfileWithAndWithoutSource(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->exactly(2))
+            ->method('query')
+            ->withConsecutive(
+                ['SELECT * FROM pref_tplfile WHERE tpl_id=7'],
+                ['SELECT f.*, s.tpl_source FROM pref_tplfile f LEFT JOIN pref_tplsource s  ON s.tpl_id=f.tpl_id WHERE f.tpl_id=7']
+            )
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'tpl_id'          => 7,
+            'tpl_refid'       => 9,
+            'tpl_tplset'      => 'default',
+            'tpl_file'        => 'index.tpl',
+            'tpl_desc'        => 'desc',
+            'tpl_lastmodified'=> 10,
+            'tpl_lastimported'=> 11,
+            'tpl_module'      => 'system',
+            'tpl_type'        => 'block',
+            'tpl_source'      => '<tpl>',
+        ]);
+
+        $handler = new XoopsTplfileHandler($database);
+        $basic   = $handler->get(7);
+        $withSrc = $handler->get(7, true);
+
+        $this->assertInstanceOf(XoopsTplfile::class, $basic);
+        $this->assertNull($basic->getVar('tpl_source'));
+        $this->assertInstanceOf(XoopsTplfile::class, $withSrc);
+        $this->assertSame('<tpl>', $withSrc->getVar('tpl_source'));
+    }
+
+    public function testLoadSourceFetchesWhenMissing(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT tpl_source FROM pref_tplsource WHERE tpl_id=4')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturn(['tpl_source' => '<tpl>']);
+
+        $tplfile = new XoopsTplfile();
+        $tplfile->setVar('tpl_id', 4);
+
+        $handler = new XoopsTplfileHandler($database);
+        $this->assertTrue($handler->loadSource($tplfile));
+        $this->assertSame('<tpl>', $tplfile->getVar('tpl_source'));
+    }
+
+    public function testInsertCreatesNewTplfileWithSource(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(13);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                [$this->stringContains('INSERT INTO pref_tplfile')],
+                [$this->stringContains('INSERT INTO pref_tplsource')]
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsTplfileHandler($database);
+
+        $tplfile = $handler->create();
+        $tplfile->setVar('tpl_module', 'system');
+        $tplfile->setVar('tpl_refid', 1);
+        $tplfile->setVar('tpl_tplset', 'default');
+        $tplfile->setVar('tpl_file', 'index.tpl');
+        $tplfile->setVar('tpl_desc', 'desc');
+        $tplfile->setVar('tpl_lastmodified', 1);
+        $tplfile->setVar('tpl_lastimported', 2);
+        $tplfile->setVar('tpl_type', 'block');
+        $tplfile->setVar('tpl_source', '<tpl>');
+
+        $this->assertTrue($handler->insert($tplfile));
+        $this->assertSame(13, $tplfile->getVar('tpl_id'));
+    }
+
+    public function testInsertUpdatesExistingTplfile(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                [$this->stringContains('UPDATE pref_tplfile SET')],
+                [$this->stringContains('UPDATE pref_tplsource SET')]
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsTplfileHandler($database);
+
+        $tplfile = $handler->create(false);
+        $tplfile->setNew(false);
+        $tplfile->setVar('tpl_id', 5);
+        $tplfile->setVar('tpl_tplset', 'default');
+        $tplfile->setVar('tpl_file', 'index.tpl');
+        $tplfile->setVar('tpl_desc', 'desc');
+        $tplfile->setVar('tpl_lastmodified', 3);
+        $tplfile->setVar('tpl_lastimported', 4);
+        $tplfile->setVar('tpl_source', '<tpl>');
+
+        $this->assertTrue($handler->insert($tplfile));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsTplfileHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testForceUpdatePersistsChanges(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                [$this->stringContains('UPDATE pref_tplfile SET')],
+                [$this->stringContains('UPDATE pref_tplsource SET')]
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $handler = new XoopsTplfileHandler($database);
+
+        $tplfile = $handler->create(false);
+        $tplfile->setNew(false);
+        $tplfile->setVar('tpl_id', 6);
+        $tplfile->setVar('tpl_tplset', 'default');
+        $tplfile->setVar('tpl_file', 'main.tpl');
+        $tplfile->setVar('tpl_desc', 'desc');
+        $tplfile->setVar('tpl_lastmodified', 5);
+        $tplfile->setVar('tpl_lastimported', 6);
+        $tplfile->setVar('tpl_source', '<tpl>');
+
+        $this->assertTrue($handler->forceUpdate($tplfile));
+    }
+
+    public function testDeleteRemovesTplfile(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('exec')
+            ->with('DELETE FROM pref_tplfile WHERE tpl_id = 8')
+            ->willReturn(true);
+
+        $handler = new XoopsTplfileHandler($database);
+
+        $tplfile = $handler->create(false);
+        $tplfile->setVar('tpl_id', 8);
+
+        $this->assertTrue($handler->delete($tplfile));
+    }
+
+    public function testGetObjectsReturnsResultsWithCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT * FROM pref_tplfile WHERE (tpl_module = 'system') ORDER BY tpl_refid")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'tpl_id'          => 1,
+                'tpl_refid'       => 9,
+                'tpl_tplset'      => 'default',
+                'tpl_file'        => 'index.tpl',
+                'tpl_desc'        => 'desc',
+                'tpl_lastmodified'=> 0,
+                'tpl_lastimported'=> 0,
+                'tpl_module'      => 'system',
+                'tpl_type'        => 'block',
+            ],
+            false
+        );
+
+        $handler  = new XoopsTplfileHandler($database);
+        $criteria = new Criteria('tpl_module', 'system');
+        $objects  = $handler->getObjects($criteria);
+
+        $this->assertCount(1, $objects);
+        $this->assertInstanceOf(XoopsTplfile::class, $objects[0]);
+        $this->assertSame(1, $objects[0]->getVar('tpl_id'));
+    }
+
+    public function testGetCountReturnsNumberOfRows(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT COUNT(*) FROM pref_tplfile WHERE (tpl_module = 'system')")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([7]);
+
+        $handler  = new XoopsTplfileHandler($database);
+        $criteria = new Criteria('tpl_module', 'system');
+
+        $this->assertSame(7, $handler->getCount($criteria));
+    }
+
+    public function testGetModuleTplCountAggregatesResults(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT tpl_module, COUNT(tpl_id) AS count FROM pref_tplfile WHERE tpl_tplset='default' GROUP BY tpl_module")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            ['tpl_module' => 'system', 'count' => 2],
+            ['tpl_module' => '', 'count' => 1],
+            false
+        );
+
+        $handler = new XoopsTplfileHandler($database);
+        $this->assertSame(['system' => 2], $handler->getModuleTplCount('default'));
+    }
+
+    public function testFindBuildsCriteriaAndDelegatesToGetObjects(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler = $this->getMockBuilder(XoopsTplfileHandler::class)
+            ->setConstructorArgs([$database])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('getObjects')
+            ->with($this->callback(static function ($criteria) {
+                $rendered = $criteria->renderWhere();
+                return str_contains($rendered, "tpl_tplset = 'custom'")
+                    && str_contains($rendered, "tpl_module = 'system'")
+                    && str_contains($rendered, "tpl_refid = 5")
+                    && str_contains($rendered, "tpl_file = 'index.tpl'")
+                    && str_contains($rendered, "tpl_type = 'block'");
+            }), true, false)
+            ->willReturn(['result']);
+
+        $this->assertSame(['result'], $handler->find('custom', 'block', 5, 'system', 'index.tpl', true));
+    }
+
+    public function testTemplateExistsUsesCount(): void
+    {
+        $database = $this->createDatabaseMock();
+        $handler  = $this->getMockBuilder(XoopsTplfileHandler::class)
+            ->setConstructorArgs([$database])
+            ->onlyMethods(['getCount'])
+            ->getMock();
+
+        $handler->method('getCount')->willReturnOnConsecutiveCalls(0, 1);
+
+        $this->assertFalse($handler->templateExists('index.tpl', 'default'));
+        $this->assertTrue($handler->templateExists('index.tpl', 'default'));
+    }
+}

--- a/tests/unit/XoopsTplsetTest.php
+++ b/tests/unit/XoopsTplsetTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/tplset.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+class XoopsTplsetTest extends TestCase
+{
+    public function testConstructorInitializesVariables(): void
+    {
+        $tplset = new XoopsTplset();
+
+        $this->assertNull($tplset->getVar('tplset_id'));
+        $this->assertNull($tplset->getVar('tplset_name'));
+        $this->assertNull($tplset->getVar('tplset_desc'));
+        $this->assertNull($tplset->getVar('tplset_credits'));
+        $this->assertSame(0, $tplset->getVar('tplset_created'));
+    }
+
+    public function testHelperMethodsReturnValues(): void
+    {
+        $tplset = new XoopsTplset();
+        $tplset->setVar('tplset_id', 3);
+        $tplset->setVar('tplset_name', 'default');
+        $tplset->setVar('tplset_desc', 'desc');
+        $tplset->setVar('tplset_credits', 'credits');
+        $tplset->setVar('tplset_created', 123);
+
+        $this->assertSame(3, $tplset->id());
+        $this->assertSame(3, $tplset->tplset_id());
+        $this->assertSame('default', $tplset->tplset_name());
+        $this->assertSame('desc', $tplset->tplset_desc());
+        $this->assertSame('credits', $tplset->tplset_credits());
+        $this->assertSame(123, $tplset->tplset_created());
+    }
+}
+
+trait TplsetDatabaseMockTrait
+{
+    protected function createDatabaseMock()
+    {
+        return $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'prefix',
+                'query',
+                'isResultSet',
+                'getRowsNum',
+                'fetchArray',
+                'exec',
+                'getInsertId',
+                'genId',
+                'quote',
+                'fetchRow',
+            ])
+            ->getMock();
+    }
+}
+
+class XoopsTplsetHandlerTest extends TestCase
+{
+    use TplsetDatabaseMockTrait;
+
+    public function testCreateReturnsNewOrExistingTplset(): void
+    {
+        $handler = new XoopsTplsetHandler($this->createDatabaseMock());
+
+        $fresh = $handler->create();
+        $this->assertInstanceOf(XoopsTplset::class, $fresh);
+        $this->assertTrue($fresh->isNew());
+
+        $existing = $handler->create(false);
+        $this->assertFalse($existing->isNew());
+    }
+
+    public function testGetRetrievesTplset(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with('SELECT * FROM pref_tplset WHERE tplset_id=7')
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'tplset_id'      => 7,
+            'tplset_name'    => 'default',
+            'tplset_desc'    => 'desc',
+            'tplset_credits' => 'credits',
+            'tplset_created' => 99,
+        ]);
+
+        $handler = new XoopsTplsetHandler($database);
+        $tplset  = $handler->get(7);
+
+        $this->assertInstanceOf(XoopsTplset::class, $tplset);
+        $this->assertSame('default', $tplset->getVar('tplset_name'));
+    }
+
+    public function testGetByNameRetrievesTplset(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT * FROM pref_tplset WHERE tplset_name='default'")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('getRowsNum')->willReturn(1);
+        $database->method('fetchArray')->willReturn([
+            'tplset_id'      => 5,
+            'tplset_name'    => 'default',
+            'tplset_desc'    => 'desc',
+            'tplset_credits' => 'credits',
+            'tplset_created' => 9,
+        ]);
+
+        $handler = new XoopsTplsetHandler($database);
+        $tplset  = $handler->getByName('default');
+
+        $this->assertInstanceOf(XoopsTplset::class, $tplset);
+        $this->assertSame(5, $tplset->getVar('tplset_id'));
+    }
+
+    public function testInsertCreatesNewTplset(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('genId')->willReturn(0);
+        $database->method('getInsertId')->willReturn(13);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with("INSERT INTO pref_tplset (tplset_id, tplset_name, tplset_desc, tplset_credits, tplset_created) VALUES (0, 'default', 'desc', 'credits', 1)")
+            ->willReturn(true);
+
+        $handler = new XoopsTplsetHandler($database);
+
+        $tplset = $handler->create();
+        $tplset->setVar('tplset_name', 'default');
+        $tplset->setVar('tplset_desc', 'desc');
+        $tplset->setVar('tplset_credits', 'credits');
+        $tplset->setVar('tplset_created', 1);
+
+        $this->assertTrue($handler->insert($tplset));
+        $this->assertSame(13, $tplset->getVar('tplset_id'));
+    }
+
+    public function testInsertUpdatesExistingTplset(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->once())
+            ->method('exec')
+            ->with("UPDATE pref_tplset SET tplset_name = 'default', tplset_desc = 'desc', tplset_credits = 'credits', tplset_created = 2 WHERE tplset_id = 4")
+            ->willReturn(true);
+
+        $handler = new XoopsTplsetHandler($database);
+
+        $tplset = $handler->create(false);
+        $tplset->setNew(false);
+        $tplset->setVar('tplset_id', 4);
+        $tplset->setVar('tplset_name', 'default');
+        $tplset->setVar('tplset_desc', 'desc');
+        $tplset->setVar('tplset_credits', 'credits');
+        $tplset->setVar('tplset_created', 2);
+
+        $this->assertTrue($handler->insert($tplset));
+    }
+
+    public function testInsertRejectsInvalidObject(): void
+    {
+        $handler = new XoopsTplsetHandler($this->createDatabaseMock());
+
+        $this->assertFalse($handler->insert(new stdClass()));
+    }
+
+    public function testDeleteRemovesTplsetAndLinks(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->method('quote')->willReturnCallback(static fn($value) => "'" . $value . "'");
+        $database->expects($this->exactly(2))
+            ->method('query')
+            ->withConsecutive(
+                ['DELETE FROM pref_tplset WHERE tplset_id = 5'],
+                ["DELETE FROM pref_imgset_tplset_link WHERE tplset_name = 'default'"]
+            )
+            ->willReturn(true);
+
+        $handler = new XoopsTplsetHandler($database);
+
+        $tplset = $handler->create(false);
+        $tplset->setVar('tplset_id', 5);
+        $tplset->setVar('tplset_name', 'default');
+
+        $this->assertTrue($handler->delete($tplset));
+    }
+
+    public function testGetObjectsReturnsResultsWithCriteria(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT * FROM pref_tplset WHERE (tplset_name = 'default') ORDER BY tplset_id")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchArray')->willReturnOnConsecutiveCalls(
+            [
+                'tplset_id'      => 1,
+                'tplset_name'    => 'default',
+                'tplset_desc'    => 'desc',
+                'tplset_credits' => 'credits',
+                'tplset_created' => 1,
+            ],
+            false
+        );
+
+        $handler  = new XoopsTplsetHandler($database);
+        $criteria = new Criteria('tplset_name', 'default');
+        $objects  = $handler->getObjects($criteria);
+
+        $this->assertCount(1, $objects);
+        $this->assertInstanceOf(XoopsTplset::class, $objects[0]);
+        $this->assertSame(1, $objects[0]->getVar('tplset_id'));
+    }
+
+    public function testGetCountReturnsNumberOfRows(): void
+    {
+        $database = $this->createDatabaseMock();
+        $database->method('prefix')->willReturnCallback(static fn($table) => 'pref_' . $table);
+        $database->expects($this->once())
+            ->method('query')
+            ->with("SELECT COUNT(*) FROM pref_tplset WHERE (tplset_name = 'default')")
+            ->willReturn('result');
+        $database->method('isResultSet')->willReturn(true);
+        $database->method('fetchRow')->willReturn([7]);
+
+        $handler  = new XoopsTplsetHandler($database);
+        $criteria = new Criteria('tplset_name', 'default');
+
+        $this->assertSame(7, $handler->getCount($criteria));
+    }
+
+    public function testGetListMapsNamesToNames(): void
+    {
+        $handler = $this->getMockBuilder(XoopsTplsetHandler::class)
+            ->setConstructorArgs([$this->createDatabaseMock()])
+            ->onlyMethods(['getObjects'])
+            ->getMock();
+
+        $tplset = new XoopsTplset();
+        $tplset->assignVar('tplset_id', 1);
+        $tplset->assignVar('tplset_name', 'default');
+
+        $handler->method('getObjects')->willReturn([1 => $tplset]);
+
+        $this->assertSame(['default' => 'default'], $handler->getList());
+    }
+}

--- a/tests/unit/XoopsTreeTest.php
+++ b/tests/unit/XoopsTreeTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xoopstree.php';
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static $connection;
+
+        public static function getDatabaseConnection()
+        {
+            return static::$connection;
+        }
+    }
+}
+
+if (!class_exists('XoopsLogger')) {
+    class XoopsLogger
+    {
+        public $deprecated = [];
+
+        public function addDeprecated($message): void
+        {
+            $this->deprecated[] = $message;
+        }
+    }
+}
+
+if (!class_exists('MyTextSanitizer')) {
+    class MyTextSanitizer
+    {
+        public static function getInstance()
+        {
+            return new self();
+        }
+
+        public function htmlSpecialChars($text)
+        {
+            return htmlspecialchars($text, ENT_QUOTES);
+        }
+    }
+}
+
+if (!defined('_DB_QUERY_ERROR')) {
+    define('_DB_QUERY_ERROR', 'Query error: %s');
+}
+
+class FakeTreeDb
+{
+    public array $data = [];
+    public array $queries = [];
+    public bool $resultSet = true;
+
+    public function query($sql)
+    {
+        $this->queries[] = $sql;
+        $rows            = $this->filterRows($sql);
+
+        return (object)['rows' => $rows];
+    }
+
+    public function isResultSet($result)
+    {
+        return $this->resultSet && is_object($result) && isset($result->rows);
+    }
+
+    public function getRowsNum($result)
+    {
+        return count($result->rows);
+    }
+
+    public function fetchArray($result)
+    {
+        return array_shift($result->rows);
+    }
+
+    public function fetchRow($result)
+    {
+        $row = array_shift($result->rows);
+        if ($row === null) {
+            return false;
+        }
+
+        return array_values($row);
+    }
+
+    public function error()
+    {
+        return 'db error';
+    }
+
+    private function filterRows(string $sql): array
+    {
+        $cols = '*';
+        if (preg_match('/SELECT\s+(.+)\s+FROM/i', $sql, $matches)) {
+            $cols = trim($matches[1]);
+        }
+
+        $conditionField = null;
+        $conditionValue = null;
+        if (preg_match('/WHERE\s+(\w+)\s*=\s*(\d+)/i', $sql, $matches)) {
+            $conditionField = $matches[1];
+            $conditionValue = (int)$matches[2];
+        }
+
+        $rows = array_filter($this->data, static function ($row) use ($conditionField, $conditionValue) {
+            if ($conditionField === null) {
+                return true;
+            }
+
+            return (int)$row[$conditionField] === $conditionValue;
+        });
+
+        if (stripos($sql, 'order by') !== false && preg_match('/ORDER BY\s+(\w+)/i', $sql, $orderMatch)) {
+            $field = $orderMatch[1];
+            usort($rows, static function ($a, $b) use ($field) {
+                return strcmp((string)$a[$field], (string)$b[$field]);
+            });
+        }
+
+        $selected = [];
+        foreach ($rows as $row) {
+            if ($cols === '*') {
+                $selected[] = $row;
+                continue;
+            }
+            $subset = [];
+            foreach (array_map('trim', explode(',', $cols)) as $col) {
+                $subset[$col] = $row[$col];
+            }
+            $selected[] = $subset;
+        }
+
+        return array_values($selected);
+    }
+}
+
+class XoopsTreeTest extends TestCase
+{
+    private FakeTreeDb $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['xoopsLogger'] = new XoopsLogger();
+        $this->db               = new FakeTreeDb();
+        $this->db->data         = [
+            ['catid' => 1, 'pid' => 0, 'title' => 'Root & Root'],
+            ['catid' => 2, 'pid' => 1, 'title' => 'Child'],
+            ['catid' => 3, 'pid' => 1, 'title' => 'Child Two'],
+            ['catid' => 4, 'pid' => 2, 'title' => 'Grandchild'],
+        ];
+        XoopsDatabaseFactory::$connection = $this->db;
+    }
+
+    private function createTree(): XoopsTree
+    {
+        return new XoopsTree('table', 'catid', 'pid');
+    }
+
+    public function testConstructorAssignsValuesAndLogsDeprecation(): void
+    {
+        $tree = $this->createTree();
+
+        $this->assertSame('table', $tree->table);
+        $this->assertSame('catid', $tree->id);
+        $this->assertSame('pid', $tree->pid);
+        $this->assertNotEmpty($GLOBALS['xoopsLogger']->deprecated);
+    }
+
+    public function testChildRetrievalHelpers(): void
+    {
+        $tree        = $this->createTree();
+        $firstChild  = $tree->getFirstChild(1, 'title');
+        $firstIds    = $tree->getFirstChildId(1);
+        $allChildIds = $tree->getAllChildId(1, 'title');
+
+        $this->assertSame(['catid' => 2, 'pid' => 1, 'title' => 'Child'], $firstChild[0]);
+        $this->assertSame([2, 3], $firstIds);
+        $this->assertSame([2, 4, 3], $allChildIds);
+    }
+
+    public function testParentRetrievalAndPaths(): void
+    {
+        $tree       = $this->createTree();
+        $parents    = $tree->getAllParentId(4, 'title');
+        $path       = $tree->getPathFromId(4, 'title');
+        $nicePath   = $tree->getNicePathFromId(4, 'title', 'http://example.com/view.php');
+        $idPath     = $tree->getIdPathFromId(4);
+
+        $this->assertSame([2, 1], $parents);
+        $this->assertSame('/Root &amp; Root/Child/Grandchild', $path);
+        $this->assertSame("<a href='http://example.com/view.php&amp;catid=4'>Grandchild</a>&nbsp;:&nbsp;<a href='http://example.com/view.php&amp;catid=2'>Child</a>&nbsp;:&nbsp;<a href='http://example.com/view.php&amp;catid=1'>Root &amp; Root</a>", $nicePath);
+        $this->assertSame('/1/2/4', $idPath);
+    }
+
+    public function testAllChildAndTreeArray(): void
+    {
+        $tree   = $this->createTree();
+        $all    = $tree->getAllChild(1, 'title');
+        $nested = $tree->getChildTreeArray(1, 'title');
+
+        $this->assertCount(3, $all);
+        $this->assertSame('Grandchild', $all[2]['title']);
+        $prefixes = array_column($nested, 'prefix', 'title');
+        $this->assertSame('.', $prefixes['Child']);
+        $this->assertSame('.', $prefixes['Child Two']);
+        $this->assertSame('..', $prefixes['Grandchild']);
+    }
+
+    public function testMakeMySelBoxOutputsOptions(): void
+    {
+        $tree = $this->createTree();
+
+        ob_start();
+        $tree->makeMySelBox('title', 'title', 3, 1, 'pick', "alert('x')");
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("<select name='pick' onchange='alert('x')'>", $output);
+        $this->assertStringContainsString("<option value='0'>----</option>", $output);
+        $this->assertStringContainsString("<option value='1'>Root &amp; Root</option>", $output);
+        $this->assertStringContainsString("<option value='3' selected>Child Two</option>", $output);
+    }
+
+    public function testQueryFailureThrowsException(): void
+    {
+        $tree             = $this->createTree();
+        $this->db->resultSet = false;
+
+        $this->expectException(\RuntimeException::class);
+        $tree->getFirstChild(1);
+    }
+}

--- a/tests/unit/XoopsUserTest.php
+++ b/tests/unit/XoopsUserTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/kernel/user.php';
+require_once XOOPS_ROOT_PATH . '/class/criteria.php';
+
+if (!class_exists('MyTextSanitizer')) {
+    class MyTextSanitizer
+    {
+        public static function getInstance()
+        {
+            return new self();
+        }
+
+        public function htmlSpecialChars($text)
+        {
+            return htmlspecialchars((string) $text, ENT_QUOTES);
+        }
+    }
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return $GLOBALS['user_test_handlers'][$name] ?? null;
+    }
+}
+
+class XoopsUserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['user_test_handlers'] = [];
+        $GLOBALS['xoopsLogger']        = null;
+        $GLOBALS['xoopsConfig']['anonymous'] = 'anonymous';
+
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'https://xoops.example.com');
+        }
+    }
+
+    public function testConstructorInitializesDefaults(): void
+    {
+        $user = new XoopsUser();
+
+        $this->assertNull($user->getVar('uid'));
+        $this->assertNull($user->getVar('uname'));
+        $this->assertNull($user->getVar('email'));
+        $this->assertSame(0, $user->getVar('user_viewemail'));
+        $this->assertSame(0, $user->getVar('attachsig'));
+        $this->assertSame(0, $user->getVar('rank'));
+        $this->assertSame(0, $user->getVar('level'));
+        $this->assertSame('0.0', $user->getVar('timezone_offset'));
+        $this->assertSame(0, $user->getVar('last_login'));
+        $this->assertSame(1, $user->getVar('uorder'));
+        $this->assertSame(XOOPS_NOTIFICATION_METHOD_PM, $user->getVar('notify_method'));
+        $this->assertSame(XOOPS_NOTIFICATION_MODE_SENDALWAYS, $user->getVar('notify_mode'));
+        $this->assertSame(1, $user->getVar('user_mailok'));
+    }
+
+    public function testConstructorAssignsArrayValues(): void
+    {
+        $user = new XoopsUser([
+            'uid'   => 42,
+            'uname' => 'tester',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->assertSame(42, $user->getVar('uid'));
+        $this->assertSame('tester', $user->getVar('uname'));
+        $this->assertSame('test@example.com', $user->getVar('email'));
+    }
+
+    public function testIsGuestAndGroups(): void
+    {
+        $user = new XoopsUser();
+        $user->setGroups([1, 2]);
+
+        $groups = $user->getGroups();
+        $this->assertSame([1, 2], $groups);
+        $this->assertSame($groups, $user->groups());
+        $this->assertFalse($user->isGuest());
+
+        $guest = new XoopsGuestUser();
+        $this->assertTrue($guest->isGuest());
+    }
+
+    public function testIsActiveAndOnline(): void
+    {
+        $onlineHandler = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['getCount'])
+            ->getMock();
+        $GLOBALS['user_test_handlers']['online'] = $onlineHandler;
+
+        $user = new XoopsUser();
+        $user->setVar('uid', 5);
+        $user->setVar('level', 0);
+
+        $onlineHandler->expects($this->once())
+            ->method('getCount')
+            ->with($this->callback(static function ($criteria) {
+                return $criteria instanceof Criteria && $criteria->column === 'online_uid' && $criteria->value === 5;
+            }))
+            ->willReturn(1);
+
+        $this->assertFalse($user->isActive());
+        $this->assertTrue($user->isOnline());
+
+        $user->setVar('level', 1);
+        $this->assertTrue($user->isActive());
+    }
+
+    public function testIsAdminUsesGroupPermissionHandler(): void
+    {
+        $groupPermHandler = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['checkRight'])
+            ->getMock();
+        $GLOBALS['user_test_handlers']['groupperm'] = $groupPermHandler;
+
+        $user = new XoopsUser();
+        $user->setGroups([3, 4]);
+
+        $groupPermHandler->expects($this->once())
+            ->method('checkRight')
+            ->with('module_admin', 1, [3, 4])
+            ->willReturn(true);
+
+        $this->assertTrue($user->isAdmin());
+    }
+
+    public function testGetUnameFromIdReturnsFormattedUserName(): void
+    {
+        $memberHandler                           = new class {
+            public function getUser($uid)
+            {
+                $user = new XoopsUser();
+                $user->setVar('uid', $uid);
+                $user->setVar('uname', 'user' . $uid);
+                $user->setVar('name', 'Real & Name');
+
+                return $user;
+            }
+        };
+        $GLOBALS['user_test_handlers']['member'] = $memberHandler;
+
+        $this->assertSame('Real &amp; Name', XoopsUser::getUnameFromId(7, 1, false));
+        $this->assertSame('user7', XoopsUser::getUnameFromId(7, 0, false));
+        $this->assertSame('<a href="https://xoops.example.com/userinfo.php?uid=7" title="user7">user7</a>', XoopsUser::getUnameFromId(7, 0, true));
+    }
+
+    public function testGetUnameFromIdFallsBackToAnonymous(): void
+    {
+        $GLOBALS['user_test_handlers']['member'] = new class {
+            public function getUser($uid)
+            {
+                return null;
+            }
+        };
+
+        $this->assertSame('anonymous', XoopsUser::getUnameFromId(0));
+    }
+
+    public function testIncrementPostDelegatesToMemberHandler(): void
+    {
+        $calls = [];
+        $GLOBALS['user_test_handlers']['member'] = new class($calls) {
+            public array $calls;
+
+            public function __construct(& $calls)
+            {
+                $this->calls = & $calls;
+            }
+
+            public function updateUserByField(...$args)
+            {
+                $this->calls[] = $args;
+
+                return 'updated';
+            }
+        };
+
+        $user = new XoopsUser();
+        $user->setVar('posts', 3);
+
+        $this->assertSame('updated', $user->incrementPost());
+        $this->assertSame([['posts', 4]], $GLOBALS['user_test_handlers']['member']->calls);
+    }
+}
+
+class XoopsUserHandlerTest extends TestCase
+{
+    public function testDeprecatedMethodsLogAndReturnFalse(): void
+    {
+        $db = $this->getMockBuilder(XoopsDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['prefix'])
+            ->getMock();
+        $db->method('prefix')->willReturn('pref_users');
+
+        $handler = new class($db) extends XoopsUserHandler {
+            public function __construct($db)
+            {
+                XoopsObjectHandler::__construct($db);
+                $this->table         = $db->prefix('users');
+                $this->keyName       = 'uid';
+                $this->className     = 'XoopsUser';
+                $this->identifierName = 'uname';
+            }
+        };
+
+        $logger = new class {
+            public array $deprecated = [];
+
+            public function addDeprecated($message)
+            {
+                $this->deprecated[] = $message;
+            }
+        };
+        $GLOBALS['xoopsLogger'] = $logger;
+
+        $this->assertFalse($handler->loginUser('name', 'pw', true));
+        $this->assertFalse($handler->updateUserByField('field', 'value', 1));
+        $this->assertCount(2, $logger->deprecated);
+        $this->assertStringContainsString('loginUser', $logger->deprecated[0]);
+        $this->assertStringContainsString('updateUserByField', $logger->deprecated[1]);
+    }
+}

--- a/tests/unit/XoopsUserUtilityTest.php
+++ b/tests/unit/XoopsUserUtilityTest.php
@@ -1,0 +1,473 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+
+if (!class_exists('MyTextSanitizer')) {
+    class MyTextSanitizer
+    {
+        public static function getInstance()
+        {
+            return new self();
+        }
+
+        public function htmlSpecialChars($text)
+        {
+            return htmlspecialchars((string) $text, ENT_QUOTES);
+        }
+    }
+}
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return $GLOBALS['userutility_handlers'][$name] ?? null;
+    }
+}
+
+if (!function_exists('xoops_getMailer')) {
+    function xoops_getMailer()
+    {
+        return $GLOBALS['userutility_mailer'];
+    }
+}
+
+if (!function_exists('xoops_loadLanguage')) {
+    function xoops_loadLanguage($name): void
+    {
+        $GLOBALS['userutility_languages'][] = $name;
+    }
+}
+
+if (!class_exists('\\Xmf\\IPAddress')) {
+    class XmfIPAddressStub
+    {
+        public static $request = '127.0.0.1';
+        private $value;
+
+        public function __construct($value)
+        {
+            $this->value = $value;
+        }
+
+        public static function fromRequest()
+        {
+            return new self(self::$request);
+        }
+
+        public function asReadable()
+        {
+            return $this->value === 'invalid' ? false : $this->value;
+        }
+
+        public function asBinary()
+        {
+            return $this->value;
+        }
+    }
+    class_alias(XmfIPAddressStub::class, 'Xmf\\IPAddress');
+    class_alias(XmfIPAddressStub::class, 'Xmf\\IPAddressStub');
+}
+
+require_once XOOPS_ROOT_PATH . '/class/userutility.php';
+
+if (!function_exists('checkEmail')) {
+    function checkEmail($email)
+    {
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+}
+
+if (!function_exists('xoops_trim')) {
+    function xoops_trim($text)
+    {
+        return trim((string) $text);
+    }
+}
+
+if (!class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static $connection;
+
+        public static function getDatabaseConnection()
+        {
+            return self::$connection;
+        }
+    }
+}
+
+if (!defined('XOOPS_CONF_USER')) {
+    define('XOOPS_CONF_USER', 2);
+}
+
+foreach ([
+             '_US_WELCOME_SUBJECT' => 'Welcome to %s',
+             '_US_INVALIDMAIL'     => 'Invalid email',
+             '_US_EMAILNOSPACES'   => 'Email has spaces',
+             '_US_INVALIDNICKNAME' => 'Invalid nickname',
+             '_US_NICKNAMETOOLONG' => 'Nickname too long (%s)',
+             '_US_NICKNAMETOOSHORT'=> 'Nickname too short (%s)',
+             '_US_NAMERESERVED'    => 'Name reserved',
+             '_US_NICKNAMETAKEN'   => 'Nickname taken',
+             '_US_EMAILTAKEN'      => 'Email taken',
+             '_US_ENTERPWD'        => 'Enter password',
+             '_US_PASSNOTSAME'     => 'Passwords not same',
+             '_US_PWDTOOSHORT'     => 'Password too short (%s)',
+             '_DB_QUERY_ERROR'     => 'Query error: %s',
+         ] as $const => $value) {
+    if (!defined($const)) {
+        define($const, $value);
+    }
+}
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'https://xoops.example.com');
+}
+
+class DummyResult
+{
+    private $rows;
+    private $index = 0;
+
+    public function __construct(array $rows)
+    {
+        $this->rows = array_values($rows);
+    }
+
+    public function fetchRow()
+    {
+        if (!isset($this->rows[$this->index])) {
+            return false;
+        }
+        $row = $this->rows[$this->index];
+        ++$this->index;
+
+        return array_values($row);
+    }
+
+    public function fetchArray()
+    {
+        if (!isset($this->rows[$this->index])) {
+            return false;
+        }
+        $row = $this->rows[$this->index];
+        ++$this->index;
+
+        return $row;
+    }
+}
+
+class DummyDatabase
+{
+    public array $queries = [];
+    private array $results;
+
+    public function __construct(array $results)
+    {
+        $this->results = $results;
+    }
+
+    public function prefix($table)
+    {
+        return 'prefix_' . $table;
+    }
+
+    public function query($sql)
+    {
+        $this->queries[] = $sql;
+
+        return array_shift($this->results);
+    }
+
+    public function isResultSet($result)
+    {
+        return $result instanceof DummyResult;
+    }
+
+    public function fetchRow($result)
+    {
+        return $result->fetchRow();
+    }
+
+    public function fetchArray($result)
+    {
+        return $result->fetchArray();
+    }
+
+    public function quote($value)
+    {
+        return "'" . $value . "'";
+    }
+
+    public function error()
+    {
+        return 'db error';
+    }
+}
+
+class DummyUser
+{
+    private $vars;
+
+    public function __construct(array $vars)
+    {
+        $this->vars = $vars;
+    }
+
+    public function getVar($name, $format = null)
+    {
+        return $this->vars[$name] ?? null;
+    }
+}
+
+class DummyMailer
+{
+    public array $methods = [];
+    public bool $sendResult = true;
+
+    public function useMail(): void
+    {
+        $this->methods[] = 'mail';
+    }
+
+    public function usePM(): void
+    {
+        $this->methods[] = 'pm';
+    }
+
+    public function setTemplate($tpl): void
+    {
+        $this->methods[] = ['template', $tpl];
+    }
+
+    public function setSubject($subject): void
+    {
+        $this->methods[] = ['subject', $subject];
+    }
+
+    public function setToUsers($user): void
+    {
+        $this->methods[] = ['to', $user];
+    }
+
+    public function assign($key, $value): void
+    {
+        $this->methods[] = ['assign', $key, $value];
+    }
+
+    public function send()
+    {
+        return $this->sendResult;
+    }
+}
+
+class XoopsUserUtilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['userutility_handlers']  = [];
+        $GLOBALS['userutility_mailer']    = null;
+        $GLOBALS['userutility_languages'] = [];
+        $GLOBALS['xoopsConfigUser']       = [];
+        $GLOBALS['xoopsConfig']           = ['sitename' => 'Test Site'];
+        $GLOBALS['xoopsConfig']['anonymous'] = 'anonymous';
+        $GLOBALS['xoopsUser']             = null;
+    }
+
+    public function testSendWelcomeReturnsEarlyWhenWelcomeTypeDisabled(): void
+    {
+        $configHandler = new class {
+            public function getConfigsByCat($cat)
+            {
+                return ['welcome_type' => 0];
+            }
+        };
+        $GLOBALS['userutility_handlers']['config'] = $configHandler;
+        $mailer                                    = new DummyMailer();
+        $GLOBALS['userutility_mailer']             = $mailer;
+
+        $result = \XoopsUserUtility::sendWelcome(new DummyUser([]));
+
+        $this->assertTrue($result);
+        $this->assertSame([], $mailer->methods);
+    }
+
+    public function testSendWelcomeLoadsUserAndSendsMailAndPm(): void
+    {
+        $GLOBALS['xoopsConfigUser'] = [
+            'welcome_type'   => 3,
+            'reg_dispdsclmr' => 1,
+            'reg_disclaimer' => 'Terms go here',
+        ];
+        $GLOBALS['xoopsConfig']['sitename'] = 'My Site';
+
+        $memberHandler = new class {
+            public function getUser($uid)
+            {
+                return new DummyUser(['uid' => $uid]);
+            }
+        };
+        $GLOBALS['userutility_handlers']['member'] = $memberHandler;
+
+        $mailer                        = new DummyMailer();
+        $GLOBALS['userutility_mailer'] = $mailer;
+
+        $result = \XoopsUserUtility::sendWelcome(12);
+
+        $this->assertTrue($result);
+        $this->assertEquals(
+            [
+                'mail',
+                'pm',
+                ['template', 'welcome.tpl'],
+                ['subject', 'Welcome to My Site'],
+                ['to', new DummyUser(['uid' => 12])],
+                ['assign', 'TERMSOFUSE', 'Terms go here'],
+            ],
+            $mailer->methods
+        );
+        $this->assertSame(['user'], $GLOBALS['userutility_languages']);
+    }
+
+    public function testSendWelcomeReturnsFalseWhenUserMissing(): void
+    {
+        $GLOBALS['xoopsConfigUser'] = ['welcome_type' => 1];
+        $GLOBALS['userutility_handlers']['member'] = new class {
+            public function getUser($uid)
+            {
+                return null;
+            }
+        };
+
+        $mailer                        = new DummyMailer();
+        $GLOBALS['userutility_mailer'] = $mailer;
+
+        $this->assertFalse(\XoopsUserUtility::sendWelcome(99));
+        $this->assertSame([], $mailer->methods);
+    }
+
+    public function testValidateReturnsErrorsForInvalidEmailAndNickname(): void
+    {
+        $GLOBALS['xoopsConfigUser'] = [
+            'bad_emails'       => [],
+            'uname_test_level' => 0,
+            'maxuname'         => 5,
+            'minuname'         => 3,
+            'bad_unames'       => [],
+            'minpass'          => 3,
+        ];
+        XoopsDatabaseFactory::$connection = new DummyDatabase([
+            new DummyResult([[0], [0]]),
+            new DummyResult([[0], [0]]),
+        ]);
+
+        $errors = \XoopsUserUtility::validate('bad name', 'invalid email');
+
+        $this->assertStringContainsString('Invalid email', $errors);
+        $this->assertStringContainsString('Email has spaces', $errors);
+        $this->assertStringContainsString('Invalid nickname', $errors);
+    }
+
+    public function testValidateChecksPasswordLength(): void
+    {
+        $GLOBALS['xoopsConfigUser'] = [
+            'bad_emails'       => [],
+            'uname_test_level' => 0,
+            'maxuname'         => 10,
+            'minuname'         => 3,
+            'bad_unames'       => [],
+            'minpass'          => 5,
+        ];
+        XoopsDatabaseFactory::$connection = new DummyDatabase([
+            new DummyResult([[0]]),
+            new DummyResult([[0]]),
+        ]);
+
+        $errors = \XoopsUserUtility::validate('good', 'good@example.com', '123', '123');
+
+        $this->assertStringContainsString('Password too short (5)', $errors);
+    }
+
+    public function testValidateThrowsWhenQueryFails(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Query error');
+
+        $GLOBALS['xoopsConfigUser'] = [
+            'bad_emails'       => [],
+            'uname_test_level' => 0,
+            'maxuname'         => 10,
+            'minuname'         => 3,
+            'bad_unames'       => [],
+            'minpass'          => 3,
+        ];
+        XoopsDatabaseFactory::$connection = new DummyDatabase([
+            false,
+        ]);
+
+        \XoopsUserUtility::validate('good', 'good@example.com');
+    }
+
+    public function testGetIPPrefersProxyAddress(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1';
+        Xmf\IPAddressStub::$request      = '192.168.0.1';
+
+        $ip = \XoopsUserUtility::getIP();
+
+        $this->assertSame(ip2long('10.0.0.1'), $ip);
+    }
+
+    public function testGetIPFallsBackWhenProxyInvalid(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = 'invalid';
+        Xmf\IPAddressStub::$request      = '192.168.0.5';
+
+        $ip = \XoopsUserUtility::getIP(true);
+
+        $this->assertSame('192.168.0.5', $ip);
+    }
+
+    public function testGetUnameFromIdsLoadsAndFormatsUsers(): void
+    {
+        $rows = [
+            ['uid' => 1, 'uname' => 'user1', 'name' => 'Real <One>'],
+            ['uid' => 2, 'uname' => 'user2', 'name' => ''],
+        ];
+        XoopsDatabaseFactory::$connection = new DummyDatabase([
+            new DummyResult($rows),
+        ]);
+
+        $users = \XoopsUserUtility::getUnameFromIds([1, 2], true, true);
+
+        $this->assertSame(
+            [
+                1 => '<a href="https://xoops.example.com/userinfo.php?uid=1" title="Real &lt;One&gt;">Real &lt;One&gt;</a>',
+                2 => '<a href="https://xoops.example.com/userinfo.php?uid=2" title="user2">user2</a>',
+            ],
+            $users
+        );
+    }
+
+    public function testGetUnameFromIdUsesMemberHandlerOrAnonymous(): void
+    {
+        $GLOBALS['userutility_handlers']['member'] = new class {
+            public function getUser($uid)
+            {
+                if ($uid === 7) {
+                    return new DummyUser(['uid' => 7, 'uname' => 'name7', 'name' => 'Real']);
+                }
+
+                return null;
+            }
+        };
+
+        $this->assertSame('Real', \XoopsUserUtility::getUnameFromId(7, true));
+        $this->assertSame('<a href="https://xoops.example.com/userinfo.php?uid=7" title="name7">name7</a>', \XoopsUserUtility::getUnameFromId(7, false, true));
+        $this->assertSame('anonymous', \XoopsUserUtility::getUnameFromId(0));
+    }
+}

--- a/tests/unit/XoopsUtilityTest.php
+++ b/tests/unit/XoopsUtilityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/utility/xoopsutility.php';
+
+class UtilityMethodInvoker
+{
+    public static function double($value)
+    {
+        return $value * 2;
+    }
+}
+
+class XoopsUtilityTest extends TestCase
+{
+    public function testRecursiveAppliesHandlersAcrossArray(): void
+    {
+        $handlers = ['strtoupper', 'strtolower'];
+        $data = ['Mixed', 'VALUE'];
+
+        $result = XoopsUtility::recursive($handlers, $data);
+
+        $this->assertSame(['MIXED', 'value'], $result);
+    }
+
+    public function testRecursiveInvokesNamedFunction(): void
+    {
+        $this->assertSame('HELLO', XoopsUtility::recursive('strtoupper', 'hello'));
+    }
+
+    public function testRecursiveReturnsInputWhenFunctionMissing(): void
+    {
+        $this->assertSame('unchanged', XoopsUtility::recursive('not_a_function', 'unchanged'));
+    }
+
+    public function testRecursiveInvokesClassMethod(): void
+    {
+        $this->assertSame(10, XoopsUtility::recursive([UtilityMethodInvoker::class, 'double'], 5));
+    }
+
+    public function testRecursiveReturnsInputWhenHandlerUnsupported(): void
+    {
+        $this->assertSame('data', XoopsUtility::recursive(new stdClass(), 'data'));
+    }
+}

--- a/tests/unit/XoopsXmlRpcTest.php
+++ b/tests/unit/XoopsXmlRpcTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpctag.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpcparser.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rpc/xmlrpcapi.php';
+require_once XOOPS_ROOT_PATH . '/class/xml/rss/xmlrss2parser.php';
+
+if (!function_exists('xoops_getHandler')) {
+    function xoops_getHandler($name)
+    {
+        return $GLOBALS['xml_rpc_test_handlers'][$name] ?? null;
+    }
+}
+
+class XoopsXmlRpcTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['xml_rpc_test_handlers'] = [];
+    }
+
+    public function testTagEncodingAndRendering(): void
+    {
+        $fault    = new XoopsXmlRpcFault(104, ' details');
+        $int      = new XoopsXmlRpcInt('5');
+        $double   = new XoopsXmlRpcDouble(1.5);
+        $boolean  = new XoopsXmlRpcBoolean(true);
+        $string   = new XoopsXmlRpcString('<test>&value');
+        $datetime = new XoopsXmlRpcDatetime('2002-01-01 00:00:00');
+        $base64   = new XoopsXmlRpcBase64('abc');
+
+        $array = new XoopsXmlRpcArray();
+        $array->add($int);
+        $array->add($string);
+
+        $struct = new XoopsXmlRpcStruct();
+        $struct->add('a', $double);
+        $struct->add('b', $boolean);
+
+        $response = new XoopsXmlRpcResponse();
+        $response->add($int);
+        $response->add($string);
+
+        $faultResponse = new XoopsXmlRpcResponse();
+        $faultResponse->add($fault);
+        $faultResponse->add($double);
+
+        $request = new XoopsXmlRpcRequest('sample.method');
+        $request->add($array);
+        $request->add($struct);
+
+        $this->assertSame('<value><int>5</int></value>', $int->render());
+        $this->assertSame('<value><double>1.5</double></value>', $double->render());
+        $this->assertSame('<value><boolean>1</boolean></value>', $boolean->render());
+        $this->assertSame('<value><string>&lt;test&gt;&amp;value</string></value>', $string->render());
+        $this->assertSame('<value><dateTime.iso8601>20020101T00:00:00</dateTime.iso8601></value>', $datetime->render());
+        $this->assertSame('<value><base64>YWJj</base64></value>', $base64->render());
+        $this->assertStringContainsString('<array><data><value><int>5</int></value><value><string>&lt;test&gt;&amp;value</string></value>', $array->render());
+        $this->assertStringContainsString('<member><name>a</name><value><double>1.5</double></value>', $struct->render());
+
+        $this->assertSame('<?xml version="1.0"?><methodResponse><params><param><value><int>5</int></value><value><string>&lt;test&gt;&amp;value</string></value></param></params></methodResponse>', $response->render());
+        $this->assertSame('<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value>104</value></member><member><name>faultString</name><value>User authentication failed\n details</value></member></struct></value></fault></methodResponse>', $faultResponse->render());
+        $this->assertSame('<?xml version="1.0"?><methodCall><methodName>sample.method</methodName><params><param><value><array><data><value><int>5</int></value><value><string>&lt;test&gt;&amp;value</string></value></data></array></value></param><param><value><struct><member><name>a</name><value><double>1.5</double></value></member><member><name>b</name><value><boolean>1</boolean></value></member></struct></value></param></params></methodCall>', $request->render());
+    }
+
+    public function testApiHelpers(): void
+    {
+        $params   = [];
+        $response = new XoopsXmlRpcResponse();
+        $module   = new class {
+            public function getVar($name)
+            {
+                return $name === 'mid' ? 12 : null;
+            }
+        };
+        $api      = new XoopsXmlRpcApi($params, $response, $module);
+
+        $api->_setXoopsTagMap('title', 'blogTitle');
+        $this->assertSame('blogTitle', $api->_getXoopsTagMap('title'));
+        $this->assertSame('unknown', $api->_getXoopsTagMap('unknown'));
+
+        $text = '<content>keep</content><remove>gone</remove>';
+        $this->assertSame('gone', $api->_getTagCdata($text, 'remove'));
+        $this->assertStringNotContainsString('remove', $text);
+
+        $api->_setUser('notobject');
+        $this->assertNull($api->user ?? null);
+
+        $user = new class {
+            public $admin = false;
+            public function isAdmin($mid)
+            {
+                return $this->admin && $mid === 12;
+            }
+        };
+        $api->_setUser($user);
+        $this->assertFalse($api->_checkAdmin());
+        $user->admin = true;
+        $this->assertTrue($api->_checkAdmin());
+    }
+
+    public function testCheckUserFlow(): void
+    {
+        $params   = [];
+        $response = new XoopsXmlRpcResponse();
+        $module   = new class {
+            public function getVar($name)
+            {
+                return 99;
+            }
+        };
+        $api      = new XoopsXmlRpcApi($params, $response, $module);
+
+        $member = new class {
+            public $loginUserArgs;
+            public $user;
+            public function loginUser($u, $p)
+            {
+                $this->loginUserArgs = [$u, $p];
+                return $this->user;
+            }
+        };
+        $groupPerm = new class {
+            public $allowed = false;
+            public function checkRight($name, $mid, $groups)
+            {
+                return $this->allowed;
+            }
+        };
+        $GLOBALS['xml_rpc_test_handlers']['member']   = $member;
+        $GLOBALS['xml_rpc_test_handlers']['groupperm'] = $groupPerm;
+
+        $this->assertFalse($api->_checkUser('bob', 'pw'));
+        $member->user  = new class {
+            public function getGroups()
+            {
+                return [1, 2];
+            }
+        };
+        $this->assertFalse($api->_checkUser('bob', 'pw'));
+        $this->assertSame(['bob', 'pw'], $member->loginUserArgs);
+
+        $groupPerm->allowed = true;
+        $this->assertTrue($api->_checkUser('bob', 'pw'));
+        $this->assertNotNull($api->user);
+    }
+
+    public function testParserExtractsValues(): void
+    {
+        $xml = '<methodCall><methodName>demo.method</methodName><params>'
+            . '<param><value><int>5</int></value></param>'
+            . '<param><value><string>text</string></value></param>'
+            . '<param><value><boolean>1</boolean></value></param>'
+            . '<param><value><dateTime.iso8601>20020101T00:00:00</dateTime.iso8601></value></param>'
+            . '<param><value><array><data><value><string>a</string></value><value><int>3</int></value></data></array></value></param>'
+            . '<param><value><struct><member><name>key</name><value><string>value</string></value></member></struct></value></param>'
+            . '</params></methodCall>';
+
+        $parser = new XoopsXmlRpcParser($xml);
+        $parser->parse();
+
+        $this->assertSame('demo.method', $parser->getMethodName());
+        $params = $parser->getParam();
+        $this->assertSame(5, $params[0]);
+        $this->assertSame('text', $params[1]);
+        $this->assertSame(1, $params[2]);
+        $this->assertSame(gmmktime(0, 0, 0, 1, 1, 2002), $params[3]);
+        $this->assertSame(['a', 3], $params[4]);
+        $this->assertSame(['key' => 'value'], $params[5]);
+    }
+
+    public function testRss2ParserCollections(): void
+    {
+        $parser = new XoopsXmlRss2Parser('<rss></rss>');
+        $value  = 'example';
+        $parser->setChannelData('title', $value);
+        $parser->setChannelData('title', $value);
+        $this->assertSame('exampleexample', $parser->getChannelData('title'));
+
+        $parser->setImageData('url', $value);
+        $this->assertSame('example', $parser->getImageData('url'));
+
+        $item = ['id' => 1];
+        $parser->setItems($item);
+        $this->assertSame([['id' => 1]], $parser->getItems());
+
+        $parser->setTempArr('cat', $value);
+        $parser->setTempArr('cat', $value, ',');
+        $this->assertSame(['cat' => 'example,example'], $parser->getTempArr());
+        $parser->resetTempArr();
+        $this->assertSame([], $parser->getTempArr());
+    }
+}

--- a/tests/unit/XoopsZipDownloaderTest.php
+++ b/tests/unit/XoopsZipDownloaderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_TU_ROOT_PATH . '/class/zipdownloader.php';
+
+class ZipfileStub
+{
+    public array $files = [];
+
+    public function addFile($data, $filename, $time): void
+    {
+        $this->files[] = ['data' => $data, 'name' => $filename, 'time' => $time];
+    }
+
+    public function file()
+    {
+        return 'zip:' . count($this->files);
+    }
+}
+
+class XoopsZipDownloaderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (function_exists('header_remove')) {
+            header_remove();
+        }
+    }
+
+    public function testConstructorSetsDefaults(): void
+    {
+        $downloader = new XoopsZipDownloader();
+
+        $this->assertInstanceOf(Zipfile::class, $downloader->archiver);
+        $this->assertSame('.zip', $downloader->ext);
+        $this->assertSame('application/x-zip', $downloader->mimetype);
+    }
+
+    public function testAddFileReadsDataAndUsesFilepath(): void
+    {
+        $downloader           = new XoopsZipDownloader();
+        $downloader->archiver = new ZipfileStub();
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'zipfile');
+        file_put_contents($tempFile, 'file-data');
+
+        $downloader->addFile($tempFile);
+
+        $this->assertSame('file-data', $downloader->archiver->files[0]['data']);
+        $this->assertSame($tempFile, $downloader->archiver->files[0]['name']);
+        $this->assertSame(filemtime($tempFile), $downloader->archiver->files[0]['time']);
+
+        unlink($tempFile);
+    }
+
+    public function testAddFileUsesNewFilenameAndTimestamp(): void
+    {
+        $downloader           = new XoopsZipDownloader();
+        $downloader->archiver = new ZipfileStub();
+
+        $original = tempnam(sys_get_temp_dir(), 'zipfile');
+        file_put_contents($original, 'original');
+
+        $renameTarget = tempnam(sys_get_temp_dir(), 'ziprename');
+        touch($renameTarget, time() - 10);
+
+        $downloader->addFile($original, $renameTarget);
+
+        $this->assertSame('original', $downloader->archiver->files[0]['data']);
+        $this->assertSame($renameTarget, $downloader->archiver->files[0]['name']);
+        $this->assertSame(filemtime($renameTarget), $downloader->archiver->files[0]['time']);
+
+        unlink($original);
+        unlink($renameTarget);
+    }
+
+    public function testAddBinaryFileReadsBinaryData(): void
+    {
+        $downloader           = new XoopsZipDownloader();
+        $downloader->archiver = new ZipfileStub();
+
+        $binaryFile = tempnam(sys_get_temp_dir(), 'zipbinary');
+        file_put_contents($binaryFile, "\x00\x01\x02");
+
+        $downloader->addBinaryFile($binaryFile);
+
+        $this->assertSame("\x00\x01\x02", $downloader->archiver->files[0]['data']);
+        $this->assertSame($binaryFile, $downloader->archiver->files[0]['name']);
+
+        unlink($binaryFile);
+    }
+
+    public function testAddFileDataPassesValues(): void
+    {
+        $downloader           = new XoopsZipDownloader();
+        $downloader->archiver = new ZipfileStub();
+
+        $downloader->addFileData('data', 'filename.txt', 123);
+
+        $this->assertSame('data', $downloader->archiver->files[0]['data']);
+        $this->assertSame('filename.txt', $downloader->archiver->files[0]['name']);
+        $this->assertSame(123, $downloader->archiver->files[0]['time']);
+    }
+
+    public function testAddBinaryFileDataDelegates(): void
+    {
+        $downloader           = new XoopsZipDownloader();
+        $downloader->archiver = new ZipfileStub();
+
+        $downloader->addBinaryFileData('binary-data', 'binary.bin', 456);
+
+        $this->assertSame('binary-data', $downloader->archiver->files[0]['data']);
+        $this->assertSame('binary.bin', $downloader->archiver->files[0]['name']);
+        $this->assertSame(456, $downloader->archiver->files[0]['time']);
+    }
+
+    public function testDownloadOutputsArchiveAndHeaders(): void
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'UnitTestBrowser/1.0';
+        $downloader                 = new XoopsZipDownloader();
+        $downloader->archiver       = new ZipfileStub();
+        $downloader->archiver->addFile('example', 'example.txt', time());
+
+        ob_start();
+        $downloader->download('archive', false);
+        $output = ob_get_clean();
+
+        $this->assertSame('zip:1', $output);
+        $headers = headers_list();
+        $this->assertContains('Content-Type: application/x-zip', $headers);
+        $this->assertContains('Content-Disposition: attachment; filename="archive.zip"', $headers);
+        $this->assertContains('Pragma: no-cache', $headers);
+    }
+}

--- a/tests/unit/ZipfileTest.php
+++ b/tests/unit/ZipfileTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/init_new.php';
+require_once XOOPS_ROOT_PATH . '/class/class.zipfile.php';
+
+class ZipfileTest extends TestCase
+{
+    public function testUnix2DosTimeClampsTo1980(): void
+    {
+        $zipfile = new Zipfile();
+
+        $result = $zipfile->unix2DosTime(mktime(0, 0, 0, 12, 31, 1970));
+
+        $this->assertSame(2162688, $result);
+    }
+
+    public function testUnix2DosTimeCalculatesExpectedBits(): void
+    {
+        $zipfile = new Zipfile();
+        $timestamp = mktime(0, 0, 0, 5, 4, 2024);
+
+        $expected = ((2024 - 1980) << 25) | (5 << 21) | (4 << 16);
+        $this->assertSame($expected, $zipfile->unix2DosTime($timestamp));
+    }
+
+    public function testAddFileStoresForwardSlashNamesAndOffsets(): void
+    {
+        $zipfile = new Zipfile();
+        $zipfile->addFile('abc', 'dir\\file.txt', 0);
+
+        $this->assertCount(1, $zipfile->datasec);
+        $this->assertCount(1, $zipfile->ctrl_dir);
+        $this->assertSame(strlen($zipfile->datasec[0]), $zipfile->old_offset);
+        $this->assertStringContainsString('dir/file.txt', $zipfile->datasec[0]);
+        $this->assertStringContainsString('dir/file.txt', $zipfile->ctrl_dir[0]);
+    }
+
+    public function testFileOutputIncludesDirectoryTrailer(): void
+    {
+        $zipfile = new Zipfile();
+        $zipfile->addFile('first', 'first.txt', 0);
+        $zipfile->addFile('second', 'second.txt', 0);
+
+        $data = implode('', $zipfile->datasec);
+        $dir  = implode('', $zipfile->ctrl_dir);
+
+        $output = $zipfile->file();
+        $tail   = substr($output, -22);
+
+        $expectedTail = "\x50\x4b\x05\x06\x00\x00\x00\x00"
+            . pack('v', 2)
+            . pack('v', 2)
+            . pack('V', strlen($dir))
+            . pack('V', strlen($data))
+            . "\x00\x00";
+
+        $this->assertSame($expectedTail, $tail);
+        $this->assertSame(strlen($data), $zipfile->old_offset);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit coverage for Zipfile DOS time conversion and path normalization
- verify archive trailer composition and offsets when adding files

## Testing
- php -l tests/unit/ZipfileTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236d4fdf4483239f7e95397238370b)