### PR TITLE
Fix SQL injection in maintenance dump and add CSRF to profile visibility

### DIFF
--- a/htdocs/modules/profile/admin/visibility.php
+++ b/htdocs/modules/profile/admin/visibility.php
@@ -27,7 +27,7 @@ $_SERVER['REQUEST_URI'] = 'admin/permissions.php';
 
 xoops_cp_header();
 
-$op = Request::getCmd('op', 'visibility', 'POST');
+$op = Request::getCmd('op', 'visibility');
 
 $visibility_handler = xoops_getModuleHandler('visibility');
 $field_handler      = xoops_getModuleHandler('field');
@@ -46,7 +46,7 @@ if (Request::hasVar('submit', 'POST')) {
 }
 if ($op === 'del') {
     if ('POST' !== Request::getMethod()) {
-        redirect_header('visibility.php', 3, 'Access denied');
+        redirect_header('visibility.php', 3, _NOPERM);
     }
     if (!$GLOBALS['xoopsSecurity']->check()) {
         redirect_header('visibility.php', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));

--- a/htdocs/modules/profile/admin/visibility.php
+++ b/htdocs/modules/profile/admin/visibility.php
@@ -27,13 +27,16 @@ $_SERVER['REQUEST_URI'] = 'admin/permissions.php';
 
 xoops_cp_header();
 
-$op = Request::hasVar('op', 'POST') ? Request::getCmd('op', 'visibility', 'POST') : Request::getCmd('op', 'visibility', 'GET');
+$op = Request::getCmd('op', 'visibility', 'POST');
 
 $visibility_handler = xoops_getModuleHandler('visibility');
 $field_handler      = xoops_getModuleHandler('field');
 $fields             = $field_handler->getList();
 
 if (Request::hasVar('submit', 'POST')) {
+    if (!$GLOBALS['xoopsSecurity']->check()) {
+        redirect_header('visibility.php', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+    }
     $visibility = $visibility_handler->create();
     $visibility->setVar('field_id', Request::getInt('field_id', 0, 'POST'));
     $visibility->setVar('user_group', Request::getInt('ug', 0, 'POST'));
@@ -42,9 +45,15 @@ if (Request::hasVar('submit', 'POST')) {
     redirect_header('visibility.php', 2, sprintf(_PROFILE_AM_SAVEDSUCCESS, _PROFILE_AM_PROF_VISIBLE));
 }
 if ($op === 'del') {
-    $criteria = new CriteriaCompo(new Criteria('field_id', Request::getInt('field_id', 0, 'GET')));
-    $criteria->add(new Criteria('user_group', Request::getInt('ug', 0, 'GET')));
-    $criteria->add(new Criteria('profile_group', Request::getInt('pg', 0, 'GET')));
+    if ('POST' !== Request::getMethod()) {
+        redirect_header('visibility.php', 3, 'Access denied');
+    }
+    if (!$GLOBALS['xoopsSecurity']->check()) {
+        redirect_header('visibility.php', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+    }
+    $criteria = new CriteriaCompo(new Criteria('field_id', Request::getInt('field_id', 0, 'POST')));
+    $criteria->add(new Criteria('user_group', Request::getInt('ug', 0, 'POST')));
+    $criteria->add(new Criteria('profile_group', Request::getInt('pg', 0, 'POST')));
     $visibility_handler->deleteAll($criteria, true);
     redirect_header('visibility.php', 2, sprintf(_PROFILE_AM_DELETEDSUCCESS, _PROFILE_AM_PROF_VISIBLE));
 }

--- a/htdocs/modules/profile/templates/profile_admin_visibility.tpl
+++ b/htdocs/modules/profile/templates/profile_admin_visibility.tpl
@@ -20,10 +20,16 @@
                             <li>
                                 <{$smarty.const._PROFILE_AM_FIELDVISIBLEFOR}> <{$groups.$user_gid}>
                                 <{$smarty.const._PROFILE_AM_FIELDVISIBLEON}> <{$groups.$profile_gid}>
-                                <a href="visibility.php?op=del&amp;field_id=<{$field_id}>&amp;ug=<{$user_gid}>&amp;pg=<{$profile_gid}>"
-                                   title="<{$smarty.const._DELETE}>">
-                                    <img src="<{$xoops_url}>/modules/profile/assets/images/no.png" alt="<{$smarty.const._DELETE}>"/>
-                                </a>
+                                <form method="post" action="visibility.php" style="display:inline;">
+                                    <input type="hidden" name="op" value="del">
+                                    <input type="hidden" name="field_id" value="<{$field_id}>">
+                                    <input type="hidden" name="ug" value="<{$user_gid}>">
+                                    <input type="hidden" name="pg" value="<{$profile_gid}>">
+                                    <{securityToken}>
+                                    <button type="submit" title="<{$smarty.const._DELETE}>" style="border:none;background:none;cursor:pointer;padding:0;">
+                                        <img src="<{$xoops_url}>/modules/profile/assets/images/no.png" alt="<{$smarty.const._DELETE}>"/>
+                                    </button>
+                                </form>
                             </li>
                         <{/foreach}>
                     </ul>

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -60,6 +60,10 @@ class SystemMaintenance
      */
     private function isValidTable($table)
     {
+        if (!is_string($table)) {
+            return false;
+        }
+
         if ($this->validTables === null) {
             $this->validTables = $this->displayTables(true);
         }

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -81,6 +81,10 @@ class SystemMaintenance
      */
     private function isValidPrefixedTable($prefixedTable)
     {
+        if (!is_string($prefixedTable)) {
+            return false;
+        }
+
         $prefixLen = strlen($this->prefix);
 
         // Verify the table actually starts with the expected prefix

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -76,8 +76,20 @@ class SystemMaintenance
      */
     private function isValidPrefixedTable($prefixedTable)
     {
+        $prefixLen = strlen($this->prefix);
+
+        // Verify the table actually starts with the expected prefix
+        if (strncmp($prefixedTable, $this->prefix, $prefixLen) !== 0) {
+            return false;
+        }
+
         // Strip the prefix to get the unprefixed name
-        $unprefixed = substr($prefixedTable, strlen($this->prefix));
+        $unprefixed = substr($prefixedTable, $prefixLen);
+
+        // Ensure the unprefixed remainder is non-empty
+        if ($unprefixed === '' || $unprefixed === false) {
+            return false;
+        }
 
         return $this->isValidTable($unprefixed);
     }

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -31,6 +31,13 @@ class SystemMaintenance
     public $prefix;
 
     /**
+     * Cached list of valid table names (without prefix).
+     *
+     * @var array|null
+     */
+    private $validTables = null;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -39,6 +46,40 @@ class SystemMaintenance
         $db           = XoopsDatabaseFactory::getDatabaseConnection();
         $this->db     = $db;
         $this->prefix = $this->db->prefix . '_';
+    }
+
+    /**
+     * Validate that a table name (without prefix) exists in the database.
+     *
+     * Prevents SQL injection by checking the user-supplied table name
+     * against the actual list of tables returned by SHOW TABLES.
+     *
+     * @param string $table Table name without prefix
+     *
+     * @return bool True if the table exists in the database
+     */
+    private function isValidTable($table)
+    {
+        if ($this->validTables === null) {
+            $this->validTables = $this->displayTables(true);
+        }
+
+        return isset($this->validTables[$table]);
+    }
+
+    /**
+     * Validate that a prefixed table name exists in the database.
+     *
+     * @param string $prefixedTable Full table name including prefix
+     *
+     * @return bool True if the table exists in the database
+     */
+    private function isValidPrefixedTable($prefixedTable)
+    {
+        // Strip the prefix to get the unprefixed name
+        $unprefixed = substr($prefixedTable, strlen($this->prefix));
+
+        return $this->isValidTable($unprefixed);
     }
 
     /**
@@ -195,6 +236,9 @@ class SystemMaintenance
         $class       = 'odd';
         $tablesCount = count($tables);
         for ($i = 0; $i < $tablesCount; ++$i) {
+            if (!$this->isValidTable($tables[$i])) {
+                continue;
+            }
             $ret .= '<tr class="' . $class . '"><td align="center">' . $this->prefix . $tables[$i] . '</td>';
             for ($j = 0; $j < 4; ++$j) {
                 if ($tab1[$j] == 1) {
@@ -258,6 +302,9 @@ class SystemMaintenance
         $class       = 'odd';
         $tablesCount = count($tables);
         for ($i = 0; $i < $tablesCount; ++$i) {
+            if (!$this->isValidTable($tables[$i])) {
+                continue;
+            }
             //structure
             $ret = $this->dump_table_structure($ret, $this->prefix . $tables[$i], $drop, $class);
             //data
@@ -295,6 +342,9 @@ class SystemMaintenance
             $modtables = $module->getInfo('tables');
             if ($modtables !== false && \is_array($modtables)) {
                 foreach ($modtables as $table) {
+                    if (!$this->isValidTable($table)) {
+                        continue;
+                    }
                     //structure
                     $ret = $this->dump_table_structure($ret, $this->prefix . $table, $drop, $class);
                     //data
@@ -322,6 +372,9 @@ class SystemMaintenance
      */
     public function dump_table_structure($ret, $table, $drop, $class)
     {
+        if (!$this->isValidPrefixedTable($table)) {
+            return $ret;
+        }
         $verif  = false;
         $sql = 'SHOW create table `' . $table . '`;';
         $result = $this->db->query($sql);
@@ -355,6 +408,9 @@ class SystemMaintenance
      */
     public function dump_table_datas($ret, $table)
     {
+        if (!$this->isValidPrefixedTable($table)) {
+            return $ret;
+        }
         $count  = 0;
         $sql = 'SELECT * FROM ' . $table . ';';
         $result = $this->db->query($sql);

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -65,7 +65,8 @@ class SystemMaintenance
         }
 
         if ($this->validTables === null) {
-            $this->validTables = $this->displayTables(true);
+            $tables = $this->displayTables(true);
+            $this->validTables = is_array($tables) ? $tables : [];
         }
 
         return isset($this->validTables[$table]);

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -60,6 +60,9 @@ class SystemMaintenance
      */
     private function isValidTable($table)
     {
+        // Defense-in-depth: callers currently always pass strings, but this is a
+        // security-critical path validating user-influenced input.
+        // @scrutinizer ignore-type
         if (!is_string($table)) {
             return false;
         }
@@ -81,6 +84,9 @@ class SystemMaintenance
      */
     private function isValidPrefixedTable($prefixedTable)
     {
+        // Defense-in-depth: callers currently always pass strings, but this is a
+        // security-critical path validating user-influenced input.
+        // @scrutinizer ignore-type
         if (!is_string($prefixedTable)) {
             return false;
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -159,6 +159,11 @@ if (!defined('_MA_USER_MORE')) {
     define('_MA_USER_MORE', 'Find more users');
 }
 
+// Permission / access constants
+if (!defined('_NOPERM')) {
+    define('_NOPERM', "Sorry, you don't have the permission to access this area.");
+}
+
 // Renderer constants — used by XoopsFormRendererLegacy
 if (!defined('_DELETE')) {
     define('_DELETE', 'Delete');
@@ -446,8 +451,12 @@ if (!class_exists('XoopsSecurity')) {
             return $this->testCheckResult;
         }
 
-        public function getErrors()
+        public function &getErrors($ashtml = false)
         {
+            if ($ashtml) {
+                $ret = implode('<br>', $this->testErrors);
+                return $ret;
+            }
             return $this->testErrors;
         }
     }
@@ -708,6 +717,14 @@ if (!defined('_AM_MODULEADMIN_ABOUT_AMOUNT_PATTERN')) {
 }
 if (!defined('_AM_MODULEADMIN_ABOUT_DONATE_IMG_ALT')) {
     define('_AM_MODULEADMIN_ABOUT_DONATE_IMG_ALT', 'Donate');
+}
+
+// Stub system_AdminIcons() for SystemMaintenance tests
+if (!function_exists('system_AdminIcons')) {
+    function system_AdminIcons(string $icon): string
+    {
+        return 'images/' . $icon;
+    }
 }
 
 // Stub checkEmail() for ModuleAdmin renderAbout

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -430,9 +430,25 @@ if (!function_exists('formatTimestamp')) {
 if (!class_exists('XoopsSecurity')) {
     class XoopsSecurity
     {
+        /** @var bool Whether check() should return true (for test control) */
+        public bool $testCheckResult = true;
+
+        /** @var string[] Errors to return from getErrors() */
+        public array $testErrors = [];
+
         public function createToken($timeout = 0, $name = 'XOOPS_TOKEN')
         {
             return 'test_token_' . $name;
+        }
+
+        public function check($clearIfValid = true, $token = false, $name = 'XOOPS_TOKEN')
+        {
+            return $this->testCheckResult;
+        }
+
+        public function getErrors()
+        {
+            return $this->testErrors;
         }
     }
 }

--- a/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
+++ b/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
@@ -21,6 +21,18 @@ use PHPUnit\Framework\TestCase;
 class ProfileVisibilityCsrfTest extends TestCase
 {
     // ---------------------------------------------------------------
+    // Helper methods
+    // ---------------------------------------------------------------
+
+    private function readSourceFile(string $relativePath): string
+    {
+        $path = XOOPS_ROOT_PATH . $relativePath;
+        $source = file_get_contents($path);
+        $this->assertNotFalse($source, 'Unable to read source file: ' . $path);
+        return $source;
+    }
+
+    // ---------------------------------------------------------------
     // XoopsSecurity::check() contract tests
     // ---------------------------------------------------------------
 
@@ -56,20 +68,19 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function requestGetMethodReturnsCurrentMethod(): void
     {
-        // Save original
-        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $original = $_SERVER['REQUEST_METHOD'] ?? null;
+        try {
+            $_SERVER['REQUEST_METHOD'] = 'POST';
+            $this->assertSame('POST', \Xmf\Request::getMethod());
 
-        $_SERVER['REQUEST_METHOD'] = 'POST';
-        $this->assertSame('POST', \Xmf\Request::getMethod());
-
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-        $this->assertSame('GET', \Xmf\Request::getMethod());
-
-        // Restore
-        if ($origMethod !== null) {
-            $_SERVER['REQUEST_METHOD'] = $origMethod;
-        } else {
-            unset($_SERVER['REQUEST_METHOD']);
+            $_SERVER['REQUEST_METHOD'] = 'GET';
+            $this->assertSame('GET', \Xmf\Request::getMethod());
+        } finally {
+            if ($original === null) {
+                unset($_SERVER['REQUEST_METHOD']);
+            } else {
+                $_SERVER['REQUEST_METHOD'] = $original;
+            }
         }
     }
 
@@ -80,53 +91,53 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function deleteOperationOnGetRequestTriggersRedirect(): void
     {
-        // Save original
-        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
-        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $original = $_SERVER['REQUEST_METHOD'] ?? null;
+        try {
+            $_SERVER['REQUEST_METHOD'] = 'GET';
 
-        // Simulate the guard logic from visibility.php
-        $op = 'del';
-        $redirected = false;
+            // Simulate the guard logic from visibility.php
+            $op = 'del';
+            $redirected = false;
 
-        if ($op === 'del') {
-            if ('POST' !== \Xmf\Request::getMethod()) {
-                $redirected = true; // Would call redirect_header()
+            if ($op === 'del') {
+                if ('POST' !== \Xmf\Request::getMethod()) {
+                    $redirected = true; // Would call redirect_header()
+                }
             }
-        }
 
-        $this->assertTrue($redirected, 'DELETE via GET should trigger redirect');
-
-        // Restore
-        if ($origMethod !== null) {
-            $_SERVER['REQUEST_METHOD'] = $origMethod;
-        } else {
-            unset($_SERVER['REQUEST_METHOD']);
+            $this->assertTrue($redirected, 'DELETE via GET should trigger redirect');
+        } finally {
+            if ($original === null) {
+                unset($_SERVER['REQUEST_METHOD']);
+            } else {
+                $_SERVER['REQUEST_METHOD'] = $original;
+            }
         }
     }
 
     #[Test]
     public function deleteOperationOnPostRequestPassesMethodCheck(): void
     {
-        // Save original
-        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
-        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $original = $_SERVER['REQUEST_METHOD'] ?? null;
+        try {
+            $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $op = 'del';
-        $redirected = false;
+            $op = 'del';
+            $redirected = false;
 
-        if ($op === 'del') {
-            if ('POST' !== \Xmf\Request::getMethod()) {
-                $redirected = true;
+            if ($op === 'del') {
+                if ('POST' !== \Xmf\Request::getMethod()) {
+                    $redirected = true;
+                }
             }
-        }
 
-        $this->assertFalse($redirected, 'DELETE via POST should pass method check');
-
-        // Restore
-        if ($origMethod !== null) {
-            $_SERVER['REQUEST_METHOD'] = $origMethod;
-        } else {
-            unset($_SERVER['REQUEST_METHOD']);
+            $this->assertFalse($redirected, 'DELETE via POST should pass method check');
+        } finally {
+            if ($original === null) {
+                unset($_SERVER['REQUEST_METHOD']);
+            } else {
+                $_SERVER['REQUEST_METHOD'] = $original;
+            }
         }
     }
 
@@ -167,29 +178,29 @@ class ProfileVisibilityCsrfTest extends TestCase
         $security->testCheckResult = false;
         $security->testErrors = ['Token mismatch'];
 
-        // Save original
-        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
-        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $original = $_SERVER['REQUEST_METHOD'] ?? null;
+        try {
+            $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        // Simulate both guards
-        $methodBlocked = false;
-        $tokenBlocked = false;
+            // Simulate both guards
+            $methodBlocked = false;
+            $tokenBlocked = false;
 
-        if ('POST' !== \Xmf\Request::getMethod()) {
-            $methodBlocked = true;
-        }
-        if (!$security->check()) {
-            $tokenBlocked = true;
-        }
+            if ('POST' !== \Xmf\Request::getMethod()) {
+                $methodBlocked = true;
+            }
+            if (!$security->check()) {
+                $tokenBlocked = true;
+            }
 
-        $this->assertFalse($methodBlocked, 'POST request should pass method check');
-        $this->assertTrue($tokenBlocked, 'Invalid token should block delete');
-
-        // Restore
-        if ($origMethod !== null) {
-            $_SERVER['REQUEST_METHOD'] = $origMethod;
-        } else {
-            unset($_SERVER['REQUEST_METHOD']);
+            $this->assertFalse($methodBlocked, 'POST request should pass method check');
+            $this->assertTrue($tokenBlocked, 'Invalid token should block delete');
+        } finally {
+            if ($original === null) {
+                unset($_SERVER['REQUEST_METHOD']);
+            } else {
+                $_SERVER['REQUEST_METHOD'] = $original;
+            }
         }
     }
 
@@ -200,9 +211,7 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function visibilityFileContainsCsrfCheckForInsert(): void
     {
-        $source = file_get_contents(
-            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
-        );
+        $source = $this->readSourceFile('/modules/profile/admin/visibility.php');
 
         // Locate the submit handler block
         $submitPos = strpos($source, "if (Request::hasVar('submit', 'POST'))");
@@ -221,9 +230,7 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function visibilityFileContainsPostOnlyCheckForDelete(): void
     {
-        $source = file_get_contents(
-            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
-        );
+        $source = $this->readSourceFile('/modules/profile/admin/visibility.php');
         $this->assertStringContainsString(
             "Request::getMethod()",
             $source,
@@ -234,9 +241,7 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function visibilityFileReadsDeleteParamsFromPost(): void
     {
-        $source = file_get_contents(
-            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
-        );
+        $source = $this->readSourceFile('/modules/profile/admin/visibility.php');
         // After the del operation, parameters should come from POST, not GET
         // Check that field_id in del block uses 'POST'
         $delBlock = strstr($source, "if (\$op === 'del')");
@@ -251,9 +256,7 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function visibilityFileRequiresPostForDelete(): void
     {
-        $source = file_get_contents(
-            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
-        );
+        $source = $this->readSourceFile('/modules/profile/admin/visibility.php');
         // The delete block must enforce POST method
         $delBlock = strstr($source, "if (\$op === 'del')");
         $this->assertNotFalse($delBlock, 'Delete block must exist');
@@ -276,8 +279,8 @@ class ProfileVisibilityCsrfTest extends TestCase
     #[Test]
     public function templateUsesPostFormForDelete(): void
     {
-        $tplSource = file_get_contents(
-            XOOPS_ROOT_PATH . '/modules/profile/templates/profile_admin_visibility.tpl'
+        $tplSource = $this->readSourceFile(
+            '/modules/profile/templates/profile_admin_visibility.tpl'
         );
         // Must NOT use GET links for delete
         $this->assertStringNotContainsString(

--- a/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
+++ b/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace modulesprofile;
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -204,11 +203,19 @@ class ProfileVisibilityCsrfTest extends TestCase
         $source = file_get_contents(
             XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
         );
-        $this->assertStringContainsString(
-            "xoopsSecurity']->check()",
-            $source,
-            'visibility.php must contain CSRF token check'
-        );
+
+        // Locate the submit handler block
+        $submitPos = strpos($source, "if (Request::hasVar('submit', 'POST'))");
+        $this->assertNotFalse($submitPos, "visibility.php must contain a submit handler");
+
+        // CSRF check must appear before insert within the submit handler
+        $checkPos = strpos($source, "xoopsSecurity']->check()", $submitPos);
+        $this->assertNotFalse($checkPos, "Submit handler must perform a CSRF token check");
+
+        $insertPos = strpos($source, 'visibility_handler->insert(', $submitPos);
+        $this->assertNotFalse($insertPos, "Submit handler must perform an insert operation");
+
+        $this->assertLessThan($insertPos, $checkPos, 'CSRF token check must run before insert in submit handler');
     }
 
     #[Test]

--- a/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
+++ b/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
@@ -242,16 +242,58 @@ class ProfileVisibilityCsrfTest extends TestCase
     }
 
     #[Test]
-    public function visibilityFileDoesNotReadOpFromGet(): void
+    public function visibilityFileRequiresPostForDelete(): void
     {
         $source = file_get_contents(
             XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
         );
-        // The $op variable should no longer fall back to GET
+        // The delete block must enforce POST method
+        $delBlock = strstr($source, "if (\$op === 'del')");
+        $this->assertNotFalse($delBlock, 'Delete block must exist');
+        $this->assertStringContainsString(
+            "Request::getMethod()",
+            $delBlock,
+            'Delete block must check request method'
+        );
+        $this->assertStringContainsString(
+            "'POST'",
+            $delBlock,
+            'Delete block must require POST'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Template verification tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function templateUsesPostFormForDelete(): void
+    {
+        $tplSource = file_get_contents(
+            XOOPS_ROOT_PATH . '/modules/profile/templates/profile_admin_visibility.tpl'
+        );
+        // Must NOT use GET links for delete
         $this->assertStringNotContainsString(
-            "getCmd('op', 'visibility', 'GET')",
-            $source,
-            'visibility.php must not read op from GET'
+            'href="visibility.php?op=del',
+            $tplSource,
+            'Template must not use GET links for delete'
+        );
+        // Must use POST form for delete
+        $this->assertStringContainsString(
+            'method="post"',
+            $tplSource,
+            'Template must use POST form for delete'
+        );
+        $this->assertStringContainsString(
+            'name="op" value="del"',
+            $tplSource,
+            'Template must include hidden op=del field'
+        );
+        // Must include CSRF security token
+        $this->assertStringContainsString(
+            '{securityToken}',
+            $tplSource,
+            'Template must include securityToken in delete form'
         );
     }
 }

--- a/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
+++ b/tests/unit/htdocs/modules/profile/ProfileVisibilityCsrfTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulesprofile;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for CSRF protection and POST-only enforcement in
+ * htdocs/modules/profile/admin/visibility.php
+ *
+ * These tests verify the security guards added to the visibility
+ * admin controller. Since visibility.php is a procedural script that
+ * relies on many global bootstrapping side-effects (xoops_cp_header,
+ * module handlers, templates, etc.), we test the security logic by
+ * verifying the XoopsSecurity stub behavior and Request::getMethod()
+ * contract that the guards depend on.
+ */
+class ProfileVisibilityCsrfTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // XoopsSecurity::check() contract tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function securityCheckReturnsTrueByDefault(): void
+    {
+        $security = new \XoopsSecurity();
+        $this->assertTrue($security->check());
+    }
+
+    #[Test]
+    public function securityCheckReturnsFalseWhenConfigured(): void
+    {
+        $security = new \XoopsSecurity();
+        $security->testCheckResult = false;
+        $this->assertFalse($security->check());
+    }
+
+    #[Test]
+    public function securityGetErrorsReturnsConfiguredErrors(): void
+    {
+        $security = new \XoopsSecurity();
+        $security->testErrors = ['Token expired', 'Invalid session'];
+        $errors = $security->getErrors();
+        $this->assertCount(2, $errors);
+        $this->assertSame('Token expired', $errors[0]);
+    }
+
+    // ---------------------------------------------------------------
+    // Request::getMethod() contract tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function requestGetMethodReturnsCurrentMethod(): void
+    {
+        // Save original
+        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->assertSame('POST', \Xmf\Request::getMethod());
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $this->assertSame('GET', \Xmf\Request::getMethod());
+
+        // Restore
+        if ($origMethod !== null) {
+            $_SERVER['REQUEST_METHOD'] = $origMethod;
+        } else {
+            unset($_SERVER['REQUEST_METHOD']);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Guard logic verification tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function deleteOperationOnGetRequestTriggersRedirect(): void
+    {
+        // Save original
+        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        // Simulate the guard logic from visibility.php
+        $op = 'del';
+        $redirected = false;
+
+        if ($op === 'del') {
+            if ('POST' !== \Xmf\Request::getMethod()) {
+                $redirected = true; // Would call redirect_header()
+            }
+        }
+
+        $this->assertTrue($redirected, 'DELETE via GET should trigger redirect');
+
+        // Restore
+        if ($origMethod !== null) {
+            $_SERVER['REQUEST_METHOD'] = $origMethod;
+        } else {
+            unset($_SERVER['REQUEST_METHOD']);
+        }
+    }
+
+    #[Test]
+    public function deleteOperationOnPostRequestPassesMethodCheck(): void
+    {
+        // Save original
+        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $op = 'del';
+        $redirected = false;
+
+        if ($op === 'del') {
+            if ('POST' !== \Xmf\Request::getMethod()) {
+                $redirected = true;
+            }
+        }
+
+        $this->assertFalse($redirected, 'DELETE via POST should pass method check');
+
+        // Restore
+        if ($origMethod !== null) {
+            $_SERVER['REQUEST_METHOD'] = $origMethod;
+        } else {
+            unset($_SERVER['REQUEST_METHOD']);
+        }
+    }
+
+    #[Test]
+    public function insertOperationWithInvalidTokenTriggersRedirect(): void
+    {
+        $security = new \XoopsSecurity();
+        $security->testCheckResult = false;
+        $security->testErrors = ['Invalid token'];
+
+        // Simulate the guard logic
+        $redirected = false;
+        if (!$security->check()) {
+            $redirected = true;
+        }
+
+        $this->assertTrue($redirected, 'Insert with invalid CSRF token should trigger redirect');
+    }
+
+    #[Test]
+    public function insertOperationWithValidTokenPasses(): void
+    {
+        $security = new \XoopsSecurity();
+        $security->testCheckResult = true;
+
+        $redirected = false;
+        if (!$security->check()) {
+            $redirected = true;
+        }
+
+        $this->assertFalse($redirected, 'Insert with valid CSRF token should pass');
+    }
+
+    #[Test]
+    public function deleteOperationWithInvalidTokenTriggersRedirect(): void
+    {
+        $security = new \XoopsSecurity();
+        $security->testCheckResult = false;
+        $security->testErrors = ['Token mismatch'];
+
+        // Save original
+        $origMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        // Simulate both guards
+        $methodBlocked = false;
+        $tokenBlocked = false;
+
+        if ('POST' !== \Xmf\Request::getMethod()) {
+            $methodBlocked = true;
+        }
+        if (!$security->check()) {
+            $tokenBlocked = true;
+        }
+
+        $this->assertFalse($methodBlocked, 'POST request should pass method check');
+        $this->assertTrue($tokenBlocked, 'Invalid token should block delete');
+
+        // Restore
+        if ($origMethod !== null) {
+            $_SERVER['REQUEST_METHOD'] = $origMethod;
+        } else {
+            unset($_SERVER['REQUEST_METHOD']);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Source file verification
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function visibilityFileContainsCsrfCheckForInsert(): void
+    {
+        $source = file_get_contents(
+            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
+        );
+        $this->assertStringContainsString(
+            "xoopsSecurity']->check()",
+            $source,
+            'visibility.php must contain CSRF token check'
+        );
+    }
+
+    #[Test]
+    public function visibilityFileContainsPostOnlyCheckForDelete(): void
+    {
+        $source = file_get_contents(
+            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
+        );
+        $this->assertStringContainsString(
+            "Request::getMethod()",
+            $source,
+            'visibility.php must check request method for delete'
+        );
+    }
+
+    #[Test]
+    public function visibilityFileReadsDeleteParamsFromPost(): void
+    {
+        $source = file_get_contents(
+            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
+        );
+        // After the del operation, parameters should come from POST, not GET
+        // Check that field_id in del block uses 'POST'
+        $delBlock = strstr($source, "if (\$op === 'del')");
+        $this->assertNotFalse($delBlock, 'Delete block must exist');
+        $this->assertStringContainsString(
+            "'field_id', 0, 'POST'",
+            $delBlock,
+            'Delete block must read field_id from POST'
+        );
+    }
+
+    #[Test]
+    public function visibilityFileDoesNotReadOpFromGet(): void
+    {
+        $source = file_get_contents(
+            XOOPS_ROOT_PATH . '/modules/profile/admin/visibility.php'
+        );
+        // The $op variable should no longer fall back to GET
+        $this->assertStringNotContainsString(
+            "getCmd('op', 'visibility', 'GET')",
+            $source,
+            'visibility.php must not read op from GET'
+        );
+    }
+}

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulessystem;
+
+use kernel\KernelTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(\SystemMaintenance::class)]
+class SystemMaintenanceTest extends KernelTestCase
+{
+    private static bool $loaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::$loaded) {
+            if (!isset($GLOBALS['xoopsLogger'])) {
+                $GLOBALS['xoopsLogger'] = \XoopsLogger::getInstance();
+            }
+            // Define constants needed by maintenance class
+            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES1')) {
+                define('_AM_SYSTEM_MAINTENANCE_TABLES1', 'Table');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_OPTIMIZE')) {
+                define('_AM_SYSTEM_MAINTENANCE_TABLES_OPTIMIZE', 'Optimize');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_CHECK')) {
+                define('_AM_SYSTEM_MAINTENANCE_TABLES_CHECK', 'Check');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_REPAIR')) {
+                define('_AM_SYSTEM_MAINTENANCE_TABLES_REPAIR', 'Repair');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_ANALYZE')) {
+                define('_AM_SYSTEM_MAINTENANCE_TABLES_ANALYZE', 'Analyze');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_TABLES')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_TABLES', 'Tables');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_STRUCTURES')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_STRUCTURES', 'Structures');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_NB_RECORDS')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_NB_RECORDS', 'Records');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_RECORDS')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_RECORDS', 'records');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_FILE_CREATED')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_FILE_CREATED', 'File created');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_RESULT')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_RESULT', 'Result');
+            }
+            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES')) {
+                define('_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES', 'No tables');
+            }
+            // Stub system_AdminIcons if not defined
+            if (!function_exists('system_AdminIcons')) {
+                function system_AdminIcons(string $icon): string
+                {
+                    return 'images/' . $icon;
+                }
+            }
+            require_once XOOPS_ROOT_PATH . '/modules/system/class/maintenance.php';
+            self::$loaded = true;
+        }
+    }
+
+    /**
+     * Create a SystemMaintenance instance with a mock database injected.
+     *
+     * @param \XoopsMySQLDatabase|\PHPUnit\Framework\MockObject\MockObject $db
+     *
+     * @return \SystemMaintenance
+     */
+    private function createMaintenance($db): \SystemMaintenance
+    {
+        $ref = new \ReflectionClass(\SystemMaintenance::class);
+        $obj = $ref->newInstanceWithoutConstructor();
+        $this->setProtectedProperty($obj, 'db', $db);
+        $this->setProtectedProperty($obj, 'prefix', 'xoops_');
+
+        return $obj;
+    }
+
+    /**
+     * Stub SHOW TABLES to return a known table list for validation.
+     *
+     * @param \XoopsMySQLDatabase|\PHPUnit\Framework\MockObject\MockObject $db
+     * @param array $tables  Unprefixed table names
+     */
+    private function stubShowTables($db, array $tables): void
+    {
+        $rows = [];
+        foreach ($tables as $t) {
+            $rows[] = ['Tables_in_test' => XOOPS_DB_PREFIX . '_' . $t];
+        }
+        $rows[] = false; // End of result set
+
+        $db->method('query')->willReturn('mock_result');
+        $db->method('isResultSet')->willReturn(true);
+        $db->method('fetchArray')->willReturnOnConsecutiveCalls(...$rows);
+    }
+
+    // ---------------------------------------------------------------
+    // isValidTable / isValidPrefixedTable tests (via reflection)
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function isValidTableReturnsTrueForExistingTable(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups', 'session']);
+        $maintenance = $this->createMaintenance($db);
+
+        $method = new \ReflectionMethod($maintenance, 'isValidTable');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($maintenance, 'users'));
+        $this->assertTrue($method->invoke($maintenance, 'groups'));
+        $this->assertTrue($method->invoke($maintenance, 'session'));
+    }
+
+    #[Test]
+    public function isValidTableReturnsFalseForNonExistentTable(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $method = new \ReflectionMethod($maintenance, 'isValidTable');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($maintenance, 'evil_table'));
+    }
+
+    #[Test]
+    public function isValidTableReturnsFalseForSqlInjectionPayload(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $method = new \ReflectionMethod($maintenance, 'isValidTable');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($maintenance, "users; DROP TABLE users; --"));
+        $this->assertFalse($method->invoke($maintenance, "users' OR '1'='1"));
+    }
+
+    #[Test]
+    public function isValidPrefixedTableReturnsTrueForValidPrefixedTable(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $method = new \ReflectionMethod($maintenance, 'isValidPrefixedTable');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($maintenance, 'xoops_users'));
+    }
+
+    #[Test]
+    public function isValidPrefixedTableReturnsFalseForInvalidPrefixedTable(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $method = new \ReflectionMethod($maintenance, 'isValidPrefixedTable');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($maintenance, 'xoops_evil_table'));
+    }
+
+    // ---------------------------------------------------------------
+    // dump_table_structure validation tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function dumpTableStructureRejectsInvalidTable(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $ret = ['', ''];
+        $result = $maintenance->dump_table_structure($ret, 'xoops_evil_inject', 0, 'odd');
+
+        // Should return unchanged $ret since the table is invalid
+        $this->assertSame($ret, $result);
+    }
+
+    // ---------------------------------------------------------------
+    // dump_table_datas validation tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function dumpTableDatasRejectsInvalidTable(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $ret = ['', ''];
+        $result = $maintenance->dump_table_datas($ret, 'xoops_evil_inject');
+
+        // Should return unchanged $ret since the table is invalid
+        $this->assertSame($ret, $result);
+    }
+
+    // ---------------------------------------------------------------
+    // displayTables tests
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function displayTablesReturnsArrayOfTableNames(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $tables = $maintenance->displayTables(true);
+
+        $this->assertIsArray($tables);
+        $this->assertArrayHasKey('users', $tables);
+        $this->assertArrayHasKey('groups', $tables);
+        $this->assertSame('users', $tables['users']);
+    }
+
+    #[Test]
+    public function displayTablesReturnsStringWhenArrayIsFalse(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users', 'groups']);
+        $maintenance = $this->createMaintenance($db);
+
+        $result = $maintenance->displayTables(false);
+
+        $this->assertIsString($result);
+        $this->assertStringContainsString('users', $result);
+        $this->assertStringContainsString('groups', $result);
+    }
+
+    // ---------------------------------------------------------------
+    // Table validation caching test
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function isValidTableCachesResults(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubShowTables($db, ['users']);
+        $maintenance = $this->createMaintenance($db);
+
+        $method = new \ReflectionMethod($maintenance, 'isValidTable');
+        $method->setAccessible(true);
+
+        // First call populates cache
+        $this->assertTrue($method->invoke($maintenance, 'users'));
+        // Second call uses cache (query() should not be called again)
+        $this->assertTrue($method->invoke($maintenance, 'users'));
+        // Invalid table still false from cache
+        $this->assertFalse($method->invoke($maintenance, 'nonexistent'));
+    }
+}

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -19,45 +19,35 @@ class SystemMaintenanceTest extends KernelTestCase
             if (!isset($GLOBALS['xoopsLogger'])) {
                 $GLOBALS['xoopsLogger'] = \XoopsLogger::getInstance();
             }
-            // Define constants needed by maintenance class
-            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES1')) {
-                define('_AM_SYSTEM_MAINTENANCE_TABLES1', 'Table');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_OPTIMIZE')) {
-                define('_AM_SYSTEM_MAINTENANCE_TABLES_OPTIMIZE', 'Optimize');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_CHECK')) {
-                define('_AM_SYSTEM_MAINTENANCE_TABLES_CHECK', 'Check');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_REPAIR')) {
-                define('_AM_SYSTEM_MAINTENANCE_TABLES_REPAIR', 'Repair');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_TABLES_ANALYZE')) {
-                define('_AM_SYSTEM_MAINTENANCE_TABLES_ANALYZE', 'Analyze');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_TABLES')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_TABLES', 'Tables');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_STRUCTURES')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_STRUCTURES', 'Structures');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_NB_RECORDS')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_NB_RECORDS', 'Records');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_RECORDS')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_RECORDS', 'records');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_FILE_CREATED')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_FILE_CREATED', 'File created');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_RESULT')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_RESULT', 'Result');
-            }
-            if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES')) {
-                define('_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES', 'No tables');
-            }
+            self::ensureMaintenanceConstants();
             require_once XOOPS_ROOT_PATH . '/modules/system/class/maintenance.php';
             self::$loaded = true;
+        }
+    }
+
+    /**
+     * Define language constants required by the SystemMaintenance class.
+     */
+    private static function ensureMaintenanceConstants(): void
+    {
+        $constants = [
+            '_AM_SYSTEM_MAINTENANCE_TABLES1'            => 'Table',
+            '_AM_SYSTEM_MAINTENANCE_TABLES_OPTIMIZE'    => 'Optimize',
+            '_AM_SYSTEM_MAINTENANCE_TABLES_CHECK'       => 'Check',
+            '_AM_SYSTEM_MAINTENANCE_TABLES_REPAIR'      => 'Repair',
+            '_AM_SYSTEM_MAINTENANCE_TABLES_ANALYZE'     => 'Analyze',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_TABLES'        => 'Tables',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_STRUCTURES'    => 'Structures',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_NB_RECORDS'    => 'Records',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_RECORDS'       => 'records',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_FILE_CREATED'  => 'File created',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_RESULT'        => 'Result',
+            '_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES'     => 'No tables',
+        ];
+        foreach ($constants as $name => $value) {
+            if (!defined($name)) {
+                define($name, $value);
+            }
         }
     }
 

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -56,13 +56,6 @@ class SystemMaintenanceTest extends KernelTestCase
             if (!defined('_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES')) {
                 define('_AM_SYSTEM_MAINTENANCE_DUMP_NO_TABLES', 'No tables');
             }
-            // Stub system_AdminIcons if not defined
-            if (!function_exists('system_AdminIcons')) {
-                function system_AdminIcons(string $icon): string
-                {
-                    return 'images/' . $icon;
-                }
-            }
             require_once XOOPS_ROOT_PATH . '/modules/system/class/maintenance.php';
             self::$loaded = true;
         }
@@ -253,7 +246,19 @@ class SystemMaintenanceTest extends KernelTestCase
     public function isValidTableCachesResults(): void
     {
         $db = $this->createMockDatabase();
-        $this->stubShowTables($db, ['users']);
+
+        // Build the rows that SHOW TABLES would return
+        $rows = [
+            ['Tables_in_test' => XOOPS_DB_PREFIX . '_users'],
+            false, // End of result set
+        ];
+
+        // query() must be called exactly once — subsequent isValidTable()
+        // calls must use the cached result, not issue another query.
+        $db->expects($this->once())->method('query')->willReturn('mock_result');
+        $db->method('isResultSet')->willReturn(true);
+        $db->method('fetchArray')->willReturnOnConsecutiveCalls(...$rows);
+
         $maintenance = $this->createMaintenance($db);
 
         $method = new \ReflectionMethod($maintenance, 'isValidTable');


### PR DESCRIPTION
## Summary
- **C-1**: Validate table names against `SHOW TABLES` before interpolating into SQL in `maintenance.php` dump methods, preventing SQL injection via POST parameter
- **C-4**: Add `$GLOBALS['xoopsSecurity']->check()` CSRF protection to profile visibility insert/delete operations; restrict delete to POST-only

## Test plan
- [ ] 10 tests for table validation (valid/invalid/injection payloads, caching, dump rejection)
- [ ] 13 tests for CSRF check contract, POST-only enforcement, guard logic
- [ ] Run maintenance dump with valid/invalid table selections
- [ ] Test profile visibility add/delete with and without valid token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile visibility: CSRF checks enforced; delete now requires POST and reads parameters from the submitted form; form submissions validated with security check.
  * System maintenance: table-name validation added to skip invalid or unprefixed tables, preventing erroneous operations.

* **Tests**
  * New unit tests for profile visibility CSRF, POST-only delete, and template/form requirements.
  * New unit tests for system maintenance table validation.
  * Test scaffolding extended with helpers to simulate security checks and admin icon stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->