### PR TITLE
Add exec() override to Protector dblayertrap and check exec results

### DIFF
--- a/htdocs/xoops_lib/modules/protector/admin/center.php
+++ b/htdocs/xoops_lib/modules/protector/admin/center.php
@@ -145,6 +145,7 @@ if ($action !== '') {
         if ($db->exec("DELETE FROM $log_table")) {
             redirect_header('center.php?page=center', 2, _AM_MSG_REMOVED);
         } else {
+            trigger_error('Protector: failed to delete log records: ' . $db->error(), E_USER_WARNING);
             redirect_header('center.php?page=center', 3, _AM_MSG_DELFAILED);
         }
         exit;
@@ -170,6 +171,7 @@ if ($action !== '') {
         }
         if (!empty($ids)) {
             if (!$db->exec("DELETE FROM $log_table WHERE lid IN (" . implode(',', $ids) . ')')) {
+                trigger_error('Protector: failed to compact log: ' . $db->error(), E_USER_WARNING);
                 redirect_header('center.php?page=center', 3, _AM_MSG_DELFAILED);
                 exit;
             }

--- a/htdocs/xoops_lib/modules/protector/admin/center.php
+++ b/htdocs/xoops_lib/modules/protector/admin/center.php
@@ -142,8 +142,11 @@ if ($action !== '') {
         exit;
     } elseif ($action === 'deleteall') {
         // remove all records
-        $db->exec("DELETE FROM $log_table");
-        redirect_header('center.php?page=center', 2, _AM_MSG_REMOVED);
+        if ($db->exec("DELETE FROM $log_table")) {
+            redirect_header('center.php?page=center', 2, _AM_MSG_REMOVED);
+        } else {
+            redirect_header('center.php?page=center', 3, _AM_MSG_DELFAILED);
+        }
         exit;
     } elseif ($action === 'compactlog') {
         // compact records (remove duplicated records (ip,type)
@@ -166,7 +169,10 @@ if ($action !== '') {
             }
         }
         if (!empty($ids)) {
-            $db->exec("DELETE FROM $log_table WHERE lid IN (" . implode(',', $ids) . ')');
+            if (!$db->exec("DELETE FROM $log_table WHERE lid IN (" . implode(',', $ids) . ')')) {
+                redirect_header('center.php?page=center', 3, _AM_MSG_DELFAILED);
+                exit;
+            }
         }
         redirect_header('center.php?page=center', 2, _AM_MSG_REMOVED);
         exit;

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
@@ -196,6 +196,7 @@ class ProtectorMySQLDatabase extends XoopsMySQLDatabaseProxy
      * @param string $sql SQL statement to execute
      *
      * @return bool TRUE on success, FALSE on failure
+     * @throws \mysqli_sql_exception
      */
     public function exec(string $sql): bool
     {

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
@@ -185,4 +185,28 @@ class ProtectorMySQLDatabase extends XoopsMySQLDatabaseProxy
 
         return $ret;
     }
+
+    /**
+     * Execute a write statement with dblayertrap SQL inspection.
+     *
+     * Mirrors the same SQL inspection logic applied in query() so that
+     * statements routed through exec() are not able to bypass dblayertrap
+     * checks when XOOPS_DB_ALTERNATIVE is active.
+     *
+     * @param string $sql SQL statement to execute
+     *
+     * @return bool TRUE on success, FALSE on failure
+     */
+    public function exec(string $sql): bool
+    {
+        $sql4check = substr($sql, 7);
+        foreach ($this->doubtful_needles as $needle) {
+            if (false !== stripos($sql4check, (string) $needle)) {
+                $this->checkSql($sql);
+                break;
+            }
+        }
+
+        return parent::exec($sql);
+    }
 }

--- a/htdocs/xoops_lib/modules/protector/language/english/admin.php
+++ b/htdocs/xoops_lib/modules/protector/language/english/admin.php
@@ -25,6 +25,7 @@ define('_AM_MSG_IPFILESUPDATED', 'Files for IPs have been updated');
 define('_AM_MSG_BADIPSCANTOPEN', 'The file for bad IP cannot be opened');
 define('_AM_MSG_GROUP1IPSCANTOPEN', 'The file for allowing group=1 cannot be opened');
 define('_AM_MSG_REMOVED', 'Records are removed');
+define('_AM_MSG_DELFAILED', 'Failed to delete records');
 define('_AM_FMT_CONFIGSNOTWRITABLE', 'Turn the configs directory writable: %s');
 // prefix_manager.php
 define('_AM_H3_PREFIXMAN', 'Prefix Manager');

--- a/tests/unit/htdocs/modules/protector/ProtectorAdminCenterTest.php
+++ b/tests/unit/htdocs/modules/protector/ProtectorAdminCenterTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace modulesprotector;
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use RedirectHeaderException;
 
 /**
  * Tests for Protector admin center.php exec() error handling.

--- a/tests/unit/htdocs/modules/protector/ProtectorAdminCenterTest.php
+++ b/tests/unit/htdocs/modules/protector/ProtectorAdminCenterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulesprotector;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RedirectHeaderException;
+
+/**
+ * Tests for Protector admin center.php exec() error handling.
+ *
+ * These tests verify that the deleteall and compactlog actions
+ * correctly check exec() return values and show appropriate
+ * error messages on failure.
+ */
+class ProtectorAdminCenterTest extends TestCase
+{
+    /**
+     * Verify the _AM_MSG_DELFAILED language constant exists.
+     */
+    #[Test]
+    public function delFailedConstantIsDefined(): void
+    {
+        // Load the language file
+        $langFile = XOOPS_PATH . '/modules/protector/language/english/admin.php';
+        if (!defined('_AM_MSG_DELFAILED')) {
+            require_once $langFile;
+        }
+        $this->assertTrue(defined('_AM_MSG_DELFAILED'));
+        $this->assertNotEmpty(constant('_AM_MSG_DELFAILED'));
+    }
+
+    /**
+     * Verify the _AM_MSG_REMOVED language constant still exists.
+     */
+    #[Test]
+    public function removedConstantIsDefined(): void
+    {
+        $langFile = XOOPS_PATH . '/modules/protector/language/english/admin.php';
+        if (!defined('_AM_MSG_REMOVED')) {
+            require_once $langFile;
+        }
+        $this->assertTrue(defined('_AM_MSG_REMOVED'));
+        $this->assertNotEmpty(constant('_AM_MSG_REMOVED'));
+    }
+
+    /**
+     * Verify that center.php source contains exec() return checks for deleteall.
+     */
+    #[Test]
+    public function deleteallActionChecksExecReturn(): void
+    {
+        $source = file_get_contents(
+            XOOPS_PATH . '/modules/protector/admin/center.php'
+        );
+
+        // The deleteall block should check exec() return with if()
+        $this->assertStringContainsString(
+            'if ($db->exec("DELETE FROM $log_table"))',
+            $source,
+            'deleteall action must check exec() return value'
+        );
+
+        // Should show error message on failure
+        $this->assertStringContainsString(
+            '_AM_MSG_DELFAILED',
+            $source,
+            'deleteall action must use _AM_MSG_DELFAILED on failure'
+        );
+    }
+
+    /**
+     * Verify that center.php source contains exec() return checks for compactlog.
+     */
+    #[Test]
+    public function compactlogActionChecksExecReturn(): void
+    {
+        $source = file_get_contents(
+            XOOPS_PATH . '/modules/protector/admin/center.php'
+        );
+
+        // The compactlog block should check exec() return with if(!...)
+        $this->assertStringContainsString(
+            'if (!$db->exec("DELETE FROM $log_table WHERE lid IN (',
+            $source,
+            'compactlog action must check exec() return value'
+        );
+    }
+
+    /**
+     * Verify that deleteall action does NOT silently redirect on failure.
+     * The source should have conditional redirect, not unconditional.
+     */
+    #[Test]
+    public function deleteallDoesNotSilentlyRedirectOnFailure(): void
+    {
+        $source = file_get_contents(
+            XOOPS_PATH . '/modules/protector/admin/center.php'
+        );
+
+        // Find the deleteall block - exec should be inside an if condition
+        // NOT as a bare statement followed by unconditional redirect
+        $pattern = '/deleteall.*?\$db->exec\([^)]+\);\s*\n\s*redirect_header/s';
+        $this->assertDoesNotMatchRegularExpression(
+            $pattern,
+            $source,
+            'deleteall must not have bare exec() followed by unconditional redirect'
+        );
+    }
+}

--- a/tests/unit/htdocs/modules/protector/ProtectorMysqlDatabaseTest.php
+++ b/tests/unit/htdocs/modules/protector/ProtectorMysqlDatabaseTest.php
@@ -269,7 +269,6 @@ class ProtectorMysqlDatabaseTest extends TestCase
     public function execCallsCheckSqlOnDoubtfulNeedle(): void
     {
         // Create a partial mock to verify checkSql is called
-        $ref = new \ReflectionClass(\ProtectorMySQLDatabase::class);
         $db = $this->getMockBuilder(\ProtectorMySQLDatabase::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['checkSql', 'injectionFound'])
@@ -282,19 +281,23 @@ class ProtectorMysqlDatabaseTest extends TestCase
 
         $db->expects($this->once())->method('checkSql')->with($sql);
 
-        // exec will fail because no real DB connection, but checkSql should be called
-        // We suppress the parent::exec error
+        // Suppress warning from parent::exec() due to no real DB connection
+        $previousHandler = set_error_handler(function ($errno, $errstr) {
+            if ($errno === E_USER_WARNING && strpos($errstr, 'mysqli') !== false) {
+                return true;
+            }
+            return false;
+        });
         try {
             $db->exec($sql);
-        } catch (\Throwable $e) {
-            // Expected — no real DB connection
+        } finally {
+            restore_error_handler();
         }
     }
 
     #[Test]
     public function execSkipsCheckSqlWhenNoNeedleMatch(): void
     {
-        $ref = new \ReflectionClass(\ProtectorMySQLDatabase::class);
         $db = $this->getMockBuilder(\ProtectorMySQLDatabase::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['checkSql', 'injectionFound'])
@@ -307,10 +310,17 @@ class ProtectorMysqlDatabaseTest extends TestCase
 
         $db->expects($this->never())->method('checkSql');
 
+        // Suppress warning from parent::exec() due to no real DB connection
+        $previousHandler = set_error_handler(function ($errno, $errstr) {
+            if ($errno === E_USER_WARNING && strpos($errstr, 'mysqli') !== false) {
+                return true;
+            }
+            return false;
+        });
         try {
             $db->exec($sql);
-        } catch (\Throwable $e) {
-            // Expected — no real DB connection
+        } finally {
+            restore_error_handler();
         }
     }
 }

--- a/tests/unit/htdocs/modules/protector/ProtectorMysqlDatabaseTest.php
+++ b/tests/unit/htdocs/modules/protector/ProtectorMysqlDatabaseTest.php
@@ -282,7 +282,7 @@ class ProtectorMysqlDatabaseTest extends TestCase
         $db->expects($this->once())->method('checkSql')->with($sql);
 
         // Suppress warning from parent::exec() due to no real DB connection
-        $previousHandler = set_error_handler(function ($errno, $errstr) {
+        set_error_handler(function ($errno, $errstr) {
             if ($errno === E_USER_WARNING && strpos($errstr, 'mysqli') !== false) {
                 return true;
             }
@@ -311,7 +311,7 @@ class ProtectorMysqlDatabaseTest extends TestCase
         $db->expects($this->never())->method('checkSql');
 
         // Suppress warning from parent::exec() due to no real DB connection
-        $previousHandler = set_error_handler(function ($errno, $errstr) {
+        set_error_handler(function ($errno, $errstr) {
             if ($errno === E_USER_WARNING && strpos($errstr, 'mysqli') !== false) {
                 return true;
             }

--- a/tests/unit/htdocs/modules/protector/ProtectorMysqlDatabaseTest.php
+++ b/tests/unit/htdocs/modules/protector/ProtectorMysqlDatabaseTest.php
@@ -224,4 +224,93 @@ class ProtectorMysqlDatabaseTest extends TestCase
         $this->db->doubtful_requests = ['test_request'];
         $this->assertSame(['test_request'], $this->db->doubtful_requests);
     }
+
+    // ---------------------------------------------------------------
+    // exec() override — dblayertrap SQL inspection
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function execMethodExists(): void
+    {
+        $this->assertTrue(method_exists($this->db, 'exec'));
+    }
+
+    #[Test]
+    public function execMethodIsDeclaredOnProtectorClass(): void
+    {
+        $ref = new \ReflectionMethod(\ProtectorMySQLDatabase::class, 'exec');
+        $this->assertSame(
+            \ProtectorMySQLDatabase::class,
+            $ref->getDeclaringClass()->getName(),
+            'exec() must be declared on ProtectorMySQLDatabase, not inherited'
+        );
+    }
+
+    #[Test]
+    public function execAcceptsStringParameter(): void
+    {
+        $ref = new \ReflectionMethod(\ProtectorMySQLDatabase::class, 'exec');
+        $params = $ref->getParameters();
+        $this->assertCount(1, $params);
+        $this->assertSame('sql', $params[0]->getName());
+        $this->assertSame('string', $params[0]->getType()->getName());
+    }
+
+    #[Test]
+    public function execReturnsBool(): void
+    {
+        $ref = new \ReflectionMethod(\ProtectorMySQLDatabase::class, 'exec');
+        $returnType = $ref->getReturnType();
+        $this->assertNotNull($returnType);
+        $this->assertSame('bool', $returnType->getName());
+    }
+
+    #[Test]
+    public function execCallsCheckSqlOnDoubtfulNeedle(): void
+    {
+        // Create a partial mock to verify checkSql is called
+        $ref = new \ReflectionClass(\ProtectorMySQLDatabase::class);
+        $db = $this->getMockBuilder(\ProtectorMySQLDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['checkSql', 'injectionFound'])
+            ->getMock();
+        $db->doubtful_requests = [];
+        $db->doubtful_needles = ['select', 'union', 'concat'];
+
+        // SQL containing 'union' (a doubtful needle) after char 7
+        $sql = "DELETE FROM users WHERE id IN (SELECT id FROM temp UNION SELECT 1)";
+
+        $db->expects($this->once())->method('checkSql')->with($sql);
+
+        // exec will fail because no real DB connection, but checkSql should be called
+        // We suppress the parent::exec error
+        try {
+            $db->exec($sql);
+        } catch (\Throwable $e) {
+            // Expected — no real DB connection
+        }
+    }
+
+    #[Test]
+    public function execSkipsCheckSqlWhenNoNeedleMatch(): void
+    {
+        $ref = new \ReflectionClass(\ProtectorMySQLDatabase::class);
+        $db = $this->getMockBuilder(\ProtectorMySQLDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['checkSql', 'injectionFound'])
+            ->getMock();
+        $db->doubtful_requests = [];
+        $db->doubtful_needles = ['select', 'union', 'concat'];
+
+        // Simple DELETE with no doubtful needles after char 7
+        $sql = "DELETE FROM logs WHERE lid = 5";
+
+        $db->expects($this->never())->method('checkSql');
+
+        try {
+            $db->exec($sql);
+        } catch (\Throwable $e) {
+            // Expected — no real DB connection
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **C-5**: Override `exec()` in `ProtectorMySQLDatabase` to apply the same SQL inspection as `query()`, preventing dblayertrap bypass after queryF-to-exec migration
- **M-4**: Check `exec()` return values in Protector admin deleteall/compactlog actions; show error on failure instead of silent success redirect

## Test plan
- [ ] 25 tests for ProtectorMySQLDatabase exec() override (method existence, signature, checkSql invocation)
- [ ] 5 tests for admin center exec() error handling and language constants
- [ ] Manual test: verify dblayertrap catches suspicious SQL via exec()
- [ ] Manual test: verify deleteall/compactlog show error on DB failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin delete actions now show explicit failure messages when record removals fail.

* **Bug Fixes**
  * Delete and compact-log flows now verify database execution results and avoid silent redirects on failure.

* **Tests**
  * Added unit tests validating delete-failure handling and database-execution checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->