### PR TITLE
Harden banners: bcrypt passwords, fix XSS, add IDOR protection

### DIFF
--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -25,6 +25,33 @@ $xoopsOption['pagetype'] = 'banners';
 include __DIR__ . '/mainfile.php';
 
 /**
+ * Get the character maximum length of bannerclient.passwd column.
+ *
+ * @param XoopsMySQLDatabase $xoopsDB
+ * @return int column length, or 0 if unknown
+ */
+function bannerClientPasswdColumnLength($xoopsDB)
+{
+    static $length = null;
+    if ($length !== null) {
+        return $length;
+    }
+    $table  = $xoopsDB->prefix('bannerclient');
+    $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+            . " WHERE `TABLE_SCHEMA` = DATABASE()"
+            . " AND `TABLE_NAME` = " . $xoopsDB->quote($table)
+            . " AND `COLUMN_NAME` = 'passwd' LIMIT 1";
+    $result = $xoopsDB->query($sql);
+    if (!$xoopsDB->isResultSet($result) || !$result instanceof \mysqli_result) {
+        $length = 0;
+        return $length;
+    }
+    $row = $xoopsDB->fetchRow($result);
+    $length = $row ? (int) $row[0] : 0;
+    return $length;
+}
+
+/**
  * Function to let your client login to see the stats
  * @return void
  */
@@ -465,24 +492,30 @@ switch ($op) {
                 // Rehash if algorithm or cost has changed
                 if ($authenticated && password_needs_rehash($storedHash, PASSWORD_DEFAULT)) {
                     $newHash = password_hash($clean_pass, PASSWORD_DEFAULT);
-                    $xoopsDB->exec(sprintf(
-                        'UPDATE %s SET passwd=%s WHERE cid=%u',
-                        $xoopsDB->prefix('bannerclient'),
-                        $xoopsDB->quote($newHash),
-                        (int) $clientId
-                    ));
+                    // Only store if column is wide enough for the hash
+                    if (bannerClientPasswdColumnLength($xoopsDB) >= strlen($newHash)) {
+                        $xoopsDB->exec(sprintf(
+                            'UPDATE %s SET passwd=%s WHERE cid=%u',
+                            $xoopsDB->prefix('bannerclient'),
+                            $xoopsDB->quote($newHash),
+                            (int) $clientId
+                        ));
+                    }
                 }
             } else {
                 // Legacy plaintext password — verify and upgrade
                 if (hash_equals((string) $storedHash, $clean_pass)) {
                     $authenticated = true;
                     $newHash = password_hash($clean_pass, PASSWORD_DEFAULT);
-                    $xoopsDB->exec(sprintf(
-                        'UPDATE %s SET passwd=%s WHERE cid=%u',
-                        $xoopsDB->prefix('bannerclient'),
-                        $xoopsDB->quote($newHash),
-                        (int) $clientId
-                    ));
+                    // Only store if column is wide enough for the hash
+                    if (bannerClientPasswdColumnLength($xoopsDB) >= strlen($newHash)) {
+                        $xoopsDB->exec(sprintf(
+                            'UPDATE %s SET passwd=%s WHERE cid=%u',
+                            $xoopsDB->prefix('bannerclient'),
+                            $xoopsDB->quote($newHash),
+                            (int) $clientId
+                        ));
+                    }
                 }
             }
 
@@ -490,6 +523,7 @@ switch ($op) {
                 redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
             }
 
+            $GLOBALS['sess_handler']->regenerate_id(true);
             $_SESSION['banner_client_id'] = (int) $clientId;
         }
         bannerstats();

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -18,6 +18,7 @@
  * @author              Kris <kris@frxoops.org>
  */
 
+use RuntimeException;
 use Xmf\Request;
 
 $xoopsOption['pagetype'] = 'banners';
@@ -100,16 +101,15 @@ function bannerstats()
 {
     /** @var \XoopsMySQLDatabase $xoopsDB */
     global $xoopsDB, $xoopsConfig, $myts;
-    $banner_login = isset($_SESSION['banner_login']) ? (string) $_SESSION['banner_login'] : '';
-    $banner_pass  = isset($_SESSION['banner_pass']) ? (string) $_SESSION['banner_pass'] : '';
-    if ($banner_login == '' || $banner_pass == '') {
+    $banner_client_id = isset($_SESSION['banner_client_id']) ? (int) $_SESSION['banner_client_id'] : 0;
+    if ($banner_client_id <= 0) {
         redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
     }
-    $sql    = sprintf('SELECT cid, name, passwd FROM %s WHERE login=%s', $xoopsDB->prefix('bannerclient'), $xoopsDB->quote($banner_login));
+    $sql    = sprintf('SELECT cid, name FROM %s WHERE cid=%u', $xoopsDB->prefix('bannerclient'), $banner_client_id);
     $result = $xoopsDB->query($sql);
     if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
-        throw new \RuntimeException(
-            \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
+        throw new RuntimeException(
+            sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
             E_USER_ERROR,
         );
     }
@@ -117,10 +117,9 @@ function bannerstats()
     if (false === $row) {
         redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
     }
-    [$cid, $name, $passwd] = $row;
-    if (hash_equals((string) $passwd, $banner_pass)) {
-        include $GLOBALS['xoops']->path('header.php');
-        $cid = (int) $cid;
+    [$cid, $name] = $row;
+    $cid = (int) $cid;
+    include $GLOBALS['xoops']->path('header.php');
         $GLOBALS['xoTheme']->addStylesheet(null, null, '
             #bannerstats {}
             #bannerstats td {
@@ -128,9 +127,9 @@ function bannerstats()
             }
         ');
         echo "<div id='bannerstats'>
-              <h4 class='content_title'>" . sprintf(_BANNERS_TITLE, $name) . "</h4><hr />
+              <h4 class='content_title'>" . sprintf(_BANNERS_TITLE, htmlspecialchars($name, ENT_QUOTES, 'UTF-8')) . "</h4><hr />
               <table summary=''>
-              <caption>" . sprintf(_BANNERS_TITLE, $name) . '</caption>
+              <caption>" . sprintf(_BANNERS_TITLE, htmlspecialchars($name, ENT_QUOTES, 'UTF-8')) . '</caption>
               <thead><tr>
               <td>ID</td>
               <td>' . _BANNERS_IMP_MADE . '</td>
@@ -144,8 +143,8 @@ function bannerstats()
         $sql = 'SELECT bid, imptotal, impmade, clicks, date FROM ' . $xoopsDB->prefix('banner') . " WHERE cid={$cid}";
         $result = $xoopsDB->query($sql);
         if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            throw new \RuntimeException(
-                \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
+            throw new RuntimeException(
+                sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
                 E_USER_ERROR,
             );
         }
@@ -180,8 +179,8 @@ function bannerstats()
         $sql = 'SELECT bid, imageurl, clickurl, htmlbanner, htmlcode FROM ' . $xoopsDB->prefix('banner') . " WHERE cid={$cid}";
         $result = $xoopsDB->query($sql);
         if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            throw new \RuntimeException(
-                \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
+            throw new RuntimeException(
+                sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
                 E_USER_ERROR,
             );
         }
@@ -228,9 +227,9 @@ function bannerstats()
         $sql    = 'SELECT bid, impressions, clicks, datestart, dateend FROM ' . $xoopsDB->prefix('bannerfinish') . " WHERE cid={$cid}";
         $result = $xoopsDB->query($sql);
         if ($xoopsDB->isResultSet($result)) {
-            echo "<h4 class='content_title'>" . sprintf(_BANNERS_FINISHED, $name) . "</h4><hr />
+            echo "<h4 class='content_title'>" . sprintf(_BANNERS_FINISHED, htmlspecialchars($name, ENT_QUOTES, 'UTF-8')) . "</h4><hr />
                   <table summary=''>
-                  <caption>" . sprintf(_BANNERS_FINISHED, $name) . '</caption>
+                  <caption>" . sprintf(_BANNERS_FINISHED, htmlspecialchars($name, ENT_QUOTES, 'UTF-8')) . '</caption>
                   <thead><tr>
                   <td>ID</td>
                   <td>' . _BANNERS_IMP_MADE . '</td>
@@ -260,9 +259,6 @@ function bannerstats()
             echo '</table></div>';
         }
         include $GLOBALS['xoops']->path('footer.php');
-    } else {
-        redirect_header('banners.php', 2);
-    }
 }
 
 /**
@@ -275,55 +271,55 @@ function emailStats($cid, $bid)
 {
     /** @var \XoopsMySQLDatabase $xoopsDB */
     global $xoopsDB, $xoopsConfig;
-    $banner_login = isset($_SESSION['banner_login']) ? (string) $_SESSION['banner_login'] : '';
-    $banner_pass  = isset($_SESSION['banner_pass']) ? (string) $_SESSION['banner_pass'] : '';
-    if ($banner_login != '' && $banner_pass != '') {
+    $banner_client_id = isset($_SESSION['banner_client_id']) ? (int) $_SESSION['banner_client_id'] : 0;
+    if ($banner_client_id > 0) {
         $cid     = (int) $cid;
         $bid     = (int) $bid;
-        $sql     = sprintf('SELECT name, email, passwd FROM %s WHERE cid=%u AND login=%s', $xoopsDB->prefix('bannerclient'), $cid, $xoopsDB->quote($banner_login));
+        if ($cid !== $banner_client_id) {
+            redirect_header('banners.php', 2);
+        }
+        $sql     = sprintf('SELECT name, email FROM %s WHERE cid=%u', $xoopsDB->prefix('bannerclient'), $cid);
         $result2 = $xoopsDB->query($sql);
         if ($xoopsDB->isResultSet($result2) && $result2 instanceof \mysqli_result) {
             $row = $xoopsDB->fetchRow($result2);
             if (false === $row) {
                 redirect_header('banners.php', 2);
             }
-            [$name, $email, $passwd] = $row;
-            if (hash_equals((string) $passwd, $banner_pass)) {
-                if ($email == '') {
-                    redirect_header('banners.php', 3, sprintf(_BANNERS_MAIL_ERROR, htmlspecialchars($name, ENT_QUOTES | ENT_HTML5, 'UTF-8')));
-                } else {
-                    $sql    = 'SELECT bid, imptotal, impmade, clicks, imageurl, clickurl, date FROM ' . $xoopsDB->prefix('banner') . " WHERE bid={$bid} AND cid={$cid}";
-                    $result = $xoopsDB->query($sql);
-                    if ($xoopsDB->isResultSet($result) && $result instanceof \mysqli_result) {
-                        $row = $xoopsDB->fetchRow($result);
-                        if (false === $row) {
-                            redirect_header('banners.php', 2);
-                        }
-                        [$bid, $imptotal, $impmade, $clicks, $imageurl, $clickurl] = $row;
-                        if ($impmade == 0) {
-                            $percent = 0;
-                        } else {
-                            $percent = substr(100 * $clicks / $impmade, 0, 5);
-                        }
-                        if ($imptotal == 0) {
-                            $left     = _BANNERS_UNLIMITED;
-                            $imptotal = _BANNERS_UNLIMITED;
-                        } else {
-                            $left = $imptotal - $impmade;
-                        }
-                        $fecha       = date('F jS Y, h:iA.');
-                        $subject     = sprintf(_BANNERS_MAIL_SUBJECT, $xoopsConfig['sitename']);
-                        $message     = sprintf(_BANNERS_MAIL_MESSAGE, $xoopsConfig['sitename'], $name, $bid, $imageurl, $clickurl, $imptotal, $impmade, $left, $clicks, $percent, $fecha);
-                        $xoopsMailer = xoops_getMailer();
-                        $xoopsMailer->useMail();
-                        $xoopsMailer->setToEmails($email);
-                        $xoopsMailer->setFromEmail($xoopsConfig['adminmail']);
-                        $xoopsMailer->setFromName($xoopsConfig['sitename']);
-                        $xoopsMailer->setSubject($subject);
-                        $xoopsMailer->setBody($message);
-                        $xoopsMailer->send();
-                        redirect_header('banners.php?op=Ok', 3, _BANNERS_MAIL_OK);
+            [$name, $email] = $row;
+            if ($email == '') {
+                redirect_header('banners.php', 3, sprintf(_BANNERS_MAIL_ERROR, htmlspecialchars($name, ENT_QUOTES | ENT_HTML5, 'UTF-8')));
+            } else {
+                $sql    = 'SELECT bid, imptotal, impmade, clicks, imageurl, clickurl, date FROM ' . $xoopsDB->prefix('banner') . " WHERE bid={$bid} AND cid={$cid}";
+                $result = $xoopsDB->query($sql);
+                if ($xoopsDB->isResultSet($result) && $result instanceof \mysqli_result) {
+                    $row = $xoopsDB->fetchRow($result);
+                    if (false === $row) {
+                        redirect_header('banners.php', 2);
                     }
+                    [$bid, $imptotal, $impmade, $clicks, $imageurl, $clickurl] = $row;
+                    if ($impmade == 0) {
+                        $percent = 0;
+                    } else {
+                        $percent = substr(100 * $clicks / $impmade, 0, 5);
+                    }
+                    if ($imptotal == 0) {
+                        $left     = _BANNERS_UNLIMITED;
+                        $imptotal = _BANNERS_UNLIMITED;
+                    } else {
+                        $left = $imptotal - $impmade;
+                    }
+                    $fecha       = date('F jS Y, h:iA.');
+                    $subject     = sprintf(_BANNERS_MAIL_SUBJECT, $xoopsConfig['sitename']);
+                    $message     = sprintf(_BANNERS_MAIL_MESSAGE, $xoopsConfig['sitename'], $name, $bid, $imageurl, $clickurl, $imptotal, $impmade, $left, $clicks, $percent, $fecha);
+                    $xoopsMailer = xoops_getMailer();
+                    $xoopsMailer->useMail();
+                    $xoopsMailer->setToEmails($email);
+                    $xoopsMailer->setFromEmail($xoopsConfig['adminmail']);
+                    $xoopsMailer->setFromName($xoopsConfig['sitename']);
+                    $xoopsMailer->setSubject($subject);
+                    $xoopsMailer->setBody($message);
+                    $xoopsMailer->send();
+                    redirect_header('banners.php?op=Ok', 3, _BANNERS_MAIL_OK);
                 }
             }
         }
@@ -342,25 +338,16 @@ function change_banner_url_by_client($cid, $bid, $url)
 {
     /** @var \XoopsMySQLDatabase $xoopsDB */
     global $xoopsDB;
-    $banner_login = isset($_SESSION['banner_login']) ? (string) $_SESSION['banner_login'] : '';
-    $banner_pass  = isset($_SESSION['banner_pass']) ? (string) $_SESSION['banner_pass'] : '';
-    if ($banner_login != '' && $banner_pass != '' && $url != '') {
+    $banner_client_id = isset($_SESSION['banner_client_id']) ? (int) $_SESSION['banner_client_id'] : 0;
+    if ($banner_client_id > 0 && $url != '') {
         $cid    = (int) $cid;
         $bid    = (int) $bid;
-        $sql    = sprintf('SELECT passwd FROM %s WHERE cid=%u AND login=%s', $xoopsDB->prefix('bannerclient'), $cid, $xoopsDB->quote($banner_login));
-        $result = $xoopsDB->query($sql);
-        if ($xoopsDB->isResultSet($result) && $result instanceof \mysqli_result) {
-            $row = $xoopsDB->fetchRow($result);
-            if (false === $row) {
-                redirect_header('banners.php', 2);
-            }
-            [$passwd] = $row;
-            if (hash_equals((string) $passwd, $banner_pass)) {
-                $sql = sprintf('UPDATE %s SET clickurl=%s WHERE bid=%u AND cid=%u', $xoopsDB->prefix('banner'), $xoopsDB->quote($url), $bid, $cid);
-                if ($xoopsDB->exec($sql)) {
-                    redirect_header('banners.php?op=Ok', 3, _BANNERS_DBUPDATED);
-                }
-            }
+        if ($cid !== $banner_client_id) {
+            redirect_header('banners.php', 2);
+        }
+        $sql = sprintf('UPDATE %s SET clickurl=%s WHERE bid=%u AND cid=%u', $xoopsDB->prefix('banner'), $xoopsDB->quote($url), $bid, $cid);
+        if ($xoopsDB->exec($sql)) {
+            redirect_header('banners.php?op=Ok', 3, _BANNERS_DBUPDATED);
         }
     }
     redirect_header('banners.php', 2);
@@ -379,8 +366,8 @@ function clickbanner($bid)
         $sql = 'SELECT clickurl FROM ' . $xoopsDB->prefix('banner') . " WHERE bid={$bid}";
         $result = $xoopsDB->query($sql);
         if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            throw new \RuntimeException(
-                \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
+            throw new RuntimeException(
+                sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
                 E_USER_ERROR,
             );
         }
@@ -454,8 +441,56 @@ switch ($op) {
                 redirect_header('banners.php', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
             }
 
-            $_SESSION['banner_login'] = $clean_login;
-            $_SESSION['banner_pass']  = $clean_pass;
+            /** @var \XoopsMySQLDatabase $xoopsDB */
+            $sql = sprintf(
+                'SELECT cid, passwd FROM %s WHERE login=%s',
+                $xoopsDB->prefix('bannerclient'),
+                $xoopsDB->quote($clean_login)
+            );
+            $result = $xoopsDB->query($sql);
+            if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
+                redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
+            }
+            $row = $xoopsDB->fetchRow($result);
+            if (false === $row) {
+                redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
+            }
+            [$clientId, $storedHash] = $row;
+
+            // Verify password: support both bcrypt hashes and legacy plaintext
+            $authenticated = false;
+            if (password_get_info($storedHash)['algo'] !== null) {
+                // Modern hashed password
+                $authenticated = password_verify($clean_pass, $storedHash);
+                // Rehash if algorithm or cost has changed
+                if ($authenticated && password_needs_rehash($storedHash, PASSWORD_DEFAULT)) {
+                    $newHash = password_hash($clean_pass, PASSWORD_DEFAULT);
+                    $xoopsDB->exec(sprintf(
+                        'UPDATE %s SET passwd=%s WHERE cid=%u',
+                        $xoopsDB->prefix('bannerclient'),
+                        $xoopsDB->quote($newHash),
+                        (int) $clientId
+                    ));
+                }
+            } else {
+                // Legacy plaintext password — verify and upgrade
+                if (hash_equals((string) $storedHash, $clean_pass)) {
+                    $authenticated = true;
+                    $newHash = password_hash($clean_pass, PASSWORD_DEFAULT);
+                    $xoopsDB->exec(sprintf(
+                        'UPDATE %s SET passwd=%s WHERE cid=%u',
+                        $xoopsDB->prefix('bannerclient'),
+                        $xoopsDB->quote($newHash),
+                        (int) $clientId
+                    ));
+                }
+            }
+
+            if (!$authenticated) {
+                redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
+            }
+
+            $_SESSION['banner_client_id'] = (int) $clientId;
         }
         bannerstats();
         break;

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -42,7 +42,7 @@ function bannerClientPasswdColumnLength($xoopsDB)
             . " AND `TABLE_NAME` = " . $xoopsDB->quote($table)
             . " AND `COLUMN_NAME` = 'passwd' LIMIT 1";
     $result = $xoopsDB->query($sql);
-    if (!$xoopsDB->isResultSet($result) || !$result instanceof \mysqli_result) {
+    if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
         $length = 0;
         return $length;
     }

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -486,7 +486,8 @@ switch ($op) {
 
             // Verify password: support both bcrypt hashes and legacy plaintext
             $authenticated = false;
-            if (password_get_info($storedHash)['algo'] !== null) {
+            $algo = password_get_info($storedHash)['algo'];
+            if ($algo !== null && $algo !== 0) {
                 // Modern hashed password
                 $authenticated = password_verify($clean_pass, $storedHash);
                 // Rehash if algorithm or cost has changed

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -303,7 +303,7 @@ function emailStats($cid, $bid)
         $cid     = (int) $cid;
         $bid     = (int) $bid;
         if ($cid !== $banner_client_id) {
-            redirect_header('banners.php', 2);
+            redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
         }
         $sql     = sprintf('SELECT name, email FROM %s WHERE cid=%u', $xoopsDB->prefix('bannerclient'), $cid);
         $result2 = $xoopsDB->query($sql);
@@ -370,7 +370,7 @@ function change_banner_url_by_client($cid, $bid, $url)
         $cid    = (int) $cid;
         $bid    = (int) $bid;
         if ($cid !== $banner_client_id) {
-            redirect_header('banners.php', 2);
+            redirect_header('banners.php', 2, _BANNERS_NO_LOGIN_DATA);
         }
         $sql = sprintf('UPDATE %s SET clickurl=%s WHERE bid=%u AND cid=%u', $xoopsDB->prefix('banner'), $xoopsDB->quote($url), $bid, $cid);
         if ($xoopsDB->exec($sql)) {

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -484,23 +484,28 @@ switch ($op) {
             }
             [$clientId, $storedHash] = $row;
 
-            // Verify password: support both bcrypt hashes and legacy plaintext
+            // Verify password: support both bcrypt hashes and legacy plaintext.
+            // All modern password_hash() outputs start with '$' (e.g. $2y$, $argon2).
+            // password_get_info() returns algo=0 (not null) for unrecognized strings,
+            // so checking for '$' prefix is the most reliable detection method.
             $authenticated = false;
-            $algo = password_get_info($storedHash)['algo'];
-            if ($algo !== null && $algo !== 0) {
+            if (str_starts_with((string) $storedHash, '$')) {
                 // Modern hashed password
                 $authenticated = password_verify($clean_pass, $storedHash);
                 // Rehash if algorithm or cost has changed
                 if ($authenticated && password_needs_rehash($storedHash, PASSWORD_DEFAULT)) {
                     $newHash = password_hash($clean_pass, PASSWORD_DEFAULT);
                     // Only store if column is wide enough for the hash
-                    if (bannerClientPasswdColumnLength($xoopsDB) >= strlen($newHash)) {
+                    $colLen = bannerClientPasswdColumnLength($xoopsDB);
+                    if ($colLen >= strlen($newHash)) {
                         $xoopsDB->exec(sprintf(
                             'UPDATE %s SET passwd=%s WHERE cid=%u',
                             $xoopsDB->prefix('bannerclient'),
                             $xoopsDB->quote($newHash),
                             (int) $clientId
                         ));
+                    } else {
+                        trigger_error('bannerclient.passwd column too narrow for password hash; run schema migration', E_USER_WARNING);
                     }
                 }
             } else {
@@ -509,13 +514,16 @@ switch ($op) {
                     $authenticated = true;
                     $newHash = password_hash($clean_pass, PASSWORD_DEFAULT);
                     // Only store if column is wide enough for the hash
-                    if (bannerClientPasswdColumnLength($xoopsDB) >= strlen($newHash)) {
+                    $colLen = bannerClientPasswdColumnLength($xoopsDB);
+                    if ($colLen >= strlen($newHash)) {
                         $xoopsDB->exec(sprintf(
                             'UPDATE %s SET passwd=%s WHERE cid=%u',
                             $xoopsDB->prefix('bannerclient'),
                             $xoopsDB->quote($newHash),
                             (int) $clientId
                         ));
+                    } else {
+                        trigger_error('bannerclient.passwd column too narrow for password hash; run schema migration', E_USER_WARNING);
                     }
                 }
             }

--- a/htdocs/banners.php
+++ b/htdocs/banners.php
@@ -310,7 +310,7 @@ function emailStats($cid, $bid)
         if ($xoopsDB->isResultSet($result2) && $result2 instanceof \mysqli_result) {
             $row = $xoopsDB->fetchRow($result2);
             if (false === $row) {
-                redirect_header('banners.php', 2);
+                redirect_header('banners.php', 2, _BANNERS_REQUEST_INVALID);
             }
             [$name, $email] = $row;
             if ($email == '') {
@@ -321,7 +321,7 @@ function emailStats($cid, $bid)
                 if ($xoopsDB->isResultSet($result) && $result instanceof \mysqli_result) {
                     $row = $xoopsDB->fetchRow($result);
                     if (false === $row) {
-                        redirect_header('banners.php', 2);
+                        redirect_header('banners.php', 2, _BANNERS_REQUEST_INVALID);
                     }
                     [$bid, $imptotal, $impmade, $clicks, $imageurl, $clickurl] = $row;
                     if ($impmade == 0) {
@@ -351,7 +351,7 @@ function emailStats($cid, $bid)
             }
         }
     }
-    redirect_header('banners.php', 2);
+    redirect_header('banners.php', 2, _BANNERS_REQUEST_INVALID);
 }
 
 /**
@@ -377,7 +377,7 @@ function change_banner_url_by_client($cid, $bid, $url)
             redirect_header('banners.php?op=Ok', 3, _BANNERS_DBUPDATED);
         }
     }
-    redirect_header('banners.php', 2);
+    redirect_header('banners.php', 2, _BANNERS_REQUEST_INVALID);
 }
 
 /**

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -58,7 +58,7 @@ CREATE TABLE bannerclient (
   contact varchar(60) NOT NULL default '',
   email varchar(60) NOT NULL default '',
   login varchar(10) NOT NULL default '',
-  passwd varchar(10) NOT NULL default '',
+  passwd varchar(255) NOT NULL default '',
   extrainfo text,
   PRIMARY KEY  (cid),
   KEY login (login)

--- a/htdocs/language/english/banners.php
+++ b/htdocs/language/english/banners.php
@@ -58,5 +58,6 @@ define('_BANNERS_NO_ID', 'No valid ID detected');
 //2.5.12
 
 define('_BANNERS_NO_FLASH', '>Sorry, Flash (.swf) files are no longer supported. Please use a modern video format.');
+define('_BANNERS_REQUEST_INVALID', 'Your request could not be processed. Please log in and try again.');
 
 

--- a/htdocs/modules/system/admin/banners/main.php
+++ b/htdocs/modules/system/admin/banners/main.php
@@ -189,7 +189,26 @@ switch ($op) {
         $obj->setVar('login', Request::getString('login', ''));
         $newPasswd = trim(Request::getString('passwd', ''));
         if ($newPasswd !== '') {
-            $obj->setVar('passwd', password_hash($newPasswd, PASSWORD_DEFAULT));
+            $hashedPasswd = password_hash($newPasswd, PASSWORD_DEFAULT);
+            // Check column width before storing hash to avoid truncation
+            $table  = $xoopsDB->prefix('bannerclient');
+            $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+                    . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                    . " AND `TABLE_NAME` = " . $xoopsDB->quote($table)
+                    . " AND `COLUMN_NAME` = 'passwd' LIMIT 1";
+            $colResult = $xoopsDB->query($sql);
+            $colLen = 0;
+            if ($xoopsDB->isResultSet($colResult) && $colResult instanceof \mysqli_result) {
+                $colRow = $xoopsDB->fetchRow($colResult);
+                $colLen = $colRow ? (int) $colRow[0] : 0;
+            }
+            if ($colLen >= strlen($hashedPasswd)) {
+                $obj->setVar('passwd', $hashedPasswd);
+            } else {
+                redirect_header('admin.php?fct=banners', 5, 'Cannot save hashed password: bannerclient.passwd column is too small. Please run the upgrade from Administration &rarr; System &rarr; Maintenance &rarr; Upgrade first.');
+            }
+        } elseif ($obj->isNew()) {
+            redirect_header('admin.php?fct=banners', 3, 'Password is required for new banner clients.');
         }
         $obj->setVar('extrainfo', Request::getText('extrainfo', ''));
 

--- a/htdocs/modules/system/admin/banners/main.php
+++ b/htdocs/modules/system/admin/banners/main.php
@@ -187,7 +187,10 @@ switch ($op) {
         $obj->setVar('contact', Request::getString('contact', ''));
         $obj->setVar('email', Request::getEmail('email', ''));
         $obj->setVar('login', Request::getString('login', ''));
-        $obj->setVar('passwd ', Request::getString('passwd ', ''));
+        $newPasswd = trim(Request::getString('passwd', ''));
+        if ($newPasswd !== '') {
+            $obj->setVar('passwd', password_hash($newPasswd, PASSWORD_DEFAULT));
+        }
         $obj->setVar('extrainfo', Request::getText('extrainfo', ''));
 
         if ($banner_client_Handler->insert($obj)) {

--- a/htdocs/modules/system/admin/banners/main.php
+++ b/htdocs/modules/system/admin/banners/main.php
@@ -205,10 +205,10 @@ switch ($op) {
             if ($colLen >= strlen($hashedPasswd)) {
                 $obj->setVar('passwd', $hashedPasswd);
             } else {
-                redirect_header('admin.php?fct=banners', 5, 'Cannot save hashed password: bannerclient.passwd column is too small. Please run the upgrade from Administration &rarr; System &rarr; Maintenance &rarr; Upgrade first.');
+                redirect_header('admin.php?fct=banners', 5, _AM_SYSTEM_BANNERS_PASSWD_COL_NARROW);
             }
         } elseif ($obj->isNew()) {
-            redirect_header('admin.php?fct=banners', 3, 'Password is required for new banner clients.');
+            redirect_header('admin.php?fct=banners', 3, _AM_SYSTEM_BANNERS_PASSWD_REQUIRED);
         }
         $obj->setVar('extrainfo', Request::getText('extrainfo', ''));
 

--- a/htdocs/modules/system/class/bannerclient.php
+++ b/htdocs/modules/system/class/bannerclient.php
@@ -75,7 +75,7 @@ class SystemBannerclient extends XoopsObject
         $form->addElement(new XoopsFormText(_AM_SYSTEM_BANNERS_CONTNAMET, 'contact', 50, 255, $this->getVar('contact')));
         $form->addElement(new XoopsFormText(_AM_SYSTEM_BANNERS_CONTMAILT, 'email', 50, 255, $this->getVar('email')));
         $form->addElement(new XoopsFormText(_AM_SYSTEM_BANNERS_CLILOGINT, 'login', 50, 255, $this->getVar('login')));
-        $form->addElement(new XoopsFormText(_AM_SYSTEM_BANNERS_CLIPASST, 'passwd', 50, 255, $this->getVar('passwd')));
+        $form->addElement(new XoopsFormPassword(_AM_SYSTEM_BANNERS_CLIPASST, 'passwd', 50, 255));
 
         $form->addElement(new xoopsFormTextArea(_AM_SYSTEM_BANNERS_EXTINFO, 'extrainfo', $this->getVar('extrainfo'), 5, 50), false);
 

--- a/htdocs/modules/system/language/english/admin/banners.php
+++ b/htdocs/modules/system/language/english/admin/banners.php
@@ -69,6 +69,9 @@ define('_AM_SYSTEM_BANNERS_EXTINFO', 'Extra Info:');
 define('_AM_SYSTEM_BANNERS_CHGCLI', 'Change Client');
 define('_AM_SYSTEM_BANNERS_USEHTML', 'Use HTML code?');
 define('_AM_SYSTEM_BANNERS_CODEHTML', 'Enter HTML code:');
+// Password validation
+define('_AM_SYSTEM_BANNERS_PASSWD_REQUIRED', 'Password is required for new banner clients.');
+define('_AM_SYSTEM_BANNERS_PASSWD_COL_NARROW', 'Cannot save hashed password: bannerclient.passwd column is too small. Please run the upgrade from Administration &rarr; System &rarr; Maintenance &rarr; Upgrade first.');
 // Tips
 define('_AM_SYSTEM_BANNERS_NAV_TIPS', '
 <ul>

--- a/tests/unit/htdocs/BannersSecurityTest.php
+++ b/tests/unit/htdocs/BannersSecurityTest.php
@@ -40,11 +40,16 @@ class BannersSecurityTest extends TestCase
     #[Test]
     public function legacyPlaintextPasswordDetectedAsNonHashed(): void
     {
-        // A plaintext password will have algo = null from password_get_info()
+        // password_get_info() returns null (PHP 8.4+) or 0 (PHP 8.2-8.3)
+        // for unrecognized/plaintext strings — either way, not a valid algo
         $plaintext = 'oldPlainPassword';
         $info = password_get_info($plaintext);
+        $algo = $info['algo'];
 
-        $this->assertNull($info['algo']);
+        $this->assertTrue(
+            $algo === null || $algo === 0,
+            'Expected algo to be null or 0 for plaintext, got: ' . var_export($algo, true)
+        );
     }
 
     #[Test]
@@ -52,8 +57,12 @@ class BannersSecurityTest extends TestCase
     {
         $hash = password_hash('somePass', PASSWORD_DEFAULT);
         $info = password_get_info($hash);
+        $algo = $info['algo'];
 
-        $this->assertNotNull($info['algo']);
+        $this->assertTrue(
+            $algo !== null && $algo !== 0,
+            'Expected algo to be a valid identifier for bcrypt hash'
+        );
     }
 
     #[Test]

--- a/tests/unit/htdocs/BannersSecurityTest.php
+++ b/tests/unit/htdocs/BannersSecurityTest.php
@@ -1,19 +1,32 @@
 <?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
 
-declare(strict_types=1);
-
-use PHPUnit\Framework\Attributes\CoversFunction;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
 
 /**
  * Tests for banner security fixes in htdocs/banners.php.
  *
  * Covers password hashing logic (C-2) and XSS escaping (C-3).
+ *
+ * @category   Test
+ * @package    XOOPS
+ * @author     XOOPS Development Team
+ * @copyright  (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license    GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link       https://xoops.org
  */
-#[CoversFunction('bannerstats')]
-#[CoversFunction('emailStats')]
-#[CoversFunction('change_banner_url_by_client')]
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
 class BannersSecurityTest extends TestCase
 {
     // ---------------------------------------------------------------
@@ -208,7 +221,7 @@ class BannersSecurityTest extends TestCase
         $banner_client_id = (int) $_SESSION['banner_client_id'];
         $cid = 5;
 
-        $this->assertSame($banner_client_id, $cid);
+        $this->assertSame($cid, $banner_client_id);
     }
 
     #[Test]
@@ -218,7 +231,7 @@ class BannersSecurityTest extends TestCase
         $banner_client_id = (int) $_SESSION['banner_client_id'];
         $cid = 99;
 
-        $this->assertNotSame($banner_client_id, $cid);
+        $this->assertNotSame($cid, $banner_client_id);
     }
 
     protected function tearDown(): void

--- a/tests/unit/htdocs/BannersSecurityTest.php
+++ b/tests/unit/htdocs/BannersSecurityTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for banner security fixes in htdocs/banners.php.
+ *
+ * Covers password hashing logic (C-2) and XSS escaping (C-3).
+ */
+#[CoversFunction('bannerstats')]
+#[CoversFunction('emailStats')]
+#[CoversFunction('change_banner_url_by_client')]
+class BannersSecurityTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // C-2: Password hashing — unit tests for the authentication logic
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function passwordHashCreatesVerifiableHash(): void
+    {
+        $plain = 'my$ecretP@ss';
+        $hash  = password_hash($plain, PASSWORD_DEFAULT);
+
+        $this->assertTrue(password_verify($plain, $hash));
+    }
+
+    #[Test]
+    public function passwordVerifyRejectsWrongPassword(): void
+    {
+        $hash = password_hash('correctPassword', PASSWORD_DEFAULT);
+
+        $this->assertFalse(password_verify('wrongPassword', $hash));
+    }
+
+    #[Test]
+    public function legacyPlaintextPasswordDetectedAsNonHashed(): void
+    {
+        // A plaintext password will have algo = null from password_get_info()
+        $plaintext = 'oldPlainPassword';
+        $info = password_get_info($plaintext);
+
+        $this->assertNull($info['algo']);
+    }
+
+    #[Test]
+    public function bcryptHashDetectedAsHashed(): void
+    {
+        $hash = password_hash('somePass', PASSWORD_DEFAULT);
+        $info = password_get_info($hash);
+
+        $this->assertNotNull($info['algo']);
+    }
+
+    #[Test]
+    public function legacyPlaintextMatchUsesHashEquals(): void
+    {
+        // Simulates the backward-compat path: plaintext stored, user provides same
+        $storedPlaintext = 'legacyPass123';
+        $userInput       = 'legacyPass123';
+
+        $this->assertTrue(hash_equals($storedPlaintext, $userInput));
+    }
+
+    #[Test]
+    public function legacyPlaintextMismatchRejects(): void
+    {
+        $storedPlaintext = 'legacyPass123';
+        $userInput       = 'wrongPass';
+
+        $this->assertFalse(hash_equals($storedPlaintext, $userInput));
+    }
+
+    #[Test]
+    public function rehashUpgradesPlaintextToBcrypt(): void
+    {
+        // Simulate the upgrade path: plaintext matches, then rehash
+        $plaintext = 'upgradeMePass';
+        $newHash   = password_hash($plaintext, PASSWORD_DEFAULT);
+
+        // The new hash should verify correctly
+        $this->assertTrue(password_verify($plaintext, $newHash));
+        // And it should now be detected as a proper hash
+        $this->assertNotNull(password_get_info($newHash)['algo']);
+    }
+
+    #[Test]
+    public function passwordNeedsRehashDetectsOutdatedHash(): void
+    {
+        // A hash made with a very low cost should trigger needs_rehash with default cost
+        $hash = password_hash('test', PASSWORD_BCRYPT, ['cost' => 4]);
+
+        $this->assertTrue(password_needs_rehash($hash, PASSWORD_DEFAULT));
+    }
+
+    // ---------------------------------------------------------------
+    // C-2: Session — stores client ID, not raw password
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function sessionStoresClientIdNotPassword(): void
+    {
+        // Simulate what the login handler now does
+        $_SESSION = [];
+        $clientId = 42;
+        $_SESSION['banner_client_id'] = (int) $clientId;
+
+        $this->assertSame(42, $_SESSION['banner_client_id']);
+        $this->assertArrayNotHasKey('banner_pass', $_SESSION);
+    }
+
+    #[Test]
+    public function sessionWithoutClientIdIsRejected(): void
+    {
+        $_SESSION = [];
+        $banner_client_id = isset($_SESSION['banner_client_id']) ? (int) $_SESSION['banner_client_id'] : 0;
+
+        $this->assertSame(0, $banner_client_id);
+        $this->assertFalse($banner_client_id > 0);
+    }
+
+    // ---------------------------------------------------------------
+    // C-3: XSS — $name is escaped in HTML output
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function htmlspecialcharsEscapesXssInBannerName(): void
+    {
+        $maliciousName = '<script>alert("xss")</script>';
+        $escaped = htmlspecialchars($maliciousName, ENT_QUOTES, 'UTF-8');
+
+        $this->assertStringNotContainsString('<script>', $escaped);
+        $this->assertStringContainsString('&lt;script&gt;', $escaped);
+    }
+
+    #[Test]
+    public function htmlspecialcharsEscapesQuotesInBannerName(): void
+    {
+        $nameWithQuotes = 'O\'Malley & "Friends"';
+        $escaped = htmlspecialchars($nameWithQuotes, ENT_QUOTES, 'UTF-8');
+
+        $this->assertStringNotContainsString("'", $escaped);
+        $this->assertStringNotContainsString('"', $escaped);
+        $this->assertStringContainsString('&#039;', $escaped);
+        $this->assertStringContainsString('&quot;', $escaped);
+        $this->assertStringContainsString('&amp;', $escaped);
+    }
+
+    #[Test]
+    public function sprintfWithEscapedNameProducesSafeHtml(): void
+    {
+        // Simulates the pattern: sprintf(_BANNERS_TITLE, htmlspecialchars($name, ENT_QUOTES, 'UTF-8'))
+        $titlePattern = 'Stats for %s';
+        $maliciousName = '<img src=x onerror=alert(1)>';
+        $escaped = htmlspecialchars($maliciousName, ENT_QUOTES, 'UTF-8');
+        $output = sprintf($titlePattern, $escaped);
+
+        $this->assertStringNotContainsString('<img', $output);
+        $this->assertStringContainsString('&lt;img', $output);
+    }
+
+    #[Test]
+    public function cleanNamePassesThroughUnchanged(): void
+    {
+        $cleanName = 'Acme Corp';
+        $escaped = htmlspecialchars($cleanName, ENT_QUOTES, 'UTF-8');
+
+        $this->assertSame('Acme Corp', $escaped);
+    }
+
+    // ---------------------------------------------------------------
+    // C-3: Finished banners also uses escaped name
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function finishedBannersPatternEscapesName(): void
+    {
+        $finishedPattern = 'Finished banners for %s';
+        $maliciousName = '"><script>document.cookie</script>';
+        $escaped = htmlspecialchars($maliciousName, ENT_QUOTES, 'UTF-8');
+        $output = sprintf($finishedPattern, $escaped);
+
+        $this->assertStringNotContainsString('<script>', $output);
+        $this->assertStringNotContainsString('">', $output);
+    }
+
+    // ---------------------------------------------------------------
+    // C-2: Authorization — cid must match session client id
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function cidMustMatchSessionClientId(): void
+    {
+        $_SESSION = ['banner_client_id' => 5];
+        $banner_client_id = (int) $_SESSION['banner_client_id'];
+        $cid = 5;
+
+        $this->assertSame($banner_client_id, $cid);
+    }
+
+    #[Test]
+    public function cidMismatchIsDetected(): void
+    {
+        $_SESSION = ['banner_client_id' => 5];
+        $banner_client_id = (int) $_SESSION['banner_client_id'];
+        $cid = 99;
+
+        $this->assertNotSame($banner_client_id, $cid);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+}

--- a/tests/unit/htdocs/BannersSecurityTest.php
+++ b/tests/unit/htdocs/BannersSecurityTest.php
@@ -53,15 +53,15 @@ class BannersSecurityTest extends TestCase
     #[Test]
     public function legacyPlaintextPasswordDetectedAsNonHashed(): void
     {
-        // password_get_info() returns null (PHP 8.4+) or 0 (PHP 8.2-8.3)
-        // for unrecognized/plaintext strings — either way, not a valid algo
+        // All modern password_hash() outputs start with '$' (e.g. $2y$, $argon2).
+        // Plaintext passwords never start with '$', so str_starts_with is
+        // the most reliable detection — password_get_info() returns algo=0
+        // (not null) for unrecognized strings, which is easy to mishandle.
         $plaintext = 'oldPlainPassword';
-        $info = password_get_info($plaintext);
-        $algo = $info['algo'];
 
-        $this->assertTrue(
-            $algo === null || $algo === 0,
-            'Expected algo to be null or 0 for plaintext, got: ' . var_export($algo, true)
+        $this->assertFalse(
+            str_starts_with($plaintext, '$'),
+            'Plaintext password should not start with $'
         );
     }
 
@@ -69,12 +69,10 @@ class BannersSecurityTest extends TestCase
     public function bcryptHashDetectedAsHashed(): void
     {
         $hash = password_hash('somePass', PASSWORD_DEFAULT);
-        $info = password_get_info($hash);
-        $algo = $info['algo'];
 
         $this->assertTrue(
-            $algo !== null && $algo !== 0,
-            'Expected algo to be a valid identifier for bcrypt hash'
+            str_starts_with($hash, '$'),
+            'Bcrypt hash should start with $'
         );
     }
 
@@ -106,8 +104,8 @@ class BannersSecurityTest extends TestCase
 
         // The new hash should verify correctly
         $this->assertTrue(password_verify($plaintext, $newHash));
-        // And it should now be detected as a proper hash
-        $this->assertNotNull(password_get_info($newHash)['algo']);
+        // And it should now be detected as a proper hash (starts with $)
+        $this->assertTrue(str_starts_with($newHash, '$'));
     }
 
     #[Test]

--- a/upgrade/upd_2.5.11-to-2.5.12/index.php
+++ b/upgrade/upd_2.5.11-to-2.5.12/index.php
@@ -90,7 +90,7 @@ class Upgrade_2512 extends XoopsUpgrade
                 . " WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = " . $GLOBALS['xoopsDB']->quote($table)
                 . " LIMIT 1";
         $result = $GLOBALS['xoopsDB']->query($sql);
-        if (!$GLOBALS['xoopsDB']->isResultSet($result) || !$result instanceof \mysqli_result) {
+        if (!$GLOBALS['xoopsDB']->isResultSet($result) || !($result instanceof \mysqli_result)) {
             return false;
         }
         return (bool)$GLOBALS['xoopsDB']->fetchArray($result);
@@ -141,7 +141,7 @@ class Upgrade_2512 extends XoopsUpgrade
                 . " AND `TABLE_NAME` = " . $GLOBALS['xoopsDB']->quote($table)
                 . " AND `COLUMN_NAME` = 'passwd' LIMIT 1";
         $result = $GLOBALS['xoopsDB']->query($sql);
-        if (!$GLOBALS['xoopsDB']->isResultSet($result) || !$result instanceof \mysqli_result) {
+        if (!$GLOBALS['xoopsDB']->isResultSet($result) || !($result instanceof \mysqli_result)) {
             return false;
         }
         $row = $GLOBALS['xoopsDB']->fetchRow($result);

--- a/upgrade/upd_2.5.11-to-2.5.12/index.php
+++ b/upgrade/upd_2.5.11-to-2.5.12/index.php
@@ -23,6 +23,7 @@ class Upgrade_2512 extends XoopsUpgrade
             'deletepurifier',
             'deletephpmailer',
             'createtokenstable',
+            'widenbannerclientpasswd',
         ];
         $this->usedFiles    = [];
         $this->pathsToCheck = [
@@ -122,6 +123,47 @@ class Upgrade_2512 extends XoopsUpgrade
             $errno = $GLOBALS['xoopsDB']->errno();
             $error = $GLOBALS['xoopsDB']->error();
             $this->logs[] = sprintf('Failed to create tokens table. Error: %s - %s', $errno, $error);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Check if bannerclient.passwd column is wide enough for password hashes.
+     *
+     * @return bool true if column is already wide enough
+     */
+    public function check_widenbannerclientpasswd()
+    {
+        $table  = $GLOBALS['xoopsDB']->prefix('bannerclient');
+        $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $GLOBALS['xoopsDB']->quote($table)
+                . " AND `COLUMN_NAME` = 'passwd' LIMIT 1";
+        $result = $GLOBALS['xoopsDB']->query($sql);
+        if (!$GLOBALS['xoopsDB']->isResultSet($result) || !$result instanceof \mysqli_result) {
+            return false;
+        }
+        $row = $GLOBALS['xoopsDB']->fetchRow($result);
+        return $row && (int) $row[0] >= 255;
+    }
+
+    /**
+     * Widen bannerclient.passwd column to accommodate password hashes.
+     *
+     * @return bool true on success
+     */
+    public function apply_widenbannerclientpasswd()
+    {
+        $table  = $GLOBALS['xoopsDB']->prefix('bannerclient');
+        $sql    = "ALTER TABLE `{$table}` MODIFY `passwd` varchar(255) NOT NULL DEFAULT ''";
+        $result = $GLOBALS['xoopsDB']->exec($sql);
+        if (!$result) {
+            $this->logs[] = sprintf(
+                'Failed to widen bannerclient.passwd column. Error: %s - %s',
+                $GLOBALS['xoopsDB']->errno(),
+                $GLOBALS['xoopsDB']->error()
+            );
             return false;
         }
         return true;


### PR DESCRIPTION
## Summary
- **C-2**: Migrate banner client passwords from plaintext to bcrypt via `password_hash()`/`password_verify()`, with automatic rehash of legacy passwords on login. Session now stores client ID instead of raw password
- **C-3**: Escape `$name` with `htmlspecialchars()` in all HTML output contexts to prevent stored XSS
- **L-3**: Add `use RuntimeException;` import, drop leading backslashes
- **Bonus**: Add IDOR protection — verify requested client ID matches session

## Test plan
- [ ] 17 tests covering password hashing, legacy upgrade path, rehash, session storage, XSS escaping, IDOR checks
- [ ] Manual test: login as banner client with old plaintext password, verify rehash occurs
- [ ] Manual test: verify banner stats page escapes HTML in client names
- [ ] Verify session-based auth works correctly after password migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer login/session flow using client IDs, consistent error handling, and HTML-escaping of client/banner names to prevent XSS.
  * Password handling tightened: no pre-filled passwords, required on create, and conditional updates on modify.

* **New Features**
  * Support for longer password hashes with an automatic upgrade/migration step to widen stored password column.

* **Tests**
  * Added comprehensive security tests covering hashing, migration/rehash, session auth, and XSS prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->