### PR TITLE
Fix null guards, password validation, multi-select reset, prefix sanitization

### DIFF
--- a/htdocs/modules/system/admin/preferences/main.php
+++ b/htdocs/modules/system/admin/preferences/main.php
@@ -432,7 +432,17 @@ switch ($op) {
             for ($i = 0; $i < $count; ++$i) {
                 $config    = $config_handler->getConfig($conf_ids[$i]);
                 $confName  = $config->getVar('conf_name');
-                $new_value = Request::getVar($confName, $config->getVar('conf_value'), 'POST');
+                $formType  = $config->getVar('conf_formtype');
+                // For multi-select form types, when nothing is selected the key
+                // is absent from POST.  Request::getVar() would then fall back
+                // to the old value, silently preserving the previous selection.
+                // Detect this and explicitly set an empty array instead.
+                $multiFormTypes = ['select_multi', 'group_multi', 'user_multi', 'theme_multi'];
+                if (in_array($formType, $multiFormTypes, true) && !Request::hasVar($confName, 'POST')) {
+                    $new_value = [];
+                } else {
+                    $new_value = Request::getVar($confName, $config->getVar('conf_value'), 'POST');
+                }
                 if (is_array($new_value) || $new_value != $config->getVar('conf_value')) {
                     // if language has been changed
                     if (!$lang_updated && $config->getVar('conf_catid') == XOOPS_CONF && $config->getVar('conf_name') === 'language') {

--- a/htdocs/modules/system/admin/smilies/main.php
+++ b/htdocs/modules/system/admin/smilies/main.php
@@ -245,6 +245,9 @@ switch ($op) {
         $smilies_id = Request::getInt('smilies_id', 0);
         if ($smilies_id > 0) {
             $obj = $smilies_Handler->get($smilies_id);
+            if (!is_object($obj)) {
+                redirect_header('admin.php?fct=smilies', 2, _AM_SYSTEM_DBERROR);
+            }
             $old = $obj->getVar('display');
             $obj->setVar('display', !$old);
             if ($smilies_Handler->insert($obj)) {

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -290,12 +290,12 @@ case 'users_save':
             break;
         }
 
-        if ($pass1 != $pass2) {
+        if ($pass1 !== $pass2) {
             xoops_error(_AM_SYSTEM_USERS_STNPDNM);
             break;
         }
 
-        if (mb_strtolower($pass1, 'UTF-8') === mb_strtolower(Request::getString('uname'), 'UTF-8')) {
+        if (mb_strtolower($pass1, 'UTF-8') === mb_strtolower(Request::getString('uname', '', 'POST'), 'UTF-8')) {
             xoops_error(_AM_SYSTEM_USERS_PWDEQUALSUNAME);
             break;
         }

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -281,16 +281,21 @@ case 'users_save':
             break;
         }
 
-        // Password match (if confirm provided)
-        if ('' !== Request::getVar('pass2', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM) &&
-            Request::getVar('password', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM) != Request::getVar('pass2', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM)) {
+        // Password confirmation is required for new users
+        $pass1 = Request::getVar('password', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM);
+        $pass2 = Request::getVar('pass2', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM);
+
+        if ('' === $pass2) {
             xoops_error(_AM_SYSTEM_USERS_STNPDNM);
             break;
         }
 
-        if ('' !== Request::getVar('pass2', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM) &&
-            '' !== Request::getVar('password', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM) &&
-            mb_strtolower(Request::getVar('password', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM), 'UTF-8') === mb_strtolower(Request::getString('uname'), 'UTF-8')) {
+        if ($pass1 != $pass2) {
+            xoops_error(_AM_SYSTEM_USERS_STNPDNM);
+            break;
+        }
+
+        if (mb_strtolower($pass1, 'UTF-8') === mb_strtolower(Request::getString('uname'), 'UTF-8')) {
             xoops_error(_AM_SYSTEM_USERS_PWDEQUALSUNAME);
             break;
         }
@@ -310,9 +315,7 @@ case 'users_save':
         $newuser->setVar('user_aim', Request::getString('user_aim'));
         $newuser->setVar('user_yim', Request::getString('user_yim'));
         $newuser->setVar('user_msnm', Request::getString('user_msnm'));
-        if ('' !== Request::getVar('pass2', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM)) {
-            $newuser->setVar('pass', password_hash(Request::getVar('password', '', 'POST', 'string', Request::MASK_ALLOW_RAW | Request::MASK_NO_TRIM), PASSWORD_DEFAULT));
-        }
+        $newuser->setVar('pass', password_hash($pass1, PASSWORD_DEFAULT));
         $newuser->setVar('timezone_offset', Request::getString('timezone_offset'));
         $newuser->setVar('uorder', Request::getString('uorder'));
         $newuser->setVar('umode', Request::getString('umode'));

--- a/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
+++ b/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
@@ -4,6 +4,18 @@ use Xmf\Request;
 
 const PREFIX_INVALID_CHAR_PATTERN = '/[^0-9A-Za-z_-]/';
 
+/**
+ * Validate a DB prefix: reject (die) if it contains characters outside [A-Za-z0-9_-].
+ * Returns the validated prefix unchanged.
+ */
+function validatePrefix(string $raw): string
+{
+    if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $raw)) {
+        die('wrong prefix');
+    }
+    return $raw;
+}
+
 include XOOPS_ROOT_PATH . '/include/cp_header.php';
 include __DIR__ . '/admin_header.php';
 require_once dirname(__DIR__) . '/class/gtickets.php';
@@ -11,11 +23,8 @@ $db = XoopsDatabaseFactory::getDatabaseConnection();
 
 // COPY TABLES
 if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
-    $new_prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('new_prefix', '', 'POST'));
-    $old_prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('old_prefix', '', 'POST'));
-    if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $new_prefix)) {
-        die('wrong prefix');
-    }
+    $new_prefix = validatePrefix(Request::getString('new_prefix', '', 'POST'));
+    $old_prefix = validatePrefix(Request::getString('old_prefix', '', 'POST'));
 
     // Ticket check
     if (!$xoopsGTicket->check(true, 'protector_admin')) {
@@ -83,10 +92,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DUMP INTO A LOCAL FILE
 } elseif (Request::hasVar('backup', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('prefix', '', 'POST'));
-    if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
-        die('wrong prefix');
-    }
+    $prefix = validatePrefix(Request::getString('prefix', '', 'POST'));
 
     // Ticket check
     if (!$xoopsGTicket->check(true, 'protector_admin')) {
@@ -205,10 +211,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DROP TABLES
 } elseif (Request::hasVar('delete', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('prefix', '', 'POST'));
-    if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
-        die('wrong prefix');
-    }
+    $prefix = validatePrefix(Request::getString('prefix', '', 'POST'));
 
     // Ticket check
     if (!$xoopsGTicket->check(true, 'protector_admin')) {

--- a/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
+++ b/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
@@ -11,8 +11,8 @@ $db = XoopsDatabaseFactory::getDatabaseConnection();
 
 // COPY TABLES
 if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
-    $new_prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('new_prefix', '', 'POST'));
-    $old_prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('old_prefix', '', 'POST'));
+    $new_prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('new_prefix', '', 'POST'));
+    $old_prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('old_prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $new_prefix)) {
         die('wrong prefix');
     }
@@ -83,7 +83,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DUMP INTO A LOCAL FILE
 } elseif (Request::hasVar('backup', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('prefix', '', 'POST'));
+    $prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
         die('wrong prefix');
     }
@@ -205,7 +205,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DROP TABLES
 } elseif (Request::hasVar('delete', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('prefix', '', 'POST'));
+    $prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
         die('wrong prefix');
     }

--- a/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
+++ b/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
@@ -11,8 +11,8 @@ $db = XoopsDatabaseFactory::getDatabaseConnection();
 
 // COPY TABLES
 if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
-    $new_prefix = Request::getString('new_prefix', '', 'POST');
-    $old_prefix = Request::getString('old_prefix', '', 'POST');
+    $new_prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('new_prefix', '', 'POST'));
+    $old_prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('old_prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $new_prefix)) {
         die('wrong prefix');
     }
@@ -83,7 +83,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DUMP INTO A LOCAL FILE
 } elseif (Request::hasVar('backup', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = Request::getString('prefix', '', 'POST');
+    $prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
         die('wrong prefix');
     }
@@ -205,7 +205,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DROP TABLES
 } elseif (Request::hasVar('delete', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = Request::getString('prefix', '', 'POST');
+    $prefix = preg_replace('/[^a-zA-Z0-9_]/', '', Request::getString('prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
         die('wrong prefix');
     }

--- a/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
+++ b/htdocs/xoops_lib/modules/protector/admin/prefix_manager.php
@@ -11,8 +11,8 @@ $db = XoopsDatabaseFactory::getDatabaseConnection();
 
 // COPY TABLES
 if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
-    $new_prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('new_prefix', '', 'POST'));
-    $old_prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('old_prefix', '', 'POST'));
+    $new_prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('new_prefix', '', 'POST'));
+    $old_prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('old_prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $new_prefix)) {
         die('wrong prefix');
     }
@@ -83,7 +83,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DUMP INTO A LOCAL FILE
 } elseif (Request::hasVar('backup', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('prefix', '', 'POST'));
+    $prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
         die('wrong prefix');
     }
@@ -205,7 +205,7 @@ if (Request::hasVar('copy', 'POST') && Request::hasVar('old_prefix', 'POST')) {
 
     // DROP TABLES
 } elseif (Request::hasVar('delete', 'POST') && Request::hasVar('prefix', 'POST')) {
-    $prefix = preg_replace('/[^a-zA-Z0-9_\-]/', '', Request::getString('prefix', '', 'POST'));
+    $prefix = preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', Request::getString('prefix', '', 'POST'));
     if (preg_match(PREFIX_INVALID_CHAR_PATTERN, $prefix)) {
         die('wrong prefix');
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -458,9 +458,13 @@ spl_autoload_register(function ($class) {
         'frameworksmoduleclasses\\' => __DIR__ . '/unit/htdocs/Frameworks/moduleclasses/',
         'frameworkstextsanitizer\\' => __DIR__ . '/unit/htdocs/Frameworks/textsanitizer/',
         'modulessystem\\'       => __DIR__ . '/unit/htdocs/modules/system/',
+        'modulessystem\\admin\\smilies\\'      => __DIR__ . '/unit/htdocs/modules/system/admin/smilies/',
+        'modulessystem\\admin\\users\\'        => __DIR__ . '/unit/htdocs/modules/system/admin/users/',
+        'modulessystem\\admin\\preferences\\'  => __DIR__ . '/unit/htdocs/modules/system/admin/preferences/',
         'modulespm\\'           => __DIR__ . '/unit/htdocs/modules/pm/',
         'modulesprofile\\'      => __DIR__ . '/unit/htdocs/modules/profile/',
         'modulesprotector\\'    => __DIR__ . '/unit/htdocs/modules/protector/',
+        'modulesprotector\\admin\\' => __DIR__ . '/unit/htdocs/modules/protector/admin/',
     ];
     foreach ($map as $prefix => $dir) {
         $len = strlen($prefix);

--- a/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
+++ b/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  *
  * The protector prefix manager previously used getCmd() which lowercases output,
  * but DB table prefixes can contain uppercase letters. The fix uses getString()
- * with manual sanitization via preg_replace('/[^a-zA-Z0-9_\-]/', '', $value).
+ * with manual sanitization via preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', $value).
  */
 class PrefixManagerSanitizationTest extends TestCase
 {
@@ -113,9 +113,9 @@ class PrefixManagerSanitizationTest extends TestCase
         $source = file_get_contents(
             XOOPS_PATH . '/modules/protector/admin/prefix_manager.php'
         );
-        // The file should use preg_replace for sanitization, not getCmd
-        $this->assertStringContainsString("preg_replace('/[^a-zA-Z0-9_\\-]/', ''", $source,
-            'prefix_manager.php must use preg_replace for case-preserving sanitization');
+        // The file should use PREFIX_INVALID_CHAR_PATTERN constant for sanitization, not getCmd
+        $this->assertStringContainsString('preg_replace(PREFIX_INVALID_CHAR_PATTERN,', $source,
+            'prefix_manager.php must use PREFIX_INVALID_CHAR_PATTERN for case-preserving sanitization');
         // Verify getCmd is NOT used for prefix values
         $this->assertStringNotContainsString('getCmd', $source,
             'prefix_manager.php must not use getCmd() which lowercases values');

--- a/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
+++ b/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulesprotector\admin;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for M-3: getCmd() lowercases case-sensitive DB prefix values (prefix_manager.php).
+ *
+ * The protector prefix manager previously used getCmd() which lowercases output,
+ * but DB table prefixes can contain uppercase letters. The fix uses getString()
+ * with manual sanitization via preg_replace('/[^a-zA-Z0-9_]/', '', $value).
+ */
+class PrefixManagerSanitizationTest extends TestCase
+{
+    /**
+     * Apply the same sanitization used in the fixed prefix_manager.php.
+     */
+    private function sanitizePrefix(string $value): string
+    {
+        return preg_replace('/[^a-zA-Z0-9_]/', '', $value);
+    }
+
+    #[Test]
+    public function preservesUppercaseLetters(): void
+    {
+        $this->assertSame('MyPrefix', $this->sanitizePrefix('MyPrefix'));
+    }
+
+    #[Test]
+    public function preservesLowercaseLetters(): void
+    {
+        $this->assertSame('xoops', $this->sanitizePrefix('xoops'));
+    }
+
+    #[Test]
+    public function preservesMixedCase(): void
+    {
+        $this->assertSame('XoOps_Test', $this->sanitizePrefix('XoOps_Test'));
+    }
+
+    #[Test]
+    public function preservesUnderscores(): void
+    {
+        $this->assertSame('my_prefix_2', $this->sanitizePrefix('my_prefix_2'));
+    }
+
+    #[Test]
+    public function preservesNumbers(): void
+    {
+        $this->assertSame('prefix123', $this->sanitizePrefix('prefix123'));
+    }
+
+    #[Test]
+    public function stripsSpecialCharacters(): void
+    {
+        $this->assertSame('prefix', $this->sanitizePrefix('pre!fix'));
+    }
+
+    #[Test]
+    public function stripsSpaces(): void
+    {
+        $this->assertSame('myprefix', $this->sanitizePrefix('my prefix'));
+    }
+
+    #[Test]
+    public function stripsSqlInjectionChars(): void
+    {
+        // Letters and numbers are preserved, but special chars are stripped
+        $this->assertSame('xoopsDROPTABLE', $this->sanitizePrefix("xoops'; DROP TABLE --"));
+    }
+
+    #[Test]
+    public function stripsHyphens(): void
+    {
+        // Note: the sanitization pattern does NOT allow hyphens, unlike
+        // the original PREFIX_INVALID_CHAR_PATTERN which did allow them.
+        // This is intentional — MySQL identifiers should use underscores.
+        $this->assertSame('myprefix', $this->sanitizePrefix('my-prefix'));
+    }
+
+    #[Test]
+    public function emptyStringRemainsEmpty(): void
+    {
+        $this->assertSame('', $this->sanitizePrefix(''));
+    }
+
+    public static function validPrefixProvider(): array
+    {
+        return [
+            'simple lowercase'     => ['xoops', 'xoops'],
+            'with underscore'      => ['xoops_test', 'xoops_test'],
+            'uppercase'            => ['XOOPS', 'XOOPS'],
+            'mixed case'           => ['XoopsDB', 'XoopsDB'],
+            'numbers'              => ['x2prefix3', 'x2prefix3'],
+            'underscore separated' => ['my_Db_prefix', 'my_Db_prefix'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('validPrefixProvider')]
+    public function preservesValidPrefixes(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->sanitizePrefix($input));
+    }
+
+    #[Test]
+    public function sourceFileUsesPregReplaceNotGetCmd(): void
+    {
+        $source = file_get_contents(
+            XOOPS_PATH . '/modules/protector/admin/prefix_manager.php'
+        );
+        // The file should use preg_replace for sanitization, not getCmd
+        $this->assertStringContainsString("preg_replace('/[^a-zA-Z0-9_]/', ''", $source,
+            'prefix_manager.php must use preg_replace for case-preserving sanitization');
+        // Verify getCmd is NOT used for prefix values
+        $this->assertStringNotContainsString('getCmd', $source,
+            'prefix_manager.php must not use getCmd() which lowercases values');
+    }
+
+    #[Test]
+    public function getCmdWouldLowercaseButSanitizeDoesNot(): void
+    {
+        // Demonstrate the problem: strtolower (what getCmd does) vs our fix
+        $input = 'MyPrefix_Test';
+        $getCmdResult = strtolower($input); // what getCmd would do
+        $fixedResult = $this->sanitizePrefix($input);
+
+        $this->assertSame('myprefix_test', $getCmdResult, 'getCmd lowercases');
+        $this->assertSame('MyPrefix_Test', $fixedResult, 'Our fix preserves case');
+        $this->assertNotSame($getCmdResult, $fixedResult, 'Results must differ for mixed case');
+    }
+}

--- a/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
+++ b/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
@@ -9,128 +9,153 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for M-3: getCmd() lowercases case-sensitive DB prefix values (prefix_manager.php).
+ * Tests for M-3: prefix_manager.php prefix validation.
  *
- * The protector prefix manager previously used getCmd() which lowercases output,
- * but DB table prefixes can contain uppercase letters. The fix uses getString()
- * with manual sanitization via preg_replace(PREFIX_INVALID_CHAR_PATTERN, '', $value).
+ * The protector prefix manager validates DB prefix input using
+ * validatePrefix() which rejects (dies) on invalid characters
+ * rather than silently stripping them. This prevents destructive
+ * operations from targeting the wrong table set.
  */
 class PrefixManagerSanitizationTest extends TestCase
 {
+    /** Same pattern used in prefix_manager.php */
+    private const INVALID_CHAR_PATTERN = '/[^0-9A-Za-z_-]/';
+
     /**
-     * Apply the same sanitization used in the fixed prefix_manager.php.
+     * Simulate validatePrefix(): return value if valid, null if it would die.
      */
-    private function sanitizePrefix(string $value): string
+    private function isValidPrefix(string $value): bool
     {
-        return preg_replace('/[^a-zA-Z0-9_\-]/', '', $value);
+        return !preg_match(self::INVALID_CHAR_PATTERN, $value);
     }
 
     #[Test]
-    public function preservesUppercaseLetters(): void
+    public function acceptsUppercaseLetters(): void
     {
-        $this->assertSame('MyPrefix', $this->sanitizePrefix('MyPrefix'));
+        $this->assertTrue($this->isValidPrefix('MyPrefix'));
     }
 
     #[Test]
-    public function preservesLowercaseLetters(): void
+    public function acceptsLowercaseLetters(): void
     {
-        $this->assertSame('xoops', $this->sanitizePrefix('xoops'));
+        $this->assertTrue($this->isValidPrefix('xoops'));
     }
 
     #[Test]
-    public function preservesMixedCase(): void
+    public function acceptsMixedCase(): void
     {
-        $this->assertSame('XoOps_Test', $this->sanitizePrefix('XoOps_Test'));
+        $this->assertTrue($this->isValidPrefix('XoOps_Test'));
     }
 
     #[Test]
-    public function preservesUnderscores(): void
+    public function acceptsUnderscores(): void
     {
-        $this->assertSame('my_prefix_2', $this->sanitizePrefix('my_prefix_2'));
+        $this->assertTrue($this->isValidPrefix('my_prefix_2'));
     }
 
     #[Test]
-    public function preservesNumbers(): void
+    public function acceptsNumbers(): void
     {
-        $this->assertSame('prefix123', $this->sanitizePrefix('prefix123'));
+        $this->assertTrue($this->isValidPrefix('prefix123'));
     }
 
     #[Test]
-    public function stripsSpecialCharacters(): void
+    public function acceptsHyphens(): void
     {
-        $this->assertSame('prefix', $this->sanitizePrefix('pre!fix'));
+        $this->assertTrue($this->isValidPrefix('my-prefix'));
     }
 
     #[Test]
-    public function stripsSpaces(): void
+    public function rejectsSpecialCharacters(): void
     {
-        $this->assertSame('myprefix', $this->sanitizePrefix('my prefix'));
+        $this->assertFalse($this->isValidPrefix('pre!fix'));
     }
 
     #[Test]
-    public function stripsSqlInjectionChars(): void
+    public function rejectsSpaces(): void
     {
-        // Letters, numbers, and hyphens are preserved; other special chars are stripped
-        $this->assertSame('xoopsDROPTABLE--', $this->sanitizePrefix("xoops'; DROP TABLE --"));
+        $this->assertFalse($this->isValidPrefix('my prefix'));
     }
 
     #[Test]
-    public function preservesHyphens(): void
+    public function rejectsSqlInjectionChars(): void
     {
-        // Hyphens are valid in MySQL table prefixes and are allowed by
-        // PREFIX_INVALID_CHAR_PATTERN, so the sanitization must preserve them.
-        $this->assertSame('my-prefix', $this->sanitizePrefix('my-prefix'));
+        $this->assertFalse($this->isValidPrefix("xoops'; DROP TABLE --"));
     }
 
     #[Test]
-    public function emptyStringRemainsEmpty(): void
+    public function acceptsEmptyString(): void
     {
-        $this->assertSame('', $this->sanitizePrefix(''));
+        // Empty prefix is valid at the pattern level (copy action generates a random one)
+        $this->assertTrue($this->isValidPrefix(''));
     }
 
     public static function validPrefixProvider(): array
     {
         return [
-            'simple lowercase'     => ['xoops', 'xoops'],
-            'with underscore'      => ['xoops_test', 'xoops_test'],
-            'uppercase'            => ['XOOPS', 'XOOPS'],
-            'mixed case'           => ['XoopsDB', 'XoopsDB'],
-            'numbers'              => ['x2prefix3', 'x2prefix3'],
-            'underscore separated' => ['my_Db_prefix', 'my_Db_prefix'],
+            'simple lowercase'     => ['xoops'],
+            'with underscore'      => ['xoops_test'],
+            'uppercase'            => ['XOOPS'],
+            'mixed case'           => ['XoopsDB'],
+            'numbers'              => ['x2prefix3'],
+            'underscore separated' => ['my_Db_prefix'],
+            'with hyphens'         => ['my-prefix-2'],
         ];
     }
 
     #[Test]
     #[DataProvider('validPrefixProvider')]
-    public function preservesValidPrefixes(string $input, string $expected): void
+    public function acceptsValidPrefixes(string $input): void
     {
-        $this->assertSame($expected, $this->sanitizePrefix($input));
+        $this->assertTrue($this->isValidPrefix($input));
+    }
+
+    public static function invalidPrefixProvider(): array
+    {
+        return [
+            'exclamation'   => ['prod!old'],
+            'semicolon'     => ["xoops';"],
+            'space'         => ['my prefix'],
+            'dot'           => ['xoops.test'],
+            'at sign'       => ['prefix@db'],
+            'backtick'      => ['prefix`test'],
+        ];
     }
 
     #[Test]
-    public function sourceFileUsesPregReplaceNotGetCmd(): void
+    #[DataProvider('invalidPrefixProvider')]
+    public function rejectsInvalidPrefixes(string $input): void
+    {
+        $this->assertFalse($this->isValidPrefix($input));
+    }
+
+    #[Test]
+    public function sourceFileUsesValidatePrefixNotPregReplace(): void
     {
         $source = file_get_contents(
             XOOPS_PATH . '/modules/protector/admin/prefix_manager.php'
         );
-        // The file should use PREFIX_INVALID_CHAR_PATTERN constant for sanitization, not getCmd
-        $this->assertStringContainsString('preg_replace(PREFIX_INVALID_CHAR_PATTERN,', $source,
-            'prefix_manager.php must use PREFIX_INVALID_CHAR_PATTERN for case-preserving sanitization');
+        $this->assertNotFalse($source, 'Failed to read prefix_manager.php');
+
+        // The file should use validatePrefix() helper, not inline preg_replace for prefix values
+        $this->assertStringContainsString('validatePrefix(', $source,
+            'prefix_manager.php must use validatePrefix() to reject invalid input');
         // Verify getCmd is NOT used for prefix values
         $this->assertStringNotContainsString('getCmd', $source,
             'prefix_manager.php must not use getCmd() which lowercases values');
+        // Verify no inline preg_replace sanitization of prefix values remains
+        $this->assertStringNotContainsString('preg_replace(PREFIX_INVALID_CHAR_PATTERN,', $source,
+            'prefix_manager.php must not silently strip characters — use validatePrefix() to reject');
     }
 
     #[Test]
-    public function getCmdWouldLowercaseButSanitizeDoesNot(): void
+    public function getCmdWouldLowercaseButValidateDoesNot(): void
     {
-        // Demonstrate the problem: strtolower (what getCmd does) vs our fix
+        // Demonstrate the problem: strtolower (what getCmd does) loses case
         $input = 'MyPrefix_Test';
-        $getCmdResult = strtolower($input); // what getCmd would do
-        $fixedResult = $this->sanitizePrefix($input);
+        $getCmdResult = strtolower($input);
 
         $this->assertSame('myprefix_test', $getCmdResult, 'getCmd lowercases');
-        $this->assertSame('MyPrefix_Test', $fixedResult, 'Our fix preserves case');
-        $this->assertNotSame($getCmdResult, $fixedResult, 'Results must differ for mixed case');
+        $this->assertTrue($this->isValidPrefix($input), 'validatePrefix accepts mixed case');
     }
 }

--- a/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
+++ b/tests/unit/htdocs/modules/protector/admin/PrefixManagerSanitizationTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  *
  * The protector prefix manager previously used getCmd() which lowercases output,
  * but DB table prefixes can contain uppercase letters. The fix uses getString()
- * with manual sanitization via preg_replace('/[^a-zA-Z0-9_]/', '', $value).
+ * with manual sanitization via preg_replace('/[^a-zA-Z0-9_\-]/', '', $value).
  */
 class PrefixManagerSanitizationTest extends TestCase
 {
@@ -22,7 +22,7 @@ class PrefixManagerSanitizationTest extends TestCase
      */
     private function sanitizePrefix(string $value): string
     {
-        return preg_replace('/[^a-zA-Z0-9_]/', '', $value);
+        return preg_replace('/[^a-zA-Z0-9_\-]/', '', $value);
     }
 
     #[Test]
@@ -70,17 +70,16 @@ class PrefixManagerSanitizationTest extends TestCase
     #[Test]
     public function stripsSqlInjectionChars(): void
     {
-        // Letters and numbers are preserved, but special chars are stripped
-        $this->assertSame('xoopsDROPTABLE', $this->sanitizePrefix("xoops'; DROP TABLE --"));
+        // Letters, numbers, and hyphens are preserved; other special chars are stripped
+        $this->assertSame('xoopsDROPTABLE--', $this->sanitizePrefix("xoops'; DROP TABLE --"));
     }
 
     #[Test]
-    public function stripsHyphens(): void
+    public function preservesHyphens(): void
     {
-        // Note: the sanitization pattern does NOT allow hyphens, unlike
-        // the original PREFIX_INVALID_CHAR_PATTERN which did allow them.
-        // This is intentional — MySQL identifiers should use underscores.
-        $this->assertSame('myprefix', $this->sanitizePrefix('my-prefix'));
+        // Hyphens are valid in MySQL table prefixes and are allowed by
+        // PREFIX_INVALID_CHAR_PATTERN, so the sanitization must preserve them.
+        $this->assertSame('my-prefix', $this->sanitizePrefix('my-prefix'));
     }
 
     #[Test]
@@ -115,7 +114,7 @@ class PrefixManagerSanitizationTest extends TestCase
             XOOPS_PATH . '/modules/protector/admin/prefix_manager.php'
         );
         // The file should use preg_replace for sanitization, not getCmd
-        $this->assertStringContainsString("preg_replace('/[^a-zA-Z0-9_]/', ''", $source,
+        $this->assertStringContainsString("preg_replace('/[^a-zA-Z0-9_\\-]/', ''", $source,
             'prefix_manager.php must use preg_replace for case-preserving sanitization');
         // Verify getCmd is NOT used for prefix values
         $this->assertStringNotContainsString('getCmd', $source,

--- a/tests/unit/htdocs/modules/system/admin/preferences/PreferencesMultiSelectTest.php
+++ b/tests/unit/htdocs/modules/system/admin/preferences/PreferencesMultiSelectTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulessystem\admin\preferences;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for H-6: Empty multi-select preserves old config value (preferences/main.php).
+ *
+ * When a multi-select form element is submitted with no selections, the
+ * corresponding POST key is absent entirely. Request::getVar() then falls
+ * back to the default (old value), silently preserving the previous selection
+ * instead of clearing it. The fix detects multi-select form types and
+ * explicitly sets an empty array when the POST key is absent.
+ */
+class PreferencesMultiSelectTest extends TestCase
+{
+    /**
+     * Simulate the fixed config save logic for multi-select detection.
+     *
+     * @param string $formType     The conf_formtype value
+     * @param bool   $postKeyExists Whether the POST key exists
+     * @param mixed  $postValue     The POST value (if key exists)
+     * @param mixed  $oldValue      The old config value
+     * @return mixed The resolved new value
+     */
+    private function resolveConfigValue(string $formType, bool $postKeyExists, $postValue, $oldValue)
+    {
+        $multiFormTypes = ['select_multi', 'group_multi', 'user_multi', 'theme_multi'];
+        if (in_array($formType, $multiFormTypes, true) && !$postKeyExists) {
+            return [];
+        }
+        // Simulate Request::getVar() fallback
+        return $postKeyExists ? $postValue : $oldValue;
+    }
+
+    #[Test]
+    public function emptyMultiSelectClearsValue(): void
+    {
+        $result = $this->resolveConfigValue('select_multi', false, null, ['old_val1', 'old_val2']);
+        $this->assertSame([], $result,
+            'Empty multi-select submission must result in empty array, not old values');
+    }
+
+    #[Test]
+    public function emptyGroupMultiClearsValue(): void
+    {
+        $result = $this->resolveConfigValue('group_multi', false, null, [1, 2, 3]);
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function emptyUserMultiClearsValue(): void
+    {
+        $result = $this->resolveConfigValue('user_multi', false, null, [5, 10]);
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function emptyThemeMultiClearsValue(): void
+    {
+        $result = $this->resolveConfigValue('theme_multi', false, null, ['theme1', 'theme2']);
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function populatedMultiSelectUsesPostValue(): void
+    {
+        $result = $this->resolveConfigValue('select_multi', true, ['new_val'], ['old_val']);
+        $this->assertSame(['new_val'], $result,
+            'Multi-select with selections should use POST value');
+    }
+
+    #[Test]
+    public function singleSelectFallsBackToOldValue(): void
+    {
+        // For non-multi types, absent POST key should still fall back to old value
+        $result = $this->resolveConfigValue('select', false, null, 'old_value');
+        $this->assertSame('old_value', $result,
+            'Single select should fall back to old value when POST key is absent');
+    }
+
+    #[Test]
+    public function textboxFallsBackToOldValue(): void
+    {
+        $result = $this->resolveConfigValue('textbox', false, null, 'old_text');
+        $this->assertSame('old_text', $result);
+    }
+
+    #[Test]
+    public function yesnoFallsBackToOldValue(): void
+    {
+        $result = $this->resolveConfigValue('yesno', false, null, '1');
+        $this->assertSame('1', $result);
+    }
+
+    public static function multiFormTypeProvider(): array
+    {
+        return [
+            'select_multi' => ['select_multi'],
+            'group_multi'  => ['group_multi'],
+            'user_multi'   => ['user_multi'],
+            'theme_multi'  => ['theme_multi'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('multiFormTypeProvider')]
+    public function allMultiFormTypesHandledCorrectly(string $formType): void
+    {
+        $result = $this->resolveConfigValue($formType, false, null, ['should_be_cleared']);
+        $this->assertSame([], $result,
+            "$formType with no POST key must yield empty array");
+    }
+
+    #[Test]
+    public function sourceFileContainsMultiSelectFix(): void
+    {
+        $source = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/preferences/main.php');
+        $this->assertStringContainsString('select_multi', $source);
+        $this->assertStringContainsString('group_multi', $source);
+        $this->assertStringContainsString('user_multi', $source);
+        $this->assertStringContainsString('theme_multi', $source);
+        $this->assertStringContainsString(
+            "!Request::hasVar(\$confName, 'POST')",
+            $source,
+            'Save handler must check for absent POST key on multi-select types'
+        );
+    }
+}

--- a/tests/unit/htdocs/modules/system/admin/smilies/SmiliesNullGuardTest.php
+++ b/tests/unit/htdocs/modules/system/admin/smilies/SmiliesNullGuardTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulessystem\admin\smilies;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for H-3: null guards after handler get() calls in smilies/main.php.
+ *
+ * The smilies admin page calls $smilies_Handler->get() in several switch cases.
+ * When get() returns null/false (e.g. invalid ID), the code must not call
+ * methods on null. This test verifies the handler's get() behavior and
+ * that the guard pattern works correctly.
+ */
+class SmiliesNullGuardTest extends TestCase
+{
+    private static bool $loaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::$loaded) {
+            if (!isset($GLOBALS['xoopsLogger'])) {
+                $GLOBALS['xoopsLogger'] = \XoopsLogger::getInstance();
+            }
+            require_once XOOPS_ROOT_PATH . '/modules/system/class/smilies.php';
+            self::$loaded = true;
+        }
+    }
+
+    #[Test]
+    public function handlerGetReturnsNullForInvalidId(): void
+    {
+        /** @var \SystemsmiliesHandler $handler */
+        $handler = new \SystemsmiliesHandler($GLOBALS['xoopsDB']);
+        // get() with an invalid/nonexistent ID should return null (stub DB returns no rows)
+        $result = $handler->get(99999);
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function nullGuardPreventsMethodCallOnNull(): void
+    {
+        /** @var \SystemsmiliesHandler $handler */
+        $handler = new \SystemsmiliesHandler($GLOBALS['xoopsDB']);
+        $obj = $handler->get(99999);
+
+        // This is the guard pattern used in main.php — must not proceed if not object
+        $this->assertFalse(is_object($obj), 'get() for invalid ID must not return an object');
+    }
+
+    #[Test]
+    public function createReturnsValidObject(): void
+    {
+        $handler = new \SystemsmiliesHandler($GLOBALS['xoopsDB']);
+        $obj = $handler->create();
+        $this->assertInstanceOf(\SystemSmilies::class, $obj);
+        $this->assertTrue(is_object($obj));
+    }
+
+    #[Test]
+    public function nullGuardPatternRedirectsForEditCase(): void
+    {
+        // Simulate the edit_smilie guard: if get() returns null, redirect_header is called
+        $handler = new \SystemsmiliesHandler($GLOBALS['xoopsDB']);
+        $obj = $handler->get(99999);
+
+        if (!is_object($obj)) {
+            // This is the path taken in main.php — redirect_header would be called
+            $this->assertFalse(is_object($obj));
+            return;
+        }
+        $this->fail('Should have taken the null guard path');
+    }
+
+    #[Test]
+    public function nullGuardPatternRedirectsForDeleteCase(): void
+    {
+        $handler = new \SystemsmiliesHandler($GLOBALS['xoopsDB']);
+        $obj = $handler->get(99998);
+
+        if (!is_object($obj)) {
+            $this->assertFalse(is_object($obj));
+            return;
+        }
+        $this->fail('Should have taken the null guard path');
+    }
+
+    #[Test]
+    public function nullGuardPatternRedirectsForUpdateDisplayCase(): void
+    {
+        $handler = new \SystemsmiliesHandler($GLOBALS['xoopsDB']);
+        $obj = $handler->get(99997);
+
+        // This is the new guard added for smilies_update_display
+        if (!is_object($obj)) {
+            $this->assertFalse(is_object($obj));
+            return;
+        }
+        $this->fail('Should have taken the null guard path');
+    }
+
+    #[Test]
+    public function sourceFileContainsNullGuardInUpdateDisplay(): void
+    {
+        $source = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/smilies/main.php');
+        // Verify the update_display case has a null guard
+        $pattern = "/case\s+'smilies_update_display'.*?if\s*\(\s*!is_object\s*\(\s*\\\$obj\s*\)\s*\)/s";
+        $this->assertMatchesRegularExpression($pattern, $source,
+            'smilies_update_display case must contain !is_object($obj) guard');
+    }
+}

--- a/tests/unit/htdocs/modules/system/admin/users/UserPasswordValidationTest.php
+++ b/tests/unit/htdocs/modules/system/admin/users/UserPasswordValidationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulessystem\admin\users;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for H-4: Password validation bypass in user admin (users/main.php).
+ *
+ * For new user creation (op=users_add), both pass1 and pass2 must be non-empty
+ * and matching. The old code only checked pass2 as a gate, allowing password
+ * validation to be skipped entirely if pass2 was empty.
+ *
+ * These tests verify the validation logic patterns used in the fixed code.
+ */
+class UserPasswordValidationTest extends TestCase
+{
+    /**
+     * Simulate the password validation logic from the fixed users/main.php.
+     * Returns null on success, or an error constant name on failure.
+     */
+    private function validateNewUserPassword(string $pass1, string $pass2, string $uname): ?string
+    {
+        // This mirrors the fixed logic in main.php for new user creation
+        if ('' === $pass2) {
+            return '_AM_SYSTEM_USERS_STNPDNM';
+        }
+
+        if ($pass1 != $pass2) {
+            return '_AM_SYSTEM_USERS_STNPDNM';
+        }
+
+        if (mb_strtolower($pass1, 'UTF-8') === mb_strtolower($uname, 'UTF-8')) {
+            return '_AM_SYSTEM_USERS_PWDEQUALSUNAME';
+        }
+
+        return null; // success
+    }
+
+    #[Test]
+    public function emptyPass2RejectsNewUser(): void
+    {
+        $result = $this->validateNewUserPassword('secret123', '', 'testuser');
+        $this->assertSame('_AM_SYSTEM_USERS_STNPDNM', $result,
+            'Empty pass2 must be rejected for new user creation');
+    }
+
+    #[Test]
+    public function bothPasswordsEmptyRejectsNewUser(): void
+    {
+        $result = $this->validateNewUserPassword('', '', 'testuser');
+        $this->assertSame('_AM_SYSTEM_USERS_STNPDNM', $result,
+            'Both passwords empty must be rejected');
+    }
+
+    #[Test]
+    public function mismatchedPasswordsRejectsNewUser(): void
+    {
+        $result = $this->validateNewUserPassword('abc123', 'xyz789', 'testuser');
+        $this->assertSame('_AM_SYSTEM_USERS_STNPDNM', $result,
+            'Mismatched passwords must be rejected');
+    }
+
+    #[Test]
+    public function passwordEqualToUsernameRejectsNewUser(): void
+    {
+        $result = $this->validateNewUserPassword('TestUser', 'TestUser', 'testuser');
+        $this->assertSame('_AM_SYSTEM_USERS_PWDEQUALSUNAME', $result,
+            'Password equal to username (case-insensitive) must be rejected');
+    }
+
+    #[Test]
+    public function validMatchingPasswordsAccepted(): void
+    {
+        $result = $this->validateNewUserPassword('Str0ng!Pass', 'Str0ng!Pass', 'admin');
+        $this->assertNull($result, 'Valid matching passwords should be accepted');
+    }
+
+    #[Test]
+    public function pass1EmptyWithPass2FilledRejects(): void
+    {
+        // pass1 is required by the earlier check: !Request::getVar('password', ...)
+        // But even if it gets through, empty pass1 != non-empty pass2
+        $result = $this->validateNewUserPassword('', 'somepassword', 'testuser');
+        $this->assertSame('_AM_SYSTEM_USERS_STNPDNM', $result,
+            'Empty pass1 with filled pass2 must be rejected (mismatch)');
+    }
+
+    #[Test]
+    public function sourceFileRequiresPass2ForNewUser(): void
+    {
+        $source = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/users/main.php');
+        // In the "Add user" section (after the else { // --- Add user --- block),
+        // verify pass2 is required (not just optional gate)
+        $this->assertStringContainsString(
+            "'' === \$pass2",
+            $source,
+            'New user creation must check for empty pass2'
+        );
+    }
+
+    #[Test]
+    public function sourceFileAlwaysHashesPasswordForNewUser(): void
+    {
+        $source = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/users/main.php');
+        // Verify that the new user path unconditionally hashes the password
+        // (no longer gated by pass2 check for the setVar('pass', ...) call)
+        $this->assertStringContainsString(
+            "\$newuser->setVar('pass', password_hash(\$pass1, PASSWORD_DEFAULT))",
+            $source,
+            'New user password must always be hashed (not gated by pass2 check)'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- **H-3**: Add null guard after `get()` in smilies admin `smilies_update_display` case
- **H-4**: Require non-empty matching passwords for new user creation in user admin
- **H-6**: Detect empty multi-select POST submissions and clear config value instead of preserving stale data
- **M-3**: Replace `getCmd()` with `getString()` + regex sanitization in Protector prefix manager to preserve case

## Test plan
- [ ] 46 tests across 4 test files covering null guards, password validation, multi-select handling, prefix sanitization
- [ ] Manual test: create new user with empty password fields — should be rejected
- [ ] Manual test: clear all selections in a multi-select preference — value should reset
- [ ] Manual test: copy tables with mixed-case prefix in Protector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-select preferences now persist empty selections when none are submitted.
  * Smilies admin now guards against invalid retrievals and redirects on error.
  * User creation/update enforces clearer password confirmation, rejects invalid passwords, and consistently hashes new passwords for new accounts.
  * Database prefix handling now validates/sanitizes prefixes (case-preserving; allows letters, numbers, underscore, hyphen).

* **Tests**
  * Added unit tests for multi-select prefs, smilies null-guards, password validation, and prefix sanitization; updated test autoloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->