### PR TITLE
Pin all Request calls to explicit GET/POST hash, fix elvis on zero-valid fields

### DIFF
--- a/htdocs/modules/profile/admin/category.php
+++ b/htdocs/modules/profile/admin/category.php
@@ -89,7 +89,7 @@ switch ($op) {
         break;
 
     case 'delete':
-        $categoryId = Request::getInt('id', 0, 'POST') ?: Request::getInt('id', 0, 'GET');
+        $categoryId = Request::hasVar('id', 'POST') ? Request::getInt('id', 0, 'POST') : Request::getInt('id', 0, 'GET');
         $obj = $handler->get($categoryId);
         if (!$obj) {
             redirect_header('category.php', 3, _TAKINGBACK);

--- a/htdocs/modules/profile/search.php
+++ b/htdocs/modules/profile/search.php
@@ -437,6 +437,9 @@ switch ($op) {
         $criteria->setOrder($order);
 
         $limit = Request::hasVar('limit', 'GET') ? Request::getInt('limit', $limit_default, 'GET') : Request::getInt('limit', $limit_default, 'POST');
+        if ($limit < 1) {
+            $limit = $limit_default;
+        }
         $criteria->setLimit($limit);
 
         $start = Request::hasVar('start', 'GET') ? Request::getInt('start', 0, 'GET') : Request::getInt('start', 0, 'POST');

--- a/htdocs/modules/profile/search.php
+++ b/htdocs/modules/profile/search.php
@@ -22,7 +22,7 @@ use Xmf\Request;
 include __DIR__ . '/header.php';
 
 $limit_default    = 20;
-$op               = Request::getCmd('op', '', 'GET') ?: Request::getCmd('op', 'search', 'POST');
+$op               = Request::hasVar('op', 'GET') ? Request::getCmd('op', 'search', 'GET') : Request::getCmd('op', 'search', 'POST');
 $groups           = $GLOBALS['xoopsUser'] ? $GLOBALS['xoopsUser']->getGroups() : [XOOPS_GROUP_ANONYMOUS];
 $searchable_types = [
     'textbox',
@@ -183,7 +183,7 @@ switch ($op) {
 
         $criteria = new CriteriaCompo(new Criteria('level', 0, '>'));
 
-        $uname = Request::getString('uname', '', 'GET') ?: Request::getString('uname', '', 'POST');
+        $uname = Request::hasVar('uname', 'GET') ? Request::getString('uname', '', 'GET') : Request::getString('uname', '', 'POST');
         $uname_match = Request::hasVar('uname_match', 'GET') ? Request::getInt('uname_match', 0, 'GET') : Request::getInt('uname_match', 0, 'POST');
         if ($uname !== '') {
             $uname = trim($uname);
@@ -237,7 +237,7 @@ switch ($op) {
             // You might render a page or redirect the user based on these results
         }
 
-        $email = Request::getString('email', '', 'GET') ?: Request::getString('email', '', 'POST');
+        $email = Request::hasVar('email', 'GET') ? Request::getString('email', '', 'GET') : Request::getString('email', '', 'POST');
         $email_match = Request::hasVar('email_match', 'GET') ? Request::getInt('email_match', 0, 'GET') : Request::getInt('email_match', 0, 'POST');
         if ($email !== '') {
             $string = $xoopsDB->escape(trim($email));
@@ -268,7 +268,7 @@ switch ($op) {
                 continue;
             }
             $fieldname = $fields[$i]->getVar('field_name');
-            $fieldValues = Request::getArray($fieldname, [], 'GET') ?: Request::getArray($fieldname, [], 'POST');
+            $fieldValues = Request::hasVar($fieldname, 'GET') ? Request::getArray($fieldname, [], 'GET') : Request::getArray($fieldname, [], 'POST');
             if (in_array($fields[$i]->getVar('field_type'), ['select', 'radio', 'timezone'])) {
                 if (empty($fieldValues)) {
                     continue;
@@ -299,8 +299,8 @@ switch ($op) {
                 switch ($fields[$i]->getVar('field_valuetype')) {
                     case XOBJ_DTYPE_OTHER:
                     case XOBJ_DTYPE_INT:
-                        $largerVal  = Request::getString($fieldname . '_larger', '', 'GET') ?: Request::getString($fieldname . '_larger', '', 'POST');
-                        $smallerVal = Request::getString($fieldname . '_smaller', '', 'GET') ?: Request::getString($fieldname . '_smaller', '', 'POST');
+                        $largerVal  = Request::hasVar($fieldname . '_larger', 'GET') ? Request::getString($fieldname . '_larger', '', 'GET') : Request::getString($fieldname . '_larger', '', 'POST');
+                        $smallerVal = Request::hasVar($fieldname . '_smaller', 'GET') ? Request::getString($fieldname . '_smaller', '', 'GET') : Request::getString($fieldname . '_smaller', '', 'POST');
                         switch ($fields[$i]->getVar('field_type')) {
                             case 'date':
                             case 'datetime':
@@ -362,7 +362,7 @@ switch ($op) {
                     case XOBJ_DTYPE_URL:
                     case XOBJ_DTYPE_TXTBOX:
                     case XOBJ_DTYPE_TXTAREA:
-                        $textFieldVal = Request::getString($fieldname, '', 'GET') ?: Request::getString($fieldname, '', 'POST');
+                        $textFieldVal = Request::hasVar($fieldname, 'GET') ? Request::getString($fieldname, '', 'GET') : Request::getString($fieldname, '', 'POST');
                         $textFieldMatch = Request::hasVar($fieldname . '_match', 'GET') ? Request::getInt($fieldname . '_match', 0, 'GET') : Request::getInt($fieldname . '_match', 0, 'POST');
                         if ($textFieldVal !== '') {
                             $value = $xoopsDB->escape(trim($textFieldVal));
@@ -402,7 +402,7 @@ switch ($op) {
 
         // change by zyspec:
         $sortby = 'uname';
-        $sortbyInput = Request::getCmd('sortby', '', 'GET') ?: Request::getCmd('sortby', '', 'POST');
+        $sortbyInput = Request::hasVar('sortby', 'GET') ? Request::getCmd('sortby', '', 'GET') : Request::getCmd('sortby', '', 'POST');
         if ($sortbyInput !== '') {
             switch ($sortbyInput) {
                 case 'name':
@@ -422,7 +422,7 @@ switch ($op) {
         // add search groups , only for Webmasters
         $searchgroups = [];
         if ($GLOBALS['xoopsUser'] && $GLOBALS['xoopsUser']->isAdmin()) {
-            $selgroups = Request::getArray('selgroups', [], 'GET') ?: Request::getArray('selgroups', [], 'POST');
+            $selgroups = Request::hasVar('selgroups', 'GET') ? Request::getArray('selgroups', [], 'GET') : Request::getArray('selgroups', [], 'POST');
             $searchgroups = empty($selgroups) ? [] : array_map('intval', $selgroups);
             foreach ($searchgroups as $group) {
                 $search_url[] = 'selgroups[]=' . $group;
@@ -436,7 +436,7 @@ switch ($op) {
         $order = $orderInt === 0 ? 'ASC' : 'DESC';
         $criteria->setOrder($order);
 
-        $limit = Request::getInt('limit', 0, 'GET') ?: Request::getInt('limit', $limit_default, 'POST');
+        $limit = Request::hasVar('limit', 'GET') ? Request::getInt('limit', $limit_default, 'GET') : Request::getInt('limit', $limit_default, 'POST');
         $criteria->setLimit($limit);
 
         $start = Request::hasVar('start', 'GET') ? Request::getInt('start', 0, 'GET') : Request::getInt('start', 0, 'POST');

--- a/htdocs/modules/system/admin/comments/main.php
+++ b/htdocs/modules/system/admin/comments/main.php
@@ -30,7 +30,7 @@ if (!xoops_getModuleOption('active_comments', 'system')) {
 }
 
 // Get Action type
-$op = Request::getString('op', 'list');
+$op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
 // Define main template
 $GLOBALS['xoopsOption']['template_main'] = 'system_comments.tpl';
 xoops_cp_header();
@@ -79,7 +79,7 @@ if ('list' === $op) {
 switch ($op) {
 
     case 'comments_jump':
-        $com_id = Request::getInt('com_id', 0);
+        $com_id = Request::hasVar('com_id', 'POST') ? Request::getInt('com_id', 0, 'POST') : Request::getInt('com_id', 0, 'GET');
         if ($com_id > 0) {
             $comment = $comment_handler->get($com_id);
             if (is_object($comment)) {
@@ -235,8 +235,8 @@ switch ($op) {
         $xoopsTpl->assign('comments_count', $comments_count);
 
         if ($comments_count > 0) {
-            $comments_start = Request::getInt('comments_start', 0);
-            $comments_limit = Request::getInt('comments_limit', 0);
+            $comments_start = Request::getInt('comments_start', 0, 'GET');
+            $comments_limit = Request::getInt('comments_limit', 0, 'GET');
             if (!in_array($comments_limit, $limit_array)) {
                 $comments_limit = xoops_getModuleOption('comments_pager', 'system');
             }

--- a/htdocs/modules/system/admin/groups/main.php
+++ b/htdocs/modules/system/admin/groups/main.php
@@ -27,7 +27,7 @@ if (!is_object($xoopsUser) || !is_object($xoopsModule) || !$xoopsUser->isAdmin($
 // Parameters
 $nb_group = xoops_getModuleOption('groups_pager', 'system');
 // Get Action type
-$op = Request::getString('op', 'list');
+$op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
 // Get groups handler
 /** @var SystemGroupHandler $groups_Handler */
 $groups_Handler = xoops_getModuleHandler('group', 'system');

--- a/htdocs/modules/system/admin/maintenance/main.php
+++ b/htdocs/modules/system/admin/maintenance/main.php
@@ -28,7 +28,7 @@ if (!xoops_getModuleOption('active_maintenance', 'system')) {
 }
 
 // Get Action type
-$op = Request::getString('op', 'list');
+$op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
 
 // Define main template
 $GLOBALS['xoopsOption']['template_main'] = 'system_maintenance.tpl';
@@ -136,11 +136,11 @@ switch ($op) {
         //Define Breadcrumb and tips
         $xoBreadCrumb->render();
 
-        $session            = Request::getInt('session', 1);
-        $cache              = Request::getArray('cache', []);
-        $tables             = Request::getArray('tables', []);
-        $avatar             = Request::getInt('avatar', 1);
-        $tables_op          = Request::getArray('maintenance', []);
+        $session            = Request::getInt('session', 1, 'POST');
+        $cache              = Request::getArray('cache', [], 'POST');
+        $tables             = Request::getArray('tables', [], 'POST');
+        $avatar             = Request::getInt('avatar', 1, 'POST');
+        $tables_op          = Request::getArray('maintenance', [], 'POST');
         $verif_cache        = false;
         $verif_session      = false;
         $verif_avatar       = false;

--- a/htdocs/modules/system/admin/preferences/main.php
+++ b/htdocs/modules/system/admin/preferences/main.php
@@ -25,9 +25,9 @@ if (!is_object($xoopsUser) || !is_object($xoopsModule) || !$xoopsUser->isAdmin($
 
 // POST config values are fetched on-demand in the 'save' handler using Request::getVar()
 // Get Action type
-$op = Request::getString('op', 'list');
+$op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
 // Setting type
-$confcat_id = Request::getInt('confcat_id', 0);
+$confcat_id = Request::getInt('confcat_id', 0, 'GET');
 
 // Define main template
 $GLOBALS['xoopsOption']['template_main'] = 'system_preferences.tpl';

--- a/htdocs/modules/system/admin/smilies/main.php
+++ b/htdocs/modules/system/admin/smilies/main.php
@@ -32,7 +32,7 @@ $nb_smilies  = xoops_getModuleOption('smilies_pager', 'system');
 $mimetypes   = ['image/gif', 'image/jpeg', 'image/pjpeg', 'image/x-png', 'image/png'];
 $upload_size = 500000;
 // Get Action type
-$op = Request::getString('op', 'list');
+$op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
 // Get smilies handler
 /** @var  SystemsmiliesHandler $smilies_Handler */
 $smilies_Handler = xoops_getModuleHandler('smilies', 'system');
@@ -65,7 +65,7 @@ switch ($op) {
         $xoBreadCrumb->addHelp(system_adminVersion('smilies', 'help'));
         $xoBreadCrumb->render();
         // Get start pager
-        $start = Request::getInt('start', 0);
+        $start = Request::getInt('start', 0, 'GET');
         // Criteria
         $criteria = new CriteriaCompo();
         $criteria->setSort('id');
@@ -156,11 +156,11 @@ switch ($op) {
         }
         // error
         $err = [];
-        $obj->setVar('code', Request::getString('code', ''));
+        $obj->setVar('code', Request::getString('code', '', 'POST'));
 
-        $obj->setVar('emotion', Request::getString('emotion', ''));
-        $obj->setVar('display', Request::getInt('display', 0));
-        if (Request::getString('code', '') == '' || Request::getString('emotion', '') == '') {
+        $obj->setVar('emotion', Request::getString('emotion', '', 'POST'));
+        $obj->setVar('display', Request::getInt('display', 0, 'POST'));
+        if (Request::getString('code', '', 'POST') == '' || Request::getString('emotion', '', 'POST') == '') {
             $err[] = 'the code or description are empty';
         }
 
@@ -242,7 +242,7 @@ switch ($op) {
 
     case 'smilies_update_display':
         // Get smilies id
-        $smilies_id = Request::getInt('smilies_id', 0);
+        $smilies_id = Request::getInt('smilies_id', 0, 'GET');
         if ($smilies_id > 0) {
             $obj = $smilies_Handler->get($smilies_id);
             $old = $obj->getVar('display');

--- a/htdocs/modules/system/admin/smilies/main.php
+++ b/htdocs/modules/system/admin/smilies/main.php
@@ -241,8 +241,8 @@ switch ($op) {
         break;
 
     case 'smilies_update_display':
-        // Get smilies id
-        $smilies_id = Request::getInt('smilies_id', 0, 'GET');
+        // Get smilies id — sent via $.post() from system_setStatus() in admin.js
+        $smilies_id = Request::getInt('smilies_id', 0, 'POST');
         if ($smilies_id > 0) {
             $obj = $smilies_Handler->get($smilies_id);
             $old = $obj->getVar('display');

--- a/htdocs/modules/system/admin/userrank/main.php
+++ b/htdocs/modules/system/admin/userrank/main.php
@@ -241,8 +241,8 @@ switch ($op) {
 
         // Update userrank status
     case 'userrank_update_special':
-        // Get rank id
-        $rank_id = Request::getInt('rank_id', 0, 'GET');
+        // Get rank id — sent via $.post() from system_setStatus() in admin.js
+        $rank_id = Request::getInt('rank_id', 0, 'POST');
         if ($rank_id > 0) {
             $obj = $userrank_Handler->get($rank_id);
             $old = $obj->getVar('rank_special');

--- a/htdocs/modules/system/admin/userrank/main.php
+++ b/htdocs/modules/system/admin/userrank/main.php
@@ -37,7 +37,7 @@ $nb_rank     = xoops_getModuleOption('userranks_pager', 'system');
 $mimetypes   = ['image/gif', 'image/jpeg', 'image/pjpeg', 'image/x-png', 'image/png'];
 $upload_size = 500000;
 // Get Action type
-$op = Request::getString('op', 'list');
+$op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
 // Get userrank handler
 /** @var SystemUserrankHandler $userrank_Handler */
 $userrank_Handler = xoops_getModuleHandler('userrank', 'system');
@@ -69,7 +69,7 @@ switch ($op) {
         $xoBreadCrumb->addTips(_AM_SYSTEM_USERRANK_TIPS);
         $xoBreadCrumb->render();
         // Get start pager
-        $start = Request::getInt('start', 0);
+        $start = Request::getInt('start', 0, 'GET');
         // Criteria
         $criteria = new CriteriaCompo();
         $criteria->setSort('rank_id');
@@ -133,7 +133,7 @@ switch ($op) {
         $xoBreadCrumb->addTips(sprintf(_AM_SYSTEM_USERRANK_TIPS_FORM1, implode(', ', $mimetypes)) . sprintf(_AM_SYSTEM_USERRANK_TIPS_FORM2, $upload_size / 1000));
         $xoBreadCrumb->render();
         // Create form
-        $obj  = $userrank_Handler->get(Request::getInt('rank_id', 0));
+        $obj  = $userrank_Handler->get(Request::getInt('rank_id', 0, 'GET'));
         $form = $obj->getForm();
         // Assign form
         $xoopsTpl->assign('form', $form->render());
@@ -151,10 +151,10 @@ switch ($op) {
         } else {
             $obj = $userrank_Handler->create();
         }
-        $obj->setVar('rank_title', Request::getString('rank_title', ''));
-        $obj->setVar('rank_min', Request::getInt('rank_min', 0));
-        $obj->setVar('rank_max', Request::getInt('rank_max', 0));
-        $obj->setVar('rank_special', Request::getInt('rank_special', 0));
+        $obj->setVar('rank_title', Request::getString('rank_title', '', 'POST'));
+        $obj->setVar('rank_min', Request::getInt('rank_min', 0, 'POST'));
+        $obj->setVar('rank_max', Request::getInt('rank_max', 0, 'POST'));
+        $obj->setVar('rank_special', Request::getInt('rank_special', 0, 'POST'));
         $err = [];
         include_once XOOPS_ROOT_PATH . '/class/uploader.php';
         $uploader_rank_img = new XoopsMediaUploader(XOOPS_UPLOAD_PATH . '/ranks', $mimetypes, $upload_size, null, null);
@@ -242,7 +242,7 @@ switch ($op) {
         // Update userrank status
     case 'userrank_update_special':
         // Get rank id
-        $rank_id = Request::getInt('rank_id', 0);
+        $rank_id = Request::getInt('rank_id', 0, 'GET');
         if ($rank_id > 0) {
             $obj = $userrank_Handler->get($rank_id);
             $old = $obj->getVar('rank_special');

--- a/tests/unit/htdocs/hardening/RequestHashPinningTest.php
+++ b/tests/unit/htdocs/hardening/RequestHashPinningTest.php
@@ -60,6 +60,7 @@ class RequestHashPinningTest extends TestCase
         }
 
         $source = file_get_contents($filePath);
+        self::assertNotFalse($source, "Failed to read file: {$filePath}");
         $lines  = explode("\n", $source);
         $violations = [];
 
@@ -113,6 +114,7 @@ class RequestHashPinningTest extends TestCase
         }
 
         $source = file_get_contents($filePath);
+        self::assertNotFalse($source, "Failed to read file: {$filePath}");
         $lines  = explode("\n", $source);
         $violations = [];
 

--- a/tests/unit/htdocs/hardening/RequestHashPinningTest.php
+++ b/tests/unit/htdocs/hardening/RequestHashPinningTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hardening;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify that all Request::getXxx() calls in hardened files include
+ * an explicit hash argument ('GET' or 'POST'), and that no elvis
+ * operator (?:) is used for dual-source Request calls.
+ */
+class RequestHashPinningTest extends TestCase
+{
+    /**
+     * Regex matching Request::getXxx( start of call.
+     * We then use a balanced-paren parser to extract the full argument list.
+     */
+    private const CALL_START_PATTERN = '/Request::(getString|getInt|getCmd|getWord|getFloat|getArray|getVar|getBool|getEmail|getUrl|getText)\s*\(/';
+
+    /**
+     * Files that have been hardened and must not contain hashless calls.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function hardenedFilesProvider(): array
+    {
+        $base = defined('XOOPS_ROOT_PATH') ? XOOPS_ROOT_PATH : dirname(__DIR__, 4) . '/htdocs';
+
+        return [
+            'edituser.php'                          => [$base . '/edituser.php'],
+            'profile/edituser.php'                  => [$base . '/modules/profile/edituser.php'],
+            'profile/admin/step.php'                => [$base . '/modules/profile/admin/step.php'],
+            'profile/admin/field.php'               => [$base . '/modules/profile/admin/field.php'],
+            'profile/admin/category.php'            => [$base . '/modules/profile/admin/category.php'],
+            'profile/admin/user.php'                => [$base . '/modules/profile/admin/user.php'],
+            'profile/admin/visibility.php'          => [$base . '/modules/profile/admin/visibility.php'],
+            'profile/search.php'                    => [$base . '/modules/profile/search.php'],
+            'system/admin/groups/main.php'          => [$base . '/modules/system/admin/groups/main.php'],
+            'system/admin/comments/main.php'        => [$base . '/modules/system/admin/comments/main.php'],
+            'system/admin/preferences/main.php'     => [$base . '/modules/system/admin/preferences/main.php'],
+            'system/admin/smilies/main.php'         => [$base . '/modules/system/admin/smilies/main.php'],
+            'system/admin/maintenance/main.php'     => [$base . '/modules/system/admin/maintenance/main.php'],
+            'system/admin/userrank/main.php'        => [$base . '/modules/system/admin/userrank/main.php'],
+            'pm/readpmsg.php'                       => [$base . '/modules/pm/readpmsg.php'],
+            'pm/admin/prune.php'                    => [$base . '/modules/pm/admin/prune.php'],
+            'banners.php'                           => [$base . '/banners.php'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('hardenedFilesProvider')]
+    public function noHashlessRequestCalls(string $filePath): void
+    {
+        if (!file_exists($filePath)) {
+            self::markTestSkipped("File not found: {$filePath}");
+        }
+
+        $source = file_get_contents($filePath);
+        $lines  = explode("\n", $source);
+        $violations = [];
+
+        foreach ($lines as $lineNum => $line) {
+            // Skip comments
+            $trimmed = ltrim($line);
+            if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '*') || str_starts_with($trimmed, '/*')) {
+                continue;
+            }
+
+            // Find all Request::getXxx( occurrences and extract balanced args
+            if (preg_match_all(self::CALL_START_PATTERN, $line, $matches, PREG_OFFSET_CAPTURE)) {
+                foreach ($matches[0] as $matchInfo) {
+                    $fullMatch = $matchInfo[0];
+                    $offset    = $matchInfo[1];
+                    // Find the opening paren position
+                    $parenPos = $offset + strlen($fullMatch) - 1;
+                    // Extract balanced argument string
+                    $inner = self::extractBalancedArgs($line, $parenPos);
+                    if ($inner === null) {
+                        continue;
+                    }
+                    $argCount = self::countArguments($inner);
+
+                    // Calls with <= 2 args are missing the hash (3rd arg)
+                    if ($argCount <= 2) {
+                        $callText = substr($line, $offset, strlen($fullMatch) + strlen($inner) + 1);
+                        $violations[] = sprintf('  Line %d: %s', $lineNum + 1, trim($callText));
+                    }
+                }
+            }
+        }
+
+        self::assertEmpty(
+            $violations,
+            sprintf(
+                "Found %d hashless Request::getXxx() call(s) in %s:\n%s",
+                count($violations),
+                basename($filePath),
+                implode("\n", $violations),
+            ),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('hardenedFilesProvider')]
+    public function noElvisOperatorOnDualSourceRequestCalls(string $filePath): void
+    {
+        if (!file_exists($filePath)) {
+            self::markTestSkipped("File not found: {$filePath}");
+        }
+
+        $source = file_get_contents($filePath);
+        $lines  = explode("\n", $source);
+        $violations = [];
+
+        // Pattern: Request::getXxx(...) ?: Request::getXxx(...)
+        $elvisPattern = '/Request::(?:getString|getInt|getCmd|getWord|getFloat|getArray|getVar|getBool|getEmail|getUrl|getText)\s*\([^)]*\)\s*\?:\s*Request::/';
+
+        foreach ($lines as $lineNum => $line) {
+            $trimmed = ltrim($line);
+            if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '*') || str_starts_with($trimmed, '/*')) {
+                continue;
+            }
+
+            if (preg_match($elvisPattern, $line)) {
+                $violations[] = sprintf('  Line %d: %s', $lineNum + 1, trim($line));
+            }
+        }
+
+        self::assertEmpty(
+            $violations,
+            sprintf(
+                "Found %d elvis operator (?:) on dual-source Request calls in %s:\n%s",
+                count($violations),
+                basename($filePath),
+                implode("\n", $violations),
+            ),
+        );
+    }
+
+    /**
+     * Extract the content between balanced parentheses starting at $startPos.
+     * $startPos must point to the opening '('.
+     *
+     * @return string|null The content between parens, or null if unbalanced.
+     */
+    private static function extractBalancedArgs(string $line, int $startPos): ?string
+    {
+        if (!isset($line[$startPos]) || $line[$startPos] !== '(') {
+            return null;
+        }
+        $depth = 0;
+        $len = strlen($line);
+        $inSingleQuote = false;
+        $inDoubleQuote = false;
+
+        for ($i = $startPos; $i < $len; $i++) {
+            $char = $line[$i];
+            if ($inSingleQuote) {
+                if ($char === "'" && $line[$i - 1] !== '\\') {
+                    $inSingleQuote = false;
+                }
+                continue;
+            }
+            if ($inDoubleQuote) {
+                if ($char === '"' && $line[$i - 1] !== '\\') {
+                    $inDoubleQuote = false;
+                }
+                continue;
+            }
+            if ($char === "'") {
+                $inSingleQuote = true;
+            } elseif ($char === '"') {
+                $inDoubleQuote = true;
+            } elseif ($char === '(') {
+                $depth++;
+            } elseif ($char === ')') {
+                $depth--;
+                if ($depth === 0) {
+                    return substr($line, $startPos + 1, $i - $startPos - 1);
+                }
+            }
+        }
+        return null; // unbalanced
+    }
+
+    /**
+     * Count the number of top-level arguments in a function call's argument string.
+     * Handles nested brackets [], parentheses (), and quoted strings.
+     */
+    private static function countArguments(string $inner): int
+    {
+        $inner = trim($inner);
+        if ($inner === '') {
+            return 0;
+        }
+
+        $count = 1;
+        $depth = 0;
+        $inSingleQuote = false;
+        $inDoubleQuote = false;
+        $len = strlen($inner);
+
+        for ($i = 0; $i < $len; $i++) {
+            $char = $inner[$i];
+
+            if ($inSingleQuote) {
+                if ($char === "'" && ($i === 0 || $inner[$i - 1] !== '\\')) {
+                    $inSingleQuote = false;
+                }
+                continue;
+            }
+            if ($inDoubleQuote) {
+                if ($char === '"' && ($i === 0 || $inner[$i - 1] !== '\\')) {
+                    $inDoubleQuote = false;
+                }
+                continue;
+            }
+
+            if ($char === "'") {
+                $inSingleQuote = true;
+            } elseif ($char === '"') {
+                $inDoubleQuote = true;
+            } elseif ($char === '(' || $char === '[') {
+                $depth++;
+            } elseif ($char === ')' || $char === ']') {
+                $depth--;
+            } elseif ($char === ',' && $depth === 0) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}


### PR DESCRIPTION
## Summary
- **H-1**: Pin ~30 hashless `Request::getXxx()` calls to explicit `'GET'` or `'POST'` across 8 files, using dual-source `hasVar` pattern for `op` parameters that can come from either method
- **H-2**: Replace all `?:` elvis operators on zero-valid fields in `profile/search.php` with `hasVar` ternary to prevent `0` being treated as falsy

### Files modified
- `system/admin/groups/main.php`, `comments/main.php`, `preferences/main.php`, `smilies/main.php`, `maintenance/main.php`, `userrank/main.php`
- `profile/admin/category.php`, `profile/search.php`

## Test plan
- [ ] 34 tests scanning all 17 listed files for hashless Request calls and elvis patterns
- [ ] Manual test: admin pages with GET parameters still work (op=edit, pagination)
- [ ] Manual test: form submissions still process correctly via POST
- [ ] Manual test: profile search with 0 values for match type and pagination offset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Stricter HTTP-method-aware request handling across admin pages: inputs are now sourced with explicit POST/GET precedence, tightening when form values are accepted.
  * Search behavior hardened: input validation and safer query execution for username and field-based searches; pagination and sorting inputs validated and normalized.

* **Tests**
  * New unit tests to detect insecure or ambiguous request usage and enforce the new request-handling conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->