### PR TITLE
Harden activation flow: clear actkey after use, verify CSPRNG + hash_equals

### DIFF
--- a/htdocs/kernel/member.php
+++ b/htdocs/kernel/member.php
@@ -691,30 +691,6 @@ class XoopsMemberHandler
         return hash_equals($expected, $actual);
     }
 
-    /**
-     * Generate a secure random token (hex-encoded).
-     * @param int $length Desired token length in HEX characters (4 bits per char). Clamped to [8, 32].
-     * @return string Random token
-     */
-    private function generateSecureToken(int $length = 32): string
-    {
-        $length = max(8, min(128, $length));
-        $bytes  = intdiv($length + 1, 2); // ceil($length/2)
-
-        try {
-            $raw = random_bytes($bytes);
-        } catch (\Throwable $e) {
-            $msg = '[CRITICAL] No CSPRNG available to generate a secure token in ' . __METHOD__;
-            if (class_exists('XoopsLogger')) {
-                \XoopsLogger::getInstance()->handleError(E_USER_ERROR, $msg, __FILE__, __LINE__);
-            } else {
-                error_log($msg);
-            }
-            throw new \RuntimeException('No CSPRNG available to generate a secure token.', 0, $e);
-        }
-
-        return substr(bin2hex($raw), 0, $length);
-    }
 
     /**
      * Check if debug output is allowed

--- a/htdocs/kernel/member.php
+++ b/htdocs/kernel/member.php
@@ -466,9 +466,8 @@ class XoopsMemberHandler
         }
         $user->setVar('level', 1);
 
-        // Generate more secure activation key
-        $actkey = $this->generateSecureToken(8);
-        $user->setVar('actkey', $actkey);
+        // Clear activation key to make the activation link one-time-use
+        $user->setVar('actkey', '');
 
         return $this->userHandler->insert($user, true);
     }

--- a/tests/unit/htdocs/kernel/ActivationHardeningTest.php
+++ b/tests/unit/htdocs/kernel/ActivationHardeningTest.php
@@ -50,13 +50,13 @@ class ActivationHardeningTest extends TestCase
     public function registerPhpUsesCsprngForActkey(): void
     {
         $source = $this->readSource('register.php');
-        $this->assertStringContainsString(
-            "bin2hex(random_bytes(4))",
+        $this->assertMatchesRegularExpression(
+            '/bin2hex\s*\(\s*random_bytes\s*\(\s*4\s*\)\s*\)/',
             $source,
             'htdocs/register.php must use bin2hex(random_bytes(4)) for actkey generation'
         );
-        $this->assertStringNotContainsString(
-            'md5(uniqid(mt_rand',
+        $this->assertDoesNotMatchRegularExpression(
+            '/md5\s*\(\s*uniqid\s*\(\s*mt_rand/',
             $source,
             'htdocs/register.php must not use weak md5(uniqid(mt_rand())) for actkey'
         );
@@ -66,13 +66,13 @@ class ActivationHardeningTest extends TestCase
     public function profileRegisterPhpUsesCsprngForActkey(): void
     {
         $source = $this->readSource('modules/profile/register.php');
-        $this->assertStringContainsString(
-            "bin2hex(random_bytes(4))",
+        $this->assertMatchesRegularExpression(
+            '/bin2hex\s*\(\s*random_bytes\s*\(\s*4\s*\)\s*\)/',
             $source,
             'profile/register.php must use bin2hex(random_bytes(4)) for actkey generation'
         );
-        $this->assertStringNotContainsString(
-            'md5(uniqid(mt_rand',
+        $this->assertDoesNotMatchRegularExpression(
+            '/md5\s*\(\s*uniqid\s*\(\s*mt_rand/',
             $source,
             'profile/register.php must not use weak md5(uniqid(mt_rand())) for actkey'
         );
@@ -82,13 +82,13 @@ class ActivationHardeningTest extends TestCase
     public function profileDeactivatePhpUsesCsprngForActkey(): void
     {
         $source = $this->readSource('modules/profile/admin/deactivate.php');
-        $this->assertStringContainsString(
-            "bin2hex(random_bytes(4))",
+        $this->assertMatchesRegularExpression(
+            '/bin2hex\s*\(\s*random_bytes\s*\(\s*4\s*\)\s*\)/',
             $source,
             'profile/admin/deactivate.php must use bin2hex(random_bytes(4)) for actkey generation'
         );
-        $this->assertStringNotContainsString(
-            'md5(uniqid(mt_rand',
+        $this->assertDoesNotMatchRegularExpression(
+            '/md5\s*\(\s*uniqid\s*\(\s*mt_rand/',
             $source,
             'profile/admin/deactivate.php must not use weak md5(uniqid(mt_rand())) for actkey'
         );
@@ -98,13 +98,13 @@ class ActivationHardeningTest extends TestCase
     public function protectorUsesCsprngForActkey(): void
     {
         $source = $this->readSource('xoops_lib/modules/protector/class/protector.php');
-        $this->assertStringContainsString(
-            "bin2hex(random_bytes(4))",
+        $this->assertMatchesRegularExpression(
+            '/bin2hex\s*\(\s*random_bytes\s*\(\s*4\s*\)\s*\)/',
             $source,
             'protector.php must use bin2hex(random_bytes(4)) for actkey generation'
         );
-        $this->assertStringNotContainsString(
-            'md5(uniqid(mt_rand',
+        $this->assertDoesNotMatchRegularExpression(
+            '/md5\s*\(\s*uniqid\s*\(\s*mt_rand/',
             $source,
             'protector.php must not use weak md5(uniqid(mt_rand())) for actkey'
         );
@@ -131,8 +131,8 @@ class ActivationHardeningTest extends TestCase
     public function registerPhpUsesHashEqualsForActkeyComparison(): void
     {
         $source = $this->readSource('register.php');
-        $this->assertStringContainsString(
-            'hash_equals(',
+        $this->assertMatchesRegularExpression(
+            '/hash_equals\s*\(/',
             $source,
             'htdocs/register.php must use hash_equals() for actkey comparison'
         );
@@ -148,8 +148,8 @@ class ActivationHardeningTest extends TestCase
     public function profileActivatePhpUsesHashEqualsForActkeyComparison(): void
     {
         $source = $this->readSource('modules/profile/activate.php');
-        $this->assertStringContainsString(
-            'hash_equals(',
+        $this->assertMatchesRegularExpression(
+            '/hash_equals\s*\(/',
             $source,
             'profile/activate.php must use hash_equals() for actkey comparison'
         );
@@ -263,37 +263,16 @@ class ActivationHardeningTest extends TestCase
     {
         $source = $this->readSource('modules/profile/include/forms.php');
 
-        // Every unserialize call must include allowed_classes => false
-        // Find lines containing unserialize
-        $lines = explode("\n", $source);
-        $unserializeLines = array_filter($lines, static function ($line) {
-            return str_contains($line, 'unserialize(');
-        });
-
-        $this->assertNotEmpty($unserializeLines, 'Should find unserialize() calls in profile forms.php');
-
-        foreach ($unserializeLines as $lineNum => $line) {
-            $this->assertStringContainsString(
-                "'allowed_classes' => false",
-                $line,
-                'Line ' . ($lineNum + 1) . ": unserialize() must include ['allowed_classes' => false]: " . trim($line)
-            );
-        }
-    }
-
-    #[Test]
-    public function profileFormsPhpHasNoUnrestrictedUnserialize(): void
-    {
-        $source = $this->readSource('modules/profile/include/forms.php');
-
-        // Count unserialize calls vs calls with allowed_classes
+        // Count unserialize calls vs calls with allowed_classes (whitespace-tolerant)
         preg_match_all('/\bunserialize\s*\(/', $source, $allCalls);
-        preg_match_all('/\bunserialize\s*\([^;]*allowed_classes/', $source, $safeCalls);
+        $this->assertNotEmpty($allCalls[0], 'Should find unserialize() calls in profile forms.php');
+
+        preg_match_all('/\bunserialize\s*\([^;]*allowed_classes\s*[\'"]?\s*=>\s*false/', $source, $safeCalls);
 
         $this->assertSame(
             count($allCalls[0]),
             count($safeCalls[0]),
-            'All unserialize() calls must have allowed_classes restriction'
+            'All unserialize() calls must have allowed_classes => false restriction'
         );
     }
 }

--- a/tests/unit/htdocs/kernel/ActivationHardeningTest.php
+++ b/tests/unit/htdocs/kernel/ActivationHardeningTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use XoopsMemberHandler;
+use XoopsMySQLDatabase;
+use XoopsUser;
+use XoopsUserHandler;
+use ReflectionClass;
+
+/**
+ * Tests for activation flow security hardening:
+ * - CSPRNG token generation (bin2hex(random_bytes(4)))
+ * - Timing-safe token comparison (hash_equals)
+ * - One-time-use actkey (cleared after activation)
+ * - Restricted unserialize in profile forms
+ */
+#[CoversClass(XoopsMemberHandler::class)]
+class ActivationHardeningTest extends TestCase
+{
+    private string $htdocsPath;
+
+    protected function setUp(): void
+    {
+        $this->htdocsPath = XOOPS_ROOT_PATH;
+    }
+
+    /**
+     * Helper: read file contents from htdocs path
+     */
+    private function readSource(string $relativePath): string
+    {
+        $fullPath = $this->htdocsPath . '/' . ltrim($relativePath, '/');
+        $this->assertFileExists($fullPath, "Source file not found: {$fullPath}");
+        return file_get_contents($fullPath);
+    }
+
+    // ---------------------------------------------------------------
+    // C-0a: Token generation uses CSPRNG (bin2hex(random_bytes(...)))
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function registerPhpUsesCsprngForActkey(): void
+    {
+        $source = $this->readSource('register.php');
+        $this->assertStringContainsString(
+            "bin2hex(random_bytes(4))",
+            $source,
+            'htdocs/register.php must use bin2hex(random_bytes(4)) for actkey generation'
+        );
+        $this->assertStringNotContainsString(
+            'md5(uniqid(mt_rand',
+            $source,
+            'htdocs/register.php must not use weak md5(uniqid(mt_rand())) for actkey'
+        );
+    }
+
+    #[Test]
+    public function profileRegisterPhpUsesCsprngForActkey(): void
+    {
+        $source = $this->readSource('modules/profile/register.php');
+        $this->assertStringContainsString(
+            "bin2hex(random_bytes(4))",
+            $source,
+            'profile/register.php must use bin2hex(random_bytes(4)) for actkey generation'
+        );
+        $this->assertStringNotContainsString(
+            'md5(uniqid(mt_rand',
+            $source,
+            'profile/register.php must not use weak md5(uniqid(mt_rand())) for actkey'
+        );
+    }
+
+    #[Test]
+    public function profileDeactivatePhpUsesCsprngForActkey(): void
+    {
+        $source = $this->readSource('modules/profile/admin/deactivate.php');
+        $this->assertStringContainsString(
+            "bin2hex(random_bytes(4))",
+            $source,
+            'profile/admin/deactivate.php must use bin2hex(random_bytes(4)) for actkey generation'
+        );
+        $this->assertStringNotContainsString(
+            'md5(uniqid(mt_rand',
+            $source,
+            'profile/admin/deactivate.php must not use weak md5(uniqid(mt_rand())) for actkey'
+        );
+    }
+
+    #[Test]
+    public function protectorUsesCsprngForActkey(): void
+    {
+        $source = $this->readSource('xoops_lib/modules/protector/class/protector.php');
+        $this->assertStringContainsString(
+            "bin2hex(random_bytes(4))",
+            $source,
+            'protector.php must use bin2hex(random_bytes(4)) for actkey generation'
+        );
+        $this->assertStringNotContainsString(
+            'md5(uniqid(mt_rand',
+            $source,
+            'protector.php must not use weak md5(uniqid(mt_rand())) for actkey'
+        );
+    }
+
+    #[Test]
+    public function generatedActkeyIsEightHexChars(): void
+    {
+        // Verify the CSPRNG output format: bin2hex(random_bytes(4)) = 8 hex chars
+        $actkey = bin2hex(random_bytes(4));
+        $this->assertSame(8, strlen($actkey), 'Activation key must be 8 characters');
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}$/',
+            $actkey,
+            'Activation key must consist of lowercase hex characters'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // C-0b: Token comparison uses hash_equals (timing-safe)
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function registerPhpUsesHashEqualsForActkeyComparison(): void
+    {
+        $source = $this->readSource('register.php');
+        $this->assertStringContainsString(
+            'hash_equals(',
+            $source,
+            'htdocs/register.php must use hash_equals() for actkey comparison'
+        );
+        // Ensure there is no loose != comparison for actkey
+        $this->assertDoesNotMatchRegularExpression(
+            '/getVar\s*\(\s*[\'"]actkey[\'"]\s*\)\s*!=\s*\$actkey/',
+            $source,
+            'htdocs/register.php must not use loose != for actkey comparison'
+        );
+    }
+
+    #[Test]
+    public function profileActivatePhpUsesHashEqualsForActkeyComparison(): void
+    {
+        $source = $this->readSource('modules/profile/activate.php');
+        $this->assertStringContainsString(
+            'hash_equals(',
+            $source,
+            'profile/activate.php must use hash_equals() for actkey comparison'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/getVar\s*\(\s*[\'"]actkey[\'"]\s*\)\s*!=\s*\$actkey/',
+            $source,
+            'profile/activate.php must not use loose != for actkey comparison'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // C-0c: One-time-use — actkey cleared after activation
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function activateUserClearsActkey(): void
+    {
+        $source = $this->readSource('kernel/member.php');
+
+        // Find the activateUser method and verify it clears actkey
+        $this->assertMatchesRegularExpression(
+            '/function\s+activateUser\b.*?setVar\s*\(\s*[\'"]actkey[\'"]\s*,\s*[\'"][\'"]\s*\)/s',
+            $source,
+            'activateUser() must clear actkey by setting it to empty string'
+        );
+    }
+
+    #[Test]
+    public function activateUserDoesNotGenerateNewToken(): void
+    {
+        $source = $this->readSource('kernel/member.php');
+
+        // Extract the activateUser method body
+        preg_match('/function\s+activateUser\b[^{]*\{(.*?)^\s{4}\}/ms', $source, $matches);
+        $this->assertNotEmpty($matches, 'Could not find activateUser method');
+
+        $methodBody = $matches[1];
+
+        // It should NOT generate a new token
+        $this->assertStringNotContainsString(
+            'generateSecureToken',
+            $methodBody,
+            'activateUser() should not generate a new token; it should clear actkey'
+        );
+    }
+
+    #[Test]
+    public function activateUserSetsActkeyToEmptyViaUnit(): void
+    {
+        // Load the member handler and dependencies
+        require_once XOOPS_ROOT_PATH . '/kernel/user.php';
+        require_once XOOPS_ROOT_PATH . '/kernel/group.php';
+        require_once XOOPS_ROOT_PATH . '/kernel/member.php';
+
+        $db = $this->createMock(XoopsMySQLDatabase::class);
+
+        $handler = (new ReflectionClass(XoopsMemberHandler::class))
+            ->newInstanceWithoutConstructor();
+
+        // Inject the mock DB
+        $ref = new ReflectionClass($handler);
+        $current = $ref;
+        while ($current) {
+            if ($current->hasProperty('db')) {
+                $prop = $current->getProperty('db');
+                $prop->setAccessible(true);
+                $prop->setValue($handler, $db);
+                break;
+            }
+            $current = $current->getParentClass();
+        }
+
+        // Create mock user handler
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->method('insert')->willReturn(true);
+
+        // Inject userHandler via reflection
+        $userHandlerProp = $ref->getProperty('userHandler');
+        $userHandlerProp->setAccessible(true);
+        $userHandlerProp->setValue($handler, $userHandler);
+
+        // Create a user with level=0 and a non-empty actkey
+        $user = new XoopsUser();
+        $user->setVar('level', 0);
+        $user->setVar('actkey', 'abc12345');
+
+        $result = $handler->activateUser($user);
+
+        $this->assertTrue($result, 'activateUser should return true on success');
+        $this->assertSame(1, (int) $user->getVar('level'), 'User level should be set to 1');
+        $this->assertSame('', $user->getVar('actkey'), 'actkey must be cleared (empty string) after activation');
+    }
+
+    // ---------------------------------------------------------------
+    // M-8: unserialize() uses allowed_classes restriction
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function profileFormsPhpUsesRestrictedUnserialize(): void
+    {
+        $source = $this->readSource('modules/profile/include/forms.php');
+
+        // Every unserialize call must include allowed_classes => false
+        // Find lines containing unserialize
+        $lines = explode("\n", $source);
+        $unserializeLines = array_filter($lines, static function ($line) {
+            return str_contains($line, 'unserialize(');
+        });
+
+        $this->assertNotEmpty($unserializeLines, 'Should find unserialize() calls in profile forms.php');
+
+        foreach ($unserializeLines as $lineNum => $line) {
+            $this->assertStringContainsString(
+                "'allowed_classes' => false",
+                $line,
+                "Line {$lineNum}: unserialize() must include ['allowed_classes' => false]: " . trim($line)
+            );
+        }
+    }
+
+    #[Test]
+    public function profileFormsPhpHasNoUnrestrictedUnserialize(): void
+    {
+        $source = $this->readSource('modules/profile/include/forms.php');
+
+        // Count unserialize calls vs calls with allowed_classes
+        preg_match_all('/\bunserialize\s*\(/', $source, $allCalls);
+        preg_match_all('/\bunserialize\s*\([^;]*allowed_classes/', $source, $safeCalls);
+
+        $this->assertSame(
+            count($allCalls[0]),
+            count($safeCalls[0]),
+            'All unserialize() calls must have allowed_classes restriction'
+        );
+    }
+}

--- a/tests/unit/htdocs/kernel/ActivationHardeningTest.php
+++ b/tests/unit/htdocs/kernel/ActivationHardeningTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use XoopsMemberHandler;
-use XoopsMySQLDatabase;
 use XoopsUser;
 use XoopsUserHandler;
 use ReflectionClass;
@@ -37,7 +36,10 @@ class ActivationHardeningTest extends TestCase
     {
         $fullPath = $this->htdocsPath . '/' . ltrim($relativePath, '/');
         $this->assertFileExists($fullPath, "Source file not found: {$fullPath}");
-        return file_get_contents($fullPath);
+        $contents = file_get_contents($fullPath);
+        $this->assertNotFalse($contents, 'Failed to read source file: ' . basename($fullPath));
+
+        return $contents;
     }
 
     // ---------------------------------------------------------------
@@ -180,11 +182,32 @@ class ActivationHardeningTest extends TestCase
     {
         $source = $this->readSource('kernel/member.php');
 
-        // Extract the activateUser method body
-        preg_match('/function\s+activateUser\b[^{]*\{(.*?)^\s{4}\}/ms', $source, $matches);
-        $this->assertNotEmpty($matches, 'Could not find activateUser method');
+        // Extract the activateUser method body using brace balancing
+        $functionPos = strpos($source, 'function activateUser');
+        $this->assertNotFalse($functionPos, 'Could not find activateUser function declaration');
 
-        $methodBody = $matches[1];
+        $openBracePos = strpos($source, '{', (int) $functionPos);
+        $this->assertNotFalse($openBracePos, 'Could not find opening brace for activateUser method');
+
+        $length = strlen($source);
+        $depth = 0;
+        $endBracePos = null;
+
+        for ($i = (int) $openBracePos; $i < $length; $i++) {
+            if ($source[$i] === '{') {
+                $depth++;
+            } elseif ($source[$i] === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    $endBracePos = $i;
+                    break;
+                }
+            }
+        }
+
+        $this->assertNotNull($endBracePos, 'Could not find matching closing brace for activateUser method');
+
+        $methodBody = substr($source, (int) $openBracePos + 1, (int) $endBracePos - (int) $openBracePos - 1);
 
         // It should NOT generate a new token
         $this->assertStringNotContainsString(
@@ -202,37 +225,27 @@ class ActivationHardeningTest extends TestCase
         require_once XOOPS_ROOT_PATH . '/kernel/group.php';
         require_once XOOPS_ROOT_PATH . '/kernel/member.php';
 
-        $db = $this->createMock(XoopsMySQLDatabase::class);
-
         $handler = (new ReflectionClass(XoopsMemberHandler::class))
             ->newInstanceWithoutConstructor();
 
-        // Inject the mock DB
         $ref = new ReflectionClass($handler);
-        $current = $ref;
-        while ($current) {
-            if ($current->hasProperty('db')) {
-                $prop = $current->getProperty('db');
-                $prop->setAccessible(true);
-                $prop->setValue($handler, $db);
-                break;
-            }
-            $current = $current->getParentClass();
-        }
-
-        // Create mock user handler
-        $userHandler = $this->createMock(XoopsUserHandler::class);
-        $userHandler->method('insert')->willReturn(true);
-
-        // Inject userHandler via reflection
-        $userHandlerProp = $ref->getProperty('userHandler');
-        $userHandlerProp->setAccessible(true);
-        $userHandlerProp->setValue($handler, $userHandler);
 
         // Create a user with level=0 and a non-empty actkey
         $user = new XoopsUser();
         $user->setVar('level', 0);
         $user->setVar('actkey', 'abc12345');
+
+        // Create mock user handler and assert insert is called with force=true
+        $userHandler = $this->createMock(XoopsUserHandler::class);
+        $userHandler->expects($this->once())
+            ->method('insert')
+            ->with($user, true)
+            ->willReturn(true);
+
+        // Inject userHandler via reflection
+        $userHandlerProp = $ref->getProperty('userHandler');
+        $userHandlerProp->setAccessible(true);
+        $userHandlerProp->setValue($handler, $userHandler);
 
         $result = $handler->activateUser($user);
 
@@ -263,7 +276,7 @@ class ActivationHardeningTest extends TestCase
             $this->assertStringContainsString(
                 "'allowed_classes' => false",
                 $line,
-                "Line {$lineNum}: unserialize() must include ['allowed_classes' => false]: " . trim($line)
+                'Line ' . ($lineNum + 1) . ": unserialize() must include ['allowed_classes' => false]: " . trim($line)
             );
         }
     }

--- a/tests/unit/htdocs/kernel/ActivationHardeningTest.php
+++ b/tests/unit/htdocs/kernel/ActivationHardeningTest.php
@@ -209,11 +209,21 @@ class ActivationHardeningTest extends TestCase
 
         $methodBody = substr($source, (int) $openBracePos + 1, (int) $endBracePos - (int) $openBracePos - 1);
 
-        // It should NOT generate a new token
+        // It should NOT generate a new token (neither via helper nor direct CSPRNG)
         $this->assertStringNotContainsString(
             'generateSecureToken',
             $methodBody,
             'activateUser() should not generate a new token; it should clear actkey'
+        );
+        $this->assertStringNotContainsString(
+            'random_bytes',
+            $methodBody,
+            'activateUser() must not regenerate activation tokens via random_bytes()'
+        );
+        $this->assertStringNotContainsString(
+            'bin2hex',
+            $methodBody,
+            'activateUser() must not regenerate activation tokens via bin2hex()'
         );
     }
 

--- a/tests/unit/htdocs/kernel/ActivationHardeningTest.php
+++ b/tests/unit/htdocs/kernel/ActivationHardeningTest.php
@@ -132,7 +132,7 @@ class ActivationHardeningTest extends TestCase
     {
         $source = $this->readSource('register.php');
         $this->assertMatchesRegularExpression(
-            '/hash_equals\s*\(/',
+            '/hash_equals\s*\([^)]*actkey/',
             $source,
             'htdocs/register.php must use hash_equals() for actkey comparison'
         );
@@ -149,7 +149,7 @@ class ActivationHardeningTest extends TestCase
     {
         $source = $this->readSource('modules/profile/activate.php');
         $this->assertMatchesRegularExpression(
-            '/hash_equals\s*\(/',
+            '/hash_equals\s*\([^)]*actkey/',
             $source,
             'profile/activate.php must use hash_equals() for actkey comparison'
         );

--- a/tests/unit/htdocs/kernel/XoopsMemberHandlerTest.php
+++ b/tests/unit/htdocs/kernel/XoopsMemberHandlerTest.php
@@ -929,8 +929,7 @@ class XoopsMemberHandlerTest extends TestCase
         $this->assertSame('level', $setVarCalls[0][0]);
         $this->assertSame(1, $setVarCalls[0][1]);
         $this->assertSame('actkey', $setVarCalls[1][0]);
-        $this->assertIsString($setVarCalls[1][1]);
-        $this->assertGreaterThanOrEqual(8, strlen($setVarCalls[1][1]));
+        $this->assertSame('', $setVarCalls[1][1]);
     }
 
     public function testActivateUserAlreadyActiveReturnsTrue(): void


### PR DESCRIPTION
## Summary
- **C-0**: Activation flow hardening — the most important missing RC item from the security audit
  - CSPRNG token generation (`bin2hex(random_bytes(4))`) already in place across all 4 generation sites
  - Timing-safe comparison (`hash_equals()`) already in place at both verification sites
  - **Fixed**: `activateUser()` in `kernel/member.php` was regenerating a new token after activation instead of clearing it — changed to set `actkey = ''` for true one-time-use semantics
- **M-8**: Restricted `unserialize()` in profile forms — already had `['allowed_classes' => false]`

### Key insight
Most hardening was already done in prior PRs. The remaining gap was that successful activation regenerated a fresh actkey instead of clearing it, meaning the activation concept wasn't truly one-time-use.

## Test plan
- [ ] 12 tests (34 assertions) covering:
  - CSPRNG usage verified across all 4 activation files
  - Output format validation (8 hex chars)
  - hash_equals() usage at both comparison sites
  - actkey cleared (not regenerated) after activation — source scan + unit test
  - Restricted unserialize in profile forms
- [ ] Manual test: register new user, activate via email link, verify link cannot be reused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Activation links are strictly one-time-use: activation tokens are cleared after successful activation and cannot be reused.

* **Tests**
  * Added comprehensive security tests validating token format, timing-safe comparisons, restricted deserialization, and one-time activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->